### PR TITLE
chore: conventions for accessors + receiver and index syntax on vec_map

### DIFF
--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -59,15 +59,15 @@ public struct StorageUnitCreatedEvent has copy, drop {
 }
 
 // === View Functions ===
-public fun get_status(storage_unit: &StorageUnit): &AssemblyStatus {
+public fun status(storage_unit: &StorageUnit): &AssemblyStatus {
     &storage_unit.status
 }
 
-public fun get_location(storage_unit: &StorageUnit): &Location {
+public fun location(storage_unit: &StorageUnit): &Location {
     &storage_unit.location
 }
 
-public fun get_inventory(storage_unit: &StorageUnit): &Inventory {
+public fun inventory(storage_unit: &StorageUnit): &Inventory {
     &storage_unit.inventory
 }
 
@@ -103,7 +103,7 @@ public fun create_storage_unit(
         storage_unit_id: assembly_id,
         max_capacity,
         location_hash,
-        status: status::get_status(&storage_unit.status),
+        status: status::status(&storage_unit.status),
     });
 
     storage_unit
@@ -137,7 +137,7 @@ public fun game_to_chain_inventory(
             type_id,
             volume,
             quantity,
-            storage_unit.location.get_hash(),
+            storage_unit.location.hash(),
             ctx,
         )
 }
@@ -196,7 +196,7 @@ public fun withdraw_by_owner(
 
 // === Test Functions ===
 #[test_only]
-public fun get_inventory_mut(storage_unit: &mut StorageUnit): &mut Inventory {
+public fun inventory_mut(storage_unit: &mut StorageUnit): &mut Inventory {
     &mut storage_unit.inventory
 }
 
@@ -206,8 +206,8 @@ public fun borrow_status_mut(storage_unit: &mut StorageUnit): &mut AssemblyStatu
 }
 
 #[test_only]
-public fun get_item_quantity(storage_unit: &StorageUnit, item_id: u64): u32 {
-    storage_unit.inventory.get_item_quantity(item_id)
+public fun item_quantity(storage_unit: &StorageUnit, item_id: u64): u32 {
+    storage_unit.inventory.item_quantity(item_id)
 }
 
 #[test_only]

--- a/contracts/world/sources/primitives/location.move
+++ b/contracts/world/sources/primitives/location.move
@@ -35,7 +35,7 @@ public fun in_proximity(_: vector<u8>, _: vector<u8>, _: vector<u8>): bool {
     true
 }
 
-public fun get_hash(location: &Location): vector<u8> {
+public fun hash(location: &Location): vector<u8> {
     location.location_hash
 }
 

--- a/contracts/world/sources/primitives/status.move
+++ b/contracts/world/sources/primitives/status.move
@@ -36,11 +36,11 @@ public struct StatusChangedEvent has copy, drop {
 }
 
 // === View Functions ===
-public fun get_status(assembly_status: &AssemblyStatus): Status {
+public fun status(assembly_status: &AssemblyStatus): Status {
     assembly_status.status
 }
 
-public fun get_assembly_id(assembly_status: &AssemblyStatus): ID {
+public fun assembly_id(assembly_status: &AssemblyStatus): ID {
     assembly_status.assembly_id
 }
 

--- a/contracts/world/tests/inventory_tests.move
+++ b/contracts/world/tests/inventory_tests.move
@@ -93,7 +93,7 @@ fun create_assembly_with_inventory() {
     {
         let storage_unit = ts::take_shared<StorageUnit>(&ts);
         assert_eq!(storage_unit.status.status_to_u8(), 0);
-        assert_eq!(storage_unit.location.get_hash(), LOCATION_A_HASH);
+        assert_eq!(storage_unit.location.hash(), LOCATION_A_HASH);
         assert_eq!(storage_unit.inventory.max_capacity(), MAX_CAPACITY);
         assert_eq!(storage_unit.inventory.used_capacity(), 0);
         ts::return_shared(storage_unit);
@@ -118,9 +118,9 @@ fun mint_items() {
 
         assert_eq!(storage_unit.inventory.used_capacity(), used_capacity);
         assert_eq!(storage_unit.inventory.remaining_capacity(), 0);
-        assert_eq!(storage_unit.inventory.get_item_quantity(AMMO_ITEM_ID), 10);
-        assert_eq!(storage_unit.inventory.get_inventory_item_length(), 1);
-        assert_eq!(storage_unit.location.get_hash(), LOCATION_A_HASH);
+        assert_eq!(storage_unit.inventory.item_quantity(AMMO_ITEM_ID), 10);
+        assert_eq!(storage_unit.inventory.inventory_item_length(), 1);
+        assert_eq!(storage_unit.location.hash(), LOCATION_A_HASH);
         ts::return_shared(storage_unit);
     };
     ts::end(ts);
@@ -157,8 +157,8 @@ fun mint_items_increases_quantity_when_exists() {
 
         assert_eq!(inv_ref.used_capacity(), used_capacity);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY - used_capacity);
-        assert_eq!(inv_ref.get_item_quantity(AMMO_ITEM_ID), 5);
-        assert_eq!(inv_ref.get_inventory_item_length(), 1);
+        assert_eq!(inv_ref.item_quantity(AMMO_ITEM_ID), 5);
+        assert_eq!(inv_ref.inventory_item_length(), 1);
         ts::return_shared(storage_unit);
         ts::return_to_sender(&ts, admin_cap);
     };
@@ -183,9 +183,9 @@ fun mint_items_increases_quantity_when_exists() {
         let inv_ref = &storage_unit.inventory;
         assert_eq!(inv_ref.used_capacity(), MAX_CAPACITY);
         assert_eq!(inv_ref.remaining_capacity(), 0);
-        assert_eq!(inv_ref.get_item_quantity(AMMO_ITEM_ID), 10);
-        assert_eq!(inv_ref.get_inventory_item_length(), 1);
-        assert_eq!(inv_ref.get_item_location(AMMO_ITEM_ID), LOCATION_A_HASH);
+        assert_eq!(inv_ref.item_quantity(AMMO_ITEM_ID), 10);
+        assert_eq!(inv_ref.inventory_item_length(), 1);
+        assert_eq!(inv_ref.item_location(AMMO_ITEM_ID), LOCATION_A_HASH);
         ts::return_shared(storage_unit);
         ts::return_to_sender(&ts, admin_cap);
     };
@@ -222,10 +222,10 @@ public fun burn_items() {
         let inv_ref = &storage_unit.inventory;
         assert_eq!(inv_ref.used_capacity(), 0);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY);
-        assert_eq!(inv_ref.get_inventory_item_length(), 0);
+        assert_eq!(inv_ref.inventory_item_length(), 0);
 
         let location_ref = &storage_unit.location;
-        assert_eq!(location_ref.get_hash(), LOCATION_A_HASH);
+        assert_eq!(location_ref.hash(), LOCATION_A_HASH);
 
         ts::return_shared(storage_unit);
         ts::return_to_sender(&ts, owner_cap);
@@ -263,7 +263,7 @@ public fun burn_partial_items() {
         let used_capacity = 5 * AMMO_VOLUME;
         assert_eq!(inv_ref.used_capacity(), used_capacity);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY - used_capacity);
-        assert_eq!(inv_ref.get_inventory_item_length(), 1);
+        assert_eq!(inv_ref.inventory_item_length(), 1);
 
         ts::return_shared(storage_unit);
         ts::return_to_sender(&ts, owner_cap);
@@ -301,7 +301,7 @@ public fun deposit_items() {
         let inv_ref = &ephemeral_storage_unit.inventory;
         assert_eq!(inv_ref.used_capacity(), 0);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY);
-        assert_eq!(inv_ref.get_inventory_item_length(), 0);
+        assert_eq!(inv_ref.inventory_item_length(), 0);
 
         ts::return_shared(ephemeral_storage_unit);
         ts::return_to_sender(&ts, owner_cap);
@@ -319,7 +319,7 @@ public fun deposit_items() {
         let inv_ref = &storage_unit.inventory;
         assert_eq!(inv_ref.used_capacity(), 0);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY);
-        assert_eq!(inv_ref.get_inventory_item_length(), 0);
+        assert_eq!(inv_ref.inventory_item_length(), 0);
 
         let mut ephemeral_storage_unit = ts::take_shared_by_id<StorageUnit>(
             &ts,
@@ -331,7 +331,7 @@ public fun deposit_items() {
         let used_capacity = (AMMO_QUANTITY as u64) * AMMO_VOLUME;
         assert_eq!(eph_inv_ref.used_capacity(), used_capacity);
         assert_eq!(eph_inv_ref.remaining_capacity(), MAX_CAPACITY - used_capacity);
-        assert_eq!(eph_inv_ref.get_inventory_item_length(), 1);
+        assert_eq!(eph_inv_ref.inventory_item_length(), 1);
 
         ts::return_shared(storage_unit);
         ts::return_shared(ephemeral_storage_unit);

--- a/contracts/world/tests/location_tests.move
+++ b/contracts/world/tests/location_tests.move
@@ -63,7 +63,7 @@ fun update_assembly_location() {
             x"7a8f5b1e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
         location::update_location(&mut gate.location, &admin_cap, location_hash);
 
-        assert_eq!(location::get_hash(&gate.location), location_hash);
+        assert_eq!(location::hash(&gate.location), location_hash);
         ts::return_shared(gate);
         ts::return_to_sender(&ts, admin_cap);
     };

--- a/contracts/world/tests/storage_unit_tests.move
+++ b/contracts/world/tests/storage_unit_tests.move
@@ -11,6 +11,8 @@ use world::{
 
 const LOCATION_A_HASH: vector<u8> =
     x"7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
+
+#[allow(unused_const)]
 const PROOF: vector<u8> = x"5a2f1b0e7c4d1a6f5e8b2d9c3f7a1e5b";
 const MAX_CAPACITY: u64 = 100000;
 const STORAGE_TYPE_ID: u64 = 50001;
@@ -96,7 +98,7 @@ fun online_storage_unit(ts: &mut ts::Scenario, user: address, storage_id: ID) {
         let owner_cap = ts::take_from_sender<OwnerCap>(ts);
         storage_unit.online(&owner_cap);
 
-        let status = storage_unit.get_status();
+        let status = storage_unit.status();
         assert_eq!(status.status_to_u8(), 1);
         ts::return_shared(storage_unit);
         ts::return_to_sender(ts, owner_cap);
@@ -148,13 +150,13 @@ fun test_create_storage_unit() {
     ts::next_tx(&mut ts, admin());
     {
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
-        let inv_ref = storage_unit.get_inventory();
-        let location_ref = storage_unit.get_location();
+        let inv_ref = storage_unit.inventory();
+        let location_ref = storage_unit.location();
 
         assert_eq!(inv_ref.used_capacity(), 0);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY);
-        assert_eq!(inv_ref.get_inventory_item_length(), 0);
-        assert_eq!(location_ref.get_hash(), LOCATION_A_HASH);
+        assert_eq!(inv_ref.inventory_item_length(), 0);
+        assert_eq!(location_ref.hash(), LOCATION_A_HASH);
         ts::return_shared(storage_unit);
     };
     ts::end(ts);
@@ -173,13 +175,13 @@ fun test_create_items_on_chain() {
     ts::next_tx(&mut ts, admin());
     {
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
-        let inv_ref = storage_unit.get_inventory();
+        let inv_ref = storage_unit.inventory();
 
         let used_capacity = (AMMO_QUANTITY as u64 * AMMO_VOLUME);
         assert_eq!(inv_ref.used_capacity(), used_capacity);
         assert_eq!(inv_ref.remaining_capacity(), MAX_CAPACITY - used_capacity);
-        assert_eq!(inv_ref.get_item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
-        assert_eq!(inv_ref.get_inventory_item_length(), 1);
+        assert_eq!(inv_ref.item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
+        assert_eq!(inv_ref.inventory_item_length(), 1);
         ts::return_shared(storage_unit);
     };
     ts::end(ts);
@@ -246,7 +248,7 @@ fun test_deposit_and_withdraw_via_extension() {
             item,
             ts.ctx(),
         );
-        assert_eq!(storage_unit.get_item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
+        assert_eq!(storage_unit.item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
         ts::return_shared(storage_unit);
     };
     ts::end(ts);
@@ -286,7 +288,7 @@ fun test_deposit_and_withdraw_by_owner() {
             &owner_cap,
             ts.ctx(),
         );
-        assert_eq!(storage_unit.get_item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
+        assert_eq!(storage_unit.item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
         ts::return_shared(storage_unit);
         ts::return_to_sender(&ts, owner_cap);
     };
@@ -334,18 +336,18 @@ fun test_swap_ammo_for_lens() {
 
         let used_capacity_a = (LENS_QUANTITY as u64* LENS_VOLUME);
         let used_capacity_b = (AMMO_QUANTITY as u64* AMMO_VOLUME);
-        let inv_ref_a = storage_a.get_inventory();
-        let inv_ref_b = storage_b.get_inventory();
+        let inv_ref_a = storage_a.inventory();
+        let inv_ref_b = storage_b.inventory();
 
         assert_eq!(inv_ref_a.used_capacity(), used_capacity_a);
         assert_eq!(inv_ref_a.remaining_capacity(), MAX_CAPACITY - used_capacity_a);
         assert_eq!(inv_ref_b.used_capacity(), used_capacity_b);
         assert_eq!(inv_ref_b.remaining_capacity(), MAX_CAPACITY - used_capacity_b);
 
-        assert_eq!(storage_a.get_item_quantity(LENS_ITEM_ID), LENS_QUANTITY);
-        assert!(!storage_a.get_inventory().contains_item(AMMO_ITEM_ID));
-        assert_eq!(storage_b.get_item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
-        assert!(!storage_b.get_inventory().contains_item(LENS_ITEM_ID));
+        assert_eq!(storage_a.item_quantity(LENS_ITEM_ID), LENS_QUANTITY);
+        assert!(!storage_a.inventory().contains_item(AMMO_ITEM_ID));
+        assert_eq!(storage_b.item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
+        assert!(!storage_b.inventory().contains_item(LENS_ITEM_ID));
 
         ts::return_shared(storage_a);
         ts::return_shared(storage_b);
@@ -376,10 +378,10 @@ fun test_swap_ammo_for_lens() {
         let storage_a = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
         let storage_b = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
 
-        assert_eq!(storage_a.get_item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
-        assert!(!storage_a.get_inventory().contains_item(LENS_ITEM_ID));
-        assert_eq!(storage_b.get_item_quantity(LENS_ITEM_ID), LENS_QUANTITY);
-        assert!(!storage_b.get_inventory().contains_item(AMMO_ITEM_ID));
+        assert_eq!(storage_a.item_quantity(AMMO_ITEM_ID), AMMO_QUANTITY);
+        assert!(!storage_a.inventory().contains_item(LENS_ITEM_ID));
+        assert_eq!(storage_b.item_quantity(LENS_ITEM_ID), LENS_QUANTITY);
+        assert!(!storage_b.inventory().contains_item(AMMO_ITEM_ID));
 
         ts::return_shared(storage_a);
         ts::return_shared(storage_b);


### PR DESCRIPTION
chore: conventions for accessors + receiver and index syntax on vec_map
    
- rename: `get_prop` to `prop`
- use `index[syntax]` on VecMap instances
- use `receiver.syntax()` on VecMap instances