### PR TITLE
feat: generate deterministic character object id

### DIFF
--- a/contracts/world/Move.lock
+++ b/contracts/world/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "0211FF260EFB672107D0F68592F7EBB7BBC075FF25CE9AB1B702B48B37A0D35C"
+manifest_digest = "C17B1DEBD6FD863B06D4C6BDC69BD477F79C83AE2D652360FA562792CE96FA12"
 deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
 dependencies = [
   { id = "Bridge", name = "Bridge" },
@@ -13,7 +13,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "db951a5ea6b125f6253a6b7f436ddba46eb0feb3", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "61dcfdbe2ddc7ad05d27fc10cd09d4c6cc151acd", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -23,11 +23,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "db951a5ea6b125f6253a6b7f436ddba46eb0feb3", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "61dcfdbe2ddc7ad05d27fc10cd09d4c6cc151acd", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "db951a5ea6b125f6253a6b7f436ddba46eb0feb3", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "61dcfdbe2ddc7ad05d27fc10cd09d4c6cc151acd", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -35,7 +35,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "db951a5ea6b125f6253a6b7f436ddba46eb0feb3", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "61dcfdbe2ddc7ad05d27fc10cd09d4c6cc151acd", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -43,6 +43,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.54.1"
+compiler-version = "1.59.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/world/tests/character_tests.move
+++ b/contracts/world/tests/character_tests.move
@@ -3,10 +3,10 @@
 module world::character_tests;
 
 use std::{string::utf8, unit_test::assert_eq};
-use sui::test_scenario as ts;
+use sui::{derived_object, test_scenario as ts};
 use world::{
     authority::{Self, AdminCap, OwnerCap},
-    character::{Self, Character},
+    character::{Self, Character, CharacterRegistry},
     world::{Self, GovernorCap}
 };
 
@@ -21,6 +21,7 @@ fun setup_world(ts: &mut ts::Scenario) {
     ts::next_tx(ts, GOVERNOR);
     {
         world::init_for_testing(ts::ctx(ts));
+        character::init_for_testing(ts::ctx(ts));
     };
 
     ts::next_tx(ts, GOVERNOR);
@@ -45,16 +46,37 @@ fun setup_character(ts: &mut ts::Scenario, game_id: u32, tribe_id: u32, name: ve
     ts::next_tx(ts, ADMIN);
     {
         let admin_cap = ts::take_from_sender<AdminCap>(ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(ts);
         let character = character::create_character(
             &admin_cap,
+            &mut registry,
             game_id,
             tribe_id,
             utf8(name),
             ts::ctx(ts),
         );
         character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
         ts::return_to_sender(ts, admin_cap);
     };
+}
+
+#[test]
+fun test_character_registry_initialized() {
+    let mut ts = ts::begin(GOVERNOR);
+    ts::next_tx(&mut ts, GOVERNOR);
+    {
+        character::init_for_testing(ts::ctx(&mut ts));
+    };
+
+    ts::next_tx(&mut ts, GOVERNOR);
+    {
+        let registry = ts::take_shared<CharacterRegistry>(&ts);
+        // Registry should exist and be shared
+        ts::return_shared(registry);
+    };
+
+    ts.end();
 }
 
 #[test]
@@ -71,6 +93,212 @@ fun test_create_character() {
         assert_eq!(character::tribe_id(&character), 100);
         assert_eq!(character::name(&character), utf8(b"test"));
         ts::return_shared(character);
+    };
+
+    ts.end();
+}
+
+#[test]
+fun test_deterministic_character_id() {
+    let mut ts = ts::begin(GOVERNOR);
+    setup_world(&mut ts);
+
+    let game_id = 42u32;
+    let character_id_1: ID;
+    let precomputed_id: ID;
+
+    // Create first character with game_id = 42
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+
+        // Pre-compute the character ID before creation
+        // Pre-computation formula: blake2b_hash(registry_id || type_tag || bcs_serialize(game_character_id))
+        // where type_tag = "sui::derived_object::DerivedObjectKey<u32>"
+        let precomputed_addr = derived_object::derive_address(
+            object::id(&registry),
+            game_id,
+        );
+        precomputed_id = object::id_from_address(precomputed_addr);
+
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            game_id,
+            100,
+            utf8(b"test1"),
+            ts::ctx(&mut ts),
+        );
+        character_id_1 = character::id(&character);
+
+        // Verify that the actual ID matches the pre-computed ID
+        assert_eq!(character_id_1, precomputed_id);
+
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+    ts.end();
+}
+
+#[test]
+fun test_different_game_ids_produce_different_character_ids() {
+    let mut ts = ts::begin(GOVERNOR);
+    setup_world(&mut ts);
+
+    let character_id_1: ID;
+    let character_id_2: ID;
+
+    // Create first character with game_id = 1
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            1u32,
+            100,
+            utf8(b"character1"),
+            ts::ctx(&mut ts),
+        );
+        character_id_1 = character::id(&character);
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    // Create second character with game_id = 2
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            2u32,
+            100,
+            utf8(b"character2"),
+            ts::ctx(&mut ts),
+        );
+        character_id_2 = character::id(&character);
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        // Different game IDs should produce different character IDs
+        assert!(character_id_1 != character_id_2, 0);
+    };
+
+    ts.end();
+}
+
+#[test]
+#[expected_failure(abort_code = derived_object::EObjectAlreadyExists)]
+fun test_duplicate_game_id_fails() {
+    let mut ts = ts::begin(GOVERNOR);
+    setup_world(&mut ts);
+
+    let game_id = 123u32;
+
+    // Create first character with game_id = 123
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            game_id,
+            100,
+            utf8(b"test1"),
+            ts::ctx(&mut ts),
+        );
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    // Try to create another character with the same game_id = 123
+    // This should fail because the derived UID was already claimed
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            game_id,
+            200,
+            utf8(b"test2"),
+            ts::ctx(&mut ts),
+        );
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    ts.end();
+}
+
+// Current limitation: derived UIDs cannot be reclaimed after deletion.
+// Recreating a character with the same game_id fails,
+// even after the original character is deleted.
+// The Sui team plans to lift this restriction in the future.
+#[test]
+#[expected_failure(abort_code = derived_object::EObjectAlreadyExists)]
+fun test_delete_recreate_character() {
+    let mut ts = ts::begin(GOVERNOR);
+    setup_world(&mut ts);
+
+    // Create first character with game_id = 1
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            1u32,
+            100,
+            utf8(b"character1"),
+            ts::ctx(&mut ts),
+        );
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    // Delete the character
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let character = ts::take_shared<Character>(&ts);
+        character::delete_character(character, &admin_cap);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    // Create another character with the same game_id = 42
+    ts::next_tx(&mut ts, ADMIN);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
+        let character = character::create_character(
+            &admin_cap,
+            &mut registry,
+            1u32,
+            200,
+            utf8(b"test2"),
+            ts::ctx(&mut ts),
+        );
+
+        character::share_character(character, &admin_cap);
+        ts::return_shared(registry);
+        ts::return_to_sender(&ts, admin_cap);
     };
 
     ts.end();
@@ -155,8 +383,10 @@ fun test_create_character_without_admin_cap() {
     ts::next_tx(&mut ts, USER_A);
     {
         let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut registry = ts::take_shared<CharacterRegistry>(&ts);
         let character = character::create_character(
             &admin_cap,
+            &mut registry,
             1,
             100,
             utf8(b"test"),


### PR DESCRIPTION
Implements deterministic character ID generation using the game's unique character ID (e.g., typeId). Character IDs are now derived using Sui's derived_object module, making them predictable and preventing duplicate character creation for the same game ID.

Limitation : 
Once a character is deleted, a new character cannot be created with the same game_character_id. The Sui team is working on lifting this restriction in a future update