### PR TITLE
chore(storage_unit): add few attributes to creation event

### DIFF
--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -56,6 +56,8 @@ public struct StorageUnitCreatedEvent has copy, drop {
     max_capacity: u64,
     location_hash: vector<u8>,
     status: Status,
+    type_id: u64,
+    item_id: u64,
 }
 
 // === View Functions ===
@@ -104,6 +106,8 @@ public fun create_storage_unit(
         max_capacity,
         location_hash,
         status: status::status(&storage_unit.status),
+        type_id: type_id,
+        item_id: item_id,
     });
 
     storage_unit


### PR DESCRIPTION
So that we have all the information we need directly in the event, to avoid a round trip to the indexer to retrieve them.
