### PR TITLE
feat: create and transfer AdminCap to package deployer

### DIFF
--- a/contracts/world/Move.lock
+++ b/contracts/world/Move.lock
@@ -43,6 +43,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.54.1"
+compiler-version = "1.58.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/world/sources/authority.move
+++ b/contracts/world/sources/authority.move
@@ -71,3 +71,12 @@ public fun delete_owner_cap(owner_cap: OwnerCap, _: &AdminCap) {
 public fun is_authorized(owner_cap: &OwnerCap, object_id: ID): bool {
     owner_cap.owned_object_id == object_id
 }
+
+fun init(ctx: &mut TxContext) {
+     let admin_cap = AdminCap {
+        id: object::new(ctx),
+        admin: ctx.sender(),
+    };
+
+    transfer::transfer(admin_cap, ctx.sender());
+}


### PR DESCRIPTION
To make it easier to develop locally I've made the following changes:

* move all files to the root of the repo, so we don't have to navigate two subfolders down to use the sui cli.
* create and transfer an `AdminCap` when we deploy the package, so that we don't need extra steps to get an `AdminCap`