### PR TITLE
chore: adding tests and comments

### DIFF
--- a/contracts/world/sources/character/character.move
+++ b/contracts/world/sources/character/character.move
@@ -21,6 +21,9 @@ const ECharacterAlreadyExists: vector<u8> = b"Character with this game character
 #[error(code = 3)]
 const ECharacterNotAuthorized: vector<u8> = b"Character not authorized";
 
+#[error(code = 4)]
+const ECharacterNameEmpty: vector<u8> = b"Character name cannot be empty";
+
 public struct CharacterRegistry has key {
     id: UID,
 }
@@ -83,10 +86,12 @@ public fun share_character(character: Character, _: &AdminCap) {
 
 public fun rename_character(character: &mut Character, owner_cap: &OwnerCap, name: String) {
     assert!(authority::is_authorized(owner_cap, object::id(character)), ECharacterNotAuthorized);
+    assert!(std::string::length(&name) > 0, ECharacterNameEmpty);
     character.name = name;
 }
 
 public fun update_tribe(character: &mut Character, _: &AdminCap, tribe_id: u32) {
+    assert!(tribe_id != 0, ETribeIdEmpty);
     character.tribe_id = tribe_id;
 }
 

--- a/contracts/world/tests/authority_tests.move
+++ b/contracts/world/tests/authority_tests.move
@@ -1,9 +1,13 @@
 #[test_only]
 module world::authority_tests;
 
+use std::unit_test::assert_eq;
 use sui::test_scenario as ts;
-use world::{authority::{Self, AdminCap}, world::{Self, GovernorCap}};
+use world::{authority::{Self, AdminCap, OwnerCap}, world::{Self, GovernorCap}};
 
+/// Tests creating and deleting an admin cap
+/// Scenario: Governor creates an admin cap for an admin, then deletes it
+/// Expected: Admin cap is created successfully and can be deleted by governor
 #[test]
 fun create_and_delete_admin_cap() {
     let _governor = @0xA;
@@ -35,8 +39,11 @@ fun create_and_delete_admin_cap() {
     ts::end(ts);
 }
 
+/// Tests creating, transferring, and deleting an owner cap
+/// Scenario: Admin creates an owner cap, transfers it to a user, then deletes it
+/// Expected: Owner cap is created, transferred successfully, and can be deleted by admin
 #[test]
-fun create_tranfer_and_delete_owner_cap() {
+fun create_transfer_and_delete_owner_cap() {
     let _governor = @0xA;
     let _admin = @0xB;
     let _userA = @0xC;
@@ -78,6 +85,56 @@ fun create_tranfer_and_delete_owner_cap() {
         authority::delete_owner_cap(owner_cap, &admin_cap);
 
         ts::return_to_sender(&ts, admin_cap);
+    };
+
+    ts::end(ts);
+}
+
+/// Tests that owner cap authorization works correctly after transfer
+/// Scenario: Admin creates owner cap, transfers it, then verifies authorization
+/// Expected: Authorization check returns true for correct object ID
+#[test]
+fun test_owner_cap_authorization_after_transfer() {
+    let _governor = @0xA;
+    let _admin = @0xB;
+    let _user = @0xC;
+
+    let mut ts = ts::begin(_governor);
+    {
+        world::init_for_testing(ts::ctx(&mut ts));
+    };
+
+    ts::next_tx(&mut ts, _governor);
+    {
+        let gov_cap = ts::take_from_sender<GovernorCap>(&ts);
+        authority::create_admin_cap(&gov_cap, _admin, ts::ctx(&mut ts));
+        ts::return_to_sender(&ts, gov_cap);
+    };
+
+    let target_object_id = object::id_from_address(@0x1234);
+    let wrong_object_id = object::id_from_address(@0x5678);
+
+    // Admin creates owner cap
+    ts::next_tx(&mut ts, _admin);
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let owner_cap = authority::create_owner_cap(&admin_cap, target_object_id, ts::ctx(&mut ts));
+        authority::transfer_owner_cap(owner_cap, &admin_cap, _user);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    // User verifies authorization
+    ts::next_tx(&mut ts, _user);
+    {
+        let owner_cap = ts::take_from_sender<OwnerCap>(&ts);
+
+        // Should be authorized for the correct object
+        assert_eq!(authority::is_authorized(&owner_cap, target_object_id), true);
+
+        // Should NOT be authorized for a different object
+        assert_eq!(authority::is_authorized(&owner_cap, wrong_object_id), false);
+
+        ts::return_to_sender(&ts, owner_cap);
     };
 
     ts::end(ts);

--- a/contracts/world/tests/character_tests.move
+++ b/contracts/world/tests/character_tests.move
@@ -47,6 +47,9 @@ fun setup_character(ts: &mut ts::Scenario, game_id: u32, tribe_id: u32, name: ve
     };
 }
 
+/// Tests that the character registry is initialized correctly
+/// Scenario: Initialize character registry and verify it exists as a shared object
+/// Expected: Registry is created and can be accessed as a shared object
 #[test]
 fun character_registry_initialized() {
     let mut ts = ts::begin(governor());
@@ -65,6 +68,9 @@ fun character_registry_initialized() {
     ts.end();
 }
 
+/// Tests creating a character with valid parameters
+/// Scenario: Admin creates a character with game_id=1, tribe_id=100, name="test"
+/// Expected: Character is created successfully with correct attributes
 #[test]
 fun create_character() {
     let mut ts = ts::begin(governor());
@@ -84,6 +90,9 @@ fun create_character() {
     ts.end();
 }
 
+/// Tests that character IDs are deterministic and can be pre-computed
+/// Scenario: Pre-compute character ID using derive_address, then create character
+/// Expected: Actual character ID matches the pre-computed ID
 #[test]
 fun deterministic_character_id() {
     let mut ts = ts::begin(governor());
@@ -128,6 +137,9 @@ fun deterministic_character_id() {
     ts.end();
 }
 
+/// Tests that different game IDs produce different character IDs
+/// Scenario: Create two characters with different game_ids (1 and 2)
+/// Expected: The two characters have different IDs
 #[test]
 fun different_game_ids_produce_different_character_ids() {
     let mut ts = ts::begin(governor());
@@ -183,6 +195,9 @@ fun different_game_ids_produce_different_character_ids() {
     ts.end();
 }
 
+/// Tests renaming a character with owner capability
+/// Scenario: Owner of character renames it from "test" to "new_name"
+/// Expected: Character name is updated successfully
 #[test]
 fun rename_character() {
     let mut ts = ts::begin(governor());
@@ -213,6 +228,9 @@ fun rename_character() {
     ts.end();
 }
 
+/// Tests updating a character's tribe ID with admin capability
+/// Scenario: Admin updates character tribe_id from 100 to 200
+/// Expected: Character tribe_id is updated successfully
 #[test]
 fun update_tribe() {
     let mut ts = ts::begin(governor());
@@ -234,6 +252,9 @@ fun update_tribe() {
     ts.end();
 }
 
+/// Tests deleting a character with admin capability
+/// Scenario: Admin deletes a character
+/// Expected: Character is deleted successfully
 #[test]
 fun delete_character() {
     let mut ts = ts::begin(governor());
@@ -253,6 +274,9 @@ fun delete_character() {
     ts.end();
 }
 
+/// Tests that creating a character with empty game_character_id fails
+/// Scenario: Attempt to create character with game_character_id = 0
+/// Expected: Transaction aborts with EGameCharacterIdEmpty error
 #[test]
 #[expected_failure(abort_code = character::EGameCharacterIdEmpty)]
 fun create_character_with_empty_game_character_id() {
@@ -263,6 +287,9 @@ fun create_character_with_empty_game_character_id() {
     abort
 }
 
+/// Tests that creating a character with empty tribe_id fails
+/// Scenario: Attempt to create character with tribe_id = 0
+/// Expected: Transaction aborts with ETribeIdEmpty error
 #[test]
 #[expected_failure(abort_code = character::ETribeIdEmpty)]
 fun create_character_with_empty_tribe_id() {
@@ -273,6 +300,9 @@ fun create_character_with_empty_tribe_id() {
     abort
 }
 
+/// Tests that creating a character with duplicate game_id fails
+/// Scenario: Create character with game_id=123, then attempt to create another with same game_id
+/// Expected: Second creation aborts with ECharacterAlreadyExists error
 #[test]
 #[expected_failure(abort_code = character::ECharacterAlreadyExists)]
 fun duplicate_game_id_fails() {
@@ -380,6 +410,10 @@ fun delete_recreate_character() {
     ts.end();
 }
 
+/// Tests that creating a character without admin capability fails
+/// Scenario: User A (not admin) attempts to create a character
+/// Expected: Transaction aborts because AdminCap is required
+/// Note: Security is enforced at compile time via &AdminCap parameter
 #[test]
 #[expected_failure]
 fun create_character_without_admin_cap() {
@@ -403,6 +437,9 @@ fun create_character_without_admin_cap() {
     }
 }
 
+/// Tests that renaming a character without proper owner capability fails
+/// Scenario: User B attempts to rename User A's character using wrong OwnerCap
+/// Expected: Transaction aborts because OwnerCap doesn't authorize access to the character
 #[test]
 #[expected_failure]
 fun test_rename_character_without_owner_cap() {
@@ -416,6 +453,84 @@ fun test_rename_character_without_owner_cap() {
         let mut character = ts::take_shared<Character>(&ts);
 
         character::rename_character(&mut character, &owner_cap, utf8(b"new_name"));
+        abort
+    }
+}
+
+/// Tests that renaming a character with an empty string fails
+/// Scenario: Owner attempts to rename character to empty string
+/// Expected: Transaction aborts with ECharacterNameEmpty error
+#[test]
+#[expected_failure(abort_code = character::ECharacterNameEmpty)]
+fun rename_character_to_empty_string() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+    setup_character(&mut ts, 1, 100, b"test");
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let character = ts::take_shared<Character>(&ts);
+        let character_id = object::id(&character);
+        ts::return_shared(character);
+
+        test_helpers::setup_owner_cap(&mut ts, user_a(), character_id);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let owner_cap = ts::take_from_sender<OwnerCap>(&ts);
+        let mut character = ts::take_shared<Character>(&ts);
+
+        // This should abort with ECharacterNameEmpty
+        character::rename_character(&mut character, &owner_cap, utf8(b""));
+
+        ts::return_shared(character);
+        ts::return_to_sender(&ts, owner_cap);
+    };
+
+    ts.end();
+}
+
+/// Tests that updating tribe_id to 0 is not allowed (validation in update_tribe)
+/// Scenario: Admin attempts to update character tribe_id to 0
+/// Expected: Transaction aborts with ETribeIdEmpty error
+#[test]
+#[expected_failure(abort_code = character::ETribeIdEmpty)]
+fun update_tribe_to_zero() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+    setup_character(&mut ts, 1, 100, b"test");
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let admin_cap = ts::take_from_sender<AdminCap>(&ts);
+        let mut character = ts::take_shared<Character>(&ts);
+
+        character::update_tribe(&mut character, &admin_cap, 0);
+        // This should abort with ETribeIdEmpty
+
+        ts::return_shared(character);
+        ts::return_to_sender(&ts, admin_cap);
+    };
+
+    ts.end();
+}
+
+/// Tests that updating tribe without admin capability fails
+/// Scenario: User A (not admin) attempts to update character tribe_id
+/// Expected: Transaction aborts because AdminCap is required
+/// Note: Security is enforced at compile time via &AdminCap parameter
+#[test]
+#[expected_failure]
+fun update_tribe_without_admin_cap() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+    setup_character(&mut ts, 1, 100, b"test");
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let _character = ts::take_shared<Character>(&ts);
+        // This should fail - user_a doesn't have AdminCap
         abort
     }
 }

--- a/contracts/world/tests/inventory_tests.move
+++ b/contracts/world/tests/inventory_tests.move
@@ -83,6 +83,9 @@ fun mint_ammo(ts: &mut ts::Scenario) {
     };
 }
 
+/// Tests creating an assembly with inventory
+/// Scenario: Admin creates a storage unit with inventory, status, and location
+/// Expected: Storage unit is created successfully with correct initial state
 #[test]
 fun create_assembly_with_inventory() {
     let mut ts = ts::begin(governor());
@@ -101,6 +104,9 @@ fun create_assembly_with_inventory() {
     ts::end(ts);
 }
 
+/// Tests minting items into inventory
+/// Scenario: Admin mints ammo items into an online storage unit
+/// Expected: Items are minted successfully, capacity is used correctly, and item quantity is correct
 #[test]
 fun mint_items() {
     let mut ts = ts::begin(governor());
@@ -126,6 +132,9 @@ fun mint_items() {
     ts::end(ts);
 }
 
+/// Tests that minting items increases quantity when item already exists
+/// Scenario: Admin mints 5 items, then mints 5 more of the same item
+/// Expected: Second mint increases quantity to 10 instead of creating a new item
 #[test]
 fun mint_items_increases_quantity_when_exists() {
     let mut ts = ts::begin(governor());
@@ -193,6 +202,9 @@ fun mint_items_increases_quantity_when_exists() {
 }
 
 // todo: check location is not being removed
+/// Tests burning all items from inventory
+/// Scenario: Owner burns all ammo items from an online storage unit
+/// Expected: All items are burned, capacity is freed, and inventory is empty
 #[test]
 public fun burn_items() {
     let mut ts = ts::begin(governor());
@@ -233,6 +245,9 @@ public fun burn_items() {
     ts::end(ts);
 }
 
+/// Tests burning partial quantity of items
+/// Scenario: Owner burns 5 out of 10 ammo items from inventory
+/// Expected: Quantity is reduced to 5, capacity is partially freed, item still exists
 #[test]
 public fun burn_partial_items() {
     let mut ts = ts::begin(governor());
@@ -271,7 +286,10 @@ public fun burn_partial_items() {
     ts::end(ts);
 }
 
-// Should it change the location ?
+/// Should it change the location ?
+/// Tests depositing items from one inventory to another
+/// Scenario: Withdraw item from storage unit and deposit into ephemeral storage unit
+/// Expected: Item is successfully transferred, capacity updated in both inventories
 #[test]
 public fun deposit_items() {
     let mut ts = ts::begin(governor());
@@ -339,6 +357,9 @@ public fun deposit_items() {
     ts::end(ts);
 }
 
+/// Tests that creating inventory with zero capacity fails
+/// Scenario: Attempt to create inventory with max_capacity = 0
+/// Expected: Transaction aborts with EInventoryInvalidCapacity error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryInvalidCapacity)]
 fun create_assembly_fail_on_empty_capacity() {
@@ -362,6 +383,9 @@ fun create_assembly_fail_on_empty_capacity() {
     ts::end(ts);
 }
 
+/// Tests that minting items with empty item_id fails
+/// Scenario: Attempt to mint items with item_id = 0
+/// Expected: Transaction aborts with EItemIdEmpty error
 #[test]
 #[expected_failure(abort_code = inventory::EItemIdEmpty)]
 fun mint_items_fail_empty_item_id() {
@@ -394,6 +418,9 @@ fun mint_items_fail_empty_item_id() {
     ts::end(ts);
 }
 
+/// Tests that minting items with empty type_id fails
+/// Scenario: Attempt to mint items with type_id = 0
+/// Expected: Transaction aborts with ETypeIdEmpty error
 #[test]
 #[expected_failure(abort_code = inventory::ETypeIdEmpty)]
 fun mint_items_fail_empty_type_id() {
@@ -426,6 +453,9 @@ fun mint_items_fail_empty_type_id() {
     ts::end(ts);
 }
 
+/// Tests that minting items into offline inventory fails
+/// Scenario: Attempt to mint items into storage unit that is not online
+/// Expected: Transaction aborts with ENotOnline error
 #[test]
 #[expected_failure(abort_code = inventory::ENotOnline)]
 fun mint_items_fail_inventory_offline() {
@@ -457,6 +487,9 @@ fun mint_items_fail_inventory_offline() {
     ts::end(ts);
 }
 
+/// Tests that minting items exceeding inventory capacity fails
+/// Scenario: Attempt to mint 15 items when inventory capacity is 1000 and each item uses 100 volume
+/// Expected: Transaction aborts with EInventoryInsufficientCapacity error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryInsufficientCapacity)]
 fun mint_fail_inventory_insufficient_capacity() {
@@ -489,6 +522,9 @@ fun mint_fail_inventory_insufficient_capacity() {
     ts::end(ts);
 }
 
+/// Tests that burning items without proper owner capability fails
+/// Scenario: User B attempts to burn items from User A's storage unit using wrong OwnerCap
+/// Expected: Transaction aborts with EInventoryAccessNotAuthorized error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryAccessNotAuthorized)]
 public fun burn_items_fail_unauthorized_owner() {
@@ -525,6 +561,9 @@ public fun burn_items_fail_unauthorized_owner() {
     ts::end(ts);
 }
 
+/// Tests that burning items that don't exist fails
+/// Scenario: Attempt to burn items from empty inventory
+/// Expected: Transaction aborts with EItemDoesNotExist error
 #[test]
 #[expected_failure(abort_code = inventory::EItemDoesNotExist)]
 public fun burn_items_fail_item_not_found() {
@@ -555,6 +594,9 @@ public fun burn_items_fail_item_not_found() {
     ts::end(ts);
 }
 
+/// Tests that burning more items than available fails
+/// Scenario: Attempt to burn 15 items when only 10 exist in inventory
+/// Expected: Transaction aborts with EInventoryInsufficientQuantity error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryInsufficientQuantity)]
 public fun burn_items_fail_insufficient_quantity() {
@@ -587,6 +629,9 @@ public fun burn_items_fail_insufficient_quantity() {
     ts::end(ts);
 }
 
+/// Tests that depositing items into inventory with insufficient capacity fails
+/// Scenario: Attempt to deposit item requiring 1000 volume into inventory with only 10 capacity
+/// Expected: Transaction aborts with EInventoryInsufficientCapacity error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryInsufficientCapacity)]
 fun deposit_item_fail_insufficient_capacity() {
@@ -646,6 +691,9 @@ fun deposit_item_fail_insufficient_capacity() {
     ts::end(ts);
 }
 
+/// Tests that withdrawing items that don't exist fails
+/// Scenario: Attempt to withdraw item with non-existent item_id
+/// Expected: Transaction aborts with EItemDoesNotExist error
 #[test]
 #[expected_failure(abort_code = inventory::EItemDoesNotExist)]
 fun withdraw_item_fail_item_not_found() {
@@ -655,18 +703,21 @@ fun withdraw_item_fail_item_not_found() {
     test_helpers::setup_owner_cap_for_user_a(&mut ts, storage_unit_id);
 
     online(&mut ts);
-    mint_ammo(&mut ts);
     ts::next_tx(&mut ts, user_a());
     {
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_unit_id);
+        // This should abort with EItemDoesNotExist
         let item = storage_unit.inventory.withdraw_item(1222);
-
+        // Unreachable code below - needed to satisfy Move's type checker
         storage_unit.inventory.deposit_item(item);
         ts::return_shared(storage_unit);
     };
     ts::end(ts);
 }
 
+/// Tests that minting items with mismatched assembly status fails
+/// Scenario: Attempt to mint items using status from a different assembly than the inventory
+/// Expected: Transaction aborts with EInventoryAssemblyMismatch error
 #[test]
 #[expected_failure(abort_code = inventory::EInventoryAssemblyMismatch)]
 fun mint_items_fail_inventory_assembly_mismatch() {

--- a/contracts/world/tests/location_tests.move
+++ b/contracts/world/tests/location_tests.move
@@ -10,6 +10,9 @@ public struct Gate has key {
     max_distance: u64,
 }
 
+/// Tests creating an assembly with location
+/// Scenario: Admin creates a gate assembly with a location hash
+/// Expected: Gate is created successfully with location attached
 #[test]
 fun create_assembly_with_location() {
     let mut ts = ts::begin(governor());
@@ -34,6 +37,9 @@ fun create_assembly_with_location() {
     ts::end(ts);
 }
 
+/// Tests updating an assembly's location
+/// Scenario: Admin updates the location hash of an existing gate
+/// Expected: Location hash is updated successfully
 #[test]
 fun update_assembly_location() {
     let mut ts = ts::begin(governor());
@@ -70,6 +76,9 @@ fun update_assembly_location() {
     ts::end(ts);
 }
 
+/// Tests verifying proximity between two locations
+/// Scenario: Verify proximity between two gates with the same location hash using a proof
+/// Expected: Proximity verification succeeds
 #[test]
 fun verify_proximity() {
     let mut ts = ts::begin(governor());
@@ -125,6 +134,9 @@ fun verify_proximity() {
     ts::end(ts);
 }
 
+/// Tests that attaching location with invalid hash length fails
+/// Scenario: Attempt to attach location with hash length != 32 bytes
+/// Expected: Transaction aborts with EInvalidHashLength error
 #[test]
 #[expected_failure(abort_code = location::EInvalidHashLength)]
 fun attach_location_with_invalid_hash_length() {

--- a/contracts/world/tests/world_tests.move
+++ b/contracts/world/tests/world_tests.move
@@ -4,6 +4,9 @@ module world::world_tests;
 use sui::test_scenario;
 use world::world;
 
+/// Tests that the world initialization creates a governor capability
+/// Scenario: World is initialized with a governor address
+/// Expected: GovernorCap is created and transferred to the governor
 #[test]
 fun creates_governor_cap() {
     let governor = @0xA;


### PR DESCRIPTION
This change ensures that the character name can not be an empty string and the tribe_id cannot be 0.