### PR TITLE
refactor(fuel): added type_id param in withdraw fuel to support backend services

### DIFF
--- a/contracts/world/sources/network_node/network_node.move
+++ b/contracts/world/sources/network_node/network_node.move
@@ -106,6 +106,7 @@ public fun withdraw_fuel(
     nwn: &mut NetworkNode,
     admin_acl: &AdminACL,
     owner_cap: &OwnerCap<NetworkNode>,
+    type_id: u64,
     quantity: u64,
     ctx: &mut TxContext,
 ) {
@@ -113,7 +114,7 @@ public fun withdraw_fuel(
     let nwn_key = nwn.key;
     assert!(access::is_authorized(owner_cap, nwn_id), ENetworkNodeNotAuthorized);
     admin_acl.verify_sponsor(ctx);
-    nwn.fuel.withdraw(nwn_id, nwn_key, quantity);
+    nwn.fuel.withdraw(nwn_id, nwn_key, type_id, quantity);
 }
 
 public fun online(nwn: &mut NetworkNode, owner_cap: &OwnerCap<NetworkNode>, clock: &Clock) {
@@ -535,9 +536,10 @@ public fun deposit_fuel_test(
 public fun withdraw_fuel_test(
     nwn: &mut NetworkNode,
     owner_cap: &OwnerCap<NetworkNode>,
+    type_id: u64,
     quantity: u64,
 ) {
     let nwn_id = object::id(nwn);
     assert!(access::is_authorized(owner_cap, nwn_id), ENetworkNodeNotAuthorized);
-    nwn.fuel.withdraw(nwn_id, nwn.key, quantity);
+    nwn.fuel.withdraw(nwn_id, nwn.key, type_id, quantity);
 }

--- a/contracts/world/sources/primitives/fuel.move
+++ b/contracts/world/sources/primitives/fuel.move
@@ -255,11 +255,12 @@ public(package) fun withdraw(
     fuel: &mut Fuel,
     assembly_id: ID,
     assembly_key: TenantItemId,
+    type_id: u64,
     quantity: u64,
 ) {
     assert!(quantity > 0, EInvalidWithdrawQuantity);
     assert!(fuel.quantity >= quantity, EInsufficientFuel);
-    assert!(option::is_some(&fuel.type_id), ETypeIdEmtpy);
+    assert!(fuel.type_id == option::some(type_id), EFuelTypeMismatch);
     let old_quantity = fuel.quantity;
     fuel.quantity = fuel.quantity - quantity;
     event::emit(FuelEvent {

--- a/contracts/world/tests/network_node/network_node_tests.move
+++ b/contracts/world/tests/network_node/network_node_tests.move
@@ -301,7 +301,7 @@ fun withdraw_fuel() {
             ts::most_recent_receiving_ticket<OwnerCap<NetworkNode>>(&character_id),
             ts.ctx(),
         );
-        nwn.withdraw_fuel_test(&owner_cap, 5);
+        nwn.withdraw_fuel_test(&owner_cap, FUEL_TYPE_ID, 5);
         assert_eq!(nwn.fuel().quantity(), 5);
         character.return_owner_cap(owner_cap, receipt);
         ts::return_shared(nwn);

--- a/contracts/world/tests/primitives/fuel_tests.move
+++ b/contracts/world/tests/primitives/fuel_tests.move
@@ -55,10 +55,10 @@ fun fuel_deposit(
     nwn.fuel.deposit(nwn_id, nwn_key, type_id, volume, quantity, clock);
 }
 
-fun fuel_withdraw(nwn: &mut NetworkNode, quantity: u64) {
+fun fuel_withdraw(nwn: &mut NetworkNode, type_id: u64, quantity: u64) {
     let nwn_id = object::id(nwn);
     let nwn_key = nwn.key;
-    nwn.fuel.withdraw(nwn_id, nwn_key, quantity);
+    nwn.fuel.withdraw(nwn_id, nwn_key, type_id, quantity);
 }
 
 fun fuel_start_burning(nwn: &mut NetworkNode, clock: &clock::Clock) {
@@ -272,7 +272,7 @@ fun withdraw_fuel() {
     ts::next_tx(&mut ts, user_a());
     {
         let mut nwn = ts::take_shared<NetworkNode>(&ts);
-        fuel_withdraw(&mut nwn, WITHDRAW_AMOUNT);
+        fuel_withdraw(&mut nwn, FUEL_TYPE_ID, WITHDRAW_AMOUNT);
         assert_eq!(nwn.fuel.quantity(), DEPOSIT_AMOUNT - WITHDRAW_AMOUNT);
         ts::return_shared(nwn);
     };
@@ -298,7 +298,7 @@ fun deposit_and_withdraw_fuel() {
     ts::next_tx(&mut ts, user_a());
     {
         let mut nwn = ts::take_shared<NetworkNode>(&ts);
-        fuel_withdraw(&mut nwn, WITHDRAW_AMOUNT);
+        fuel_withdraw(&mut nwn, FUEL_TYPE_ID, WITHDRAW_AMOUNT);
         assert_eq!(nwn.fuel.quantity(), DEPOSIT_AMOUNT - WITHDRAW_AMOUNT);
         ts::return_shared(nwn);
     };
@@ -761,7 +761,7 @@ fun withdraw_insufficient_fuel() {
     ts::next_tx(&mut ts, user_a());
     {
         let mut nwn = ts::take_shared<NetworkNode>(&ts);
-        fuel_withdraw(&mut nwn, WITHDRAW_AMOUNT); // Should abort
+        fuel_withdraw(&mut nwn, FUEL_TYPE_ID, WITHDRAW_AMOUNT); // Should abort
         ts::return_shared(nwn);
     };
 
@@ -913,7 +913,7 @@ fun withdraw_with_zero_quantity() {
     {
         let mut nwn = ts::take_shared<NetworkNode>(&ts);
         fuel_deposit(&mut nwn, FUEL_TYPE_ID, FUEL_VOLUME, DEPOSIT_AMOUNT, &clock);
-        fuel_withdraw(&mut nwn, 0); // Should abort
+        fuel_withdraw(&mut nwn, FUEL_TYPE_ID, 0); // Should abort
         ts::return_shared(nwn);
     };
 


### PR DESCRIPTION
- Add type_id to withdraw_fuel and enforce fuel type
- Added check for type_id matches the deposited fuel type (EFuelTypeMismatch on mismatch).
