### PR TITLE
Deposit Receipts via Extension WIP (bearer assets)

### DIFF
--- a/contracts/extension_examples/sources/vault_receipts.move
+++ b/contracts/extension_examples/sources/vault_receipts.move
@@ -1,0 +1,217 @@
+/// Vault Receipts extension demonstrating bearer token (deposit receipt) pattern.
+///
+/// This extension allows players to deposit items into the main inventory and receive
+/// a transferable bearer token (DepositReceipt) representing their deposit.
+/// The receipt can be freely transferred, sold, or held, and later redeemed by
+/// whoever possesses it to withdraw the deposited items.
+///
+/// Flow:
+/// 1. Player calls `deposit_for_receipt` to move items from ephemeral -> main inventory
+/// 2. Extension mints a `DepositReceipt` (owned object) and transfers it to the depositor
+/// 3. Receipt holder (anyone) can call `redeem_receipt` to withdraw items to their ephemeral
+///
+/// Use Cases:
+/// - Escrow services
+/// - Collateralized lending (receipt as collateral)
+/// - Tradeable warehouse receipts
+/// - Gift vouchers / claim tickets
+///
+/// Note: Items with the same `type_id` are pooled in main inventory. If multiple receipts
+/// exist for the same type, redemption follows FIFO order from the shared pool.
+module extension_examples::vault_receipts;
+
+use sui::event;
+use world::{
+    access::OwnerCap,
+    character::Character,
+    inventory,
+    storage_unit::StorageUnit,
+};
+
+// === Errors ===
+#[error(code = 0)]
+const EStorageUnitMismatch: vector<u8> = b"Receipt belongs to a different storage unit";
+
+// === Structs ===
+
+/// Witness type for extension authorization
+public struct VaultAuth has drop {}
+
+/// Bearer token representing deposited items.
+/// Whoever holds this receipt can redeem the items from the storage unit.
+public struct DepositReceipt has key, store {
+    id: UID,
+    /// The storage unit where the items are deposited
+    storage_unit_id: ID,
+    /// The type of items deposited
+    type_id: u64,
+    /// The quantity of items this receipt represents
+    quantity: u32,
+    /// Optional: original depositor for tracking/auditing
+    depositor: address,
+}
+
+// === Events ===
+
+public struct ReceiptMintedEvent has copy, drop {
+    receipt_id: ID,
+    storage_unit_id: ID,
+    type_id: u64,
+    quantity: u32,
+    depositor: address,
+}
+
+public struct ReceiptRedeemedEvent has copy, drop {
+    receipt_id: ID,
+    storage_unit_id: ID,
+    type_id: u64,
+    quantity: u32,
+    redeemer: address,
+}
+
+// === Public Functions ===
+
+/// Returns the VaultAuth witness for extension authorization
+public fun vault_auth(): VaultAuth { VaultAuth {} }
+
+/// Deposit items from player's ephemeral inventory into main inventory and mint a receipt.
+/// The receipt is transferred to the depositor and can be freely traded.
+///
+/// # Arguments
+/// * `storage_unit` - The storage unit to deposit into
+/// * `character` - The depositor's character
+/// * `owner_cap` - The depositor's OwnerCap (Character or StorageUnit)
+/// * `type_id` - The type of items to deposit
+///
+/// # Returns
+/// * `DepositReceipt` - Bearer token representing the deposit
+public fun deposit_for_receipt<T: key>(
+    storage_unit: &mut StorageUnit,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    type_id: u64,
+    ctx: &mut TxContext,
+): DepositReceipt {
+    // Withdraw from player's ephemeral inventory
+    let (item, item_location) = storage_unit.withdraw_from_owned<VaultAuth, T>(
+        character,
+        owner_cap,
+        VaultAuth {},
+        type_id,
+        ctx,
+    );
+
+    let quantity = inventory::quantity(&item);
+
+    // Deposit to main inventory (extension-controlled)
+    storage_unit.deposit_item<VaultAuth>(
+        character,
+        item,
+        item_location,
+        VaultAuth {},
+        ctx,
+    );
+
+    // Mint bearer receipt
+    let receipt_uid = object::new(ctx);
+    let receipt_id = object::uid_to_inner(&receipt_uid);
+    let storage_unit_id = object::id(storage_unit);
+    let depositor = ctx.sender();
+
+    event::emit(ReceiptMintedEvent {
+        receipt_id,
+        storage_unit_id,
+        type_id,
+        quantity,
+        depositor,
+    });
+
+    DepositReceipt {
+        id: receipt_uid,
+        storage_unit_id,
+        type_id,
+        quantity,
+        depositor,
+    }
+}
+
+/// Redeem a receipt to withdraw items from main inventory to the redeemer's ephemeral.
+/// The receipt is burned upon redemption.
+///
+/// # Arguments
+/// * `receipt` - The bearer receipt to redeem (consumed)
+/// * `storage_unit` - The storage unit to withdraw from
+/// * `character` - The redeemer's character
+/// * `owner_cap` - The redeemer's OwnerCap (Character or StorageUnit)
+public fun redeem_receipt<T: key>(
+    receipt: DepositReceipt,
+    storage_unit: &mut StorageUnit,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    ctx: &mut TxContext,
+) {
+    let DepositReceipt {
+        id,
+        storage_unit_id,
+        type_id,
+        quantity,
+        ..
+    } = receipt;
+
+    let receipt_id = object::uid_to_inner(&id);
+
+    // Verify receipt matches this storage unit
+    assert!(storage_unit_id == object::id(storage_unit), EStorageUnitMismatch);
+
+    // Delete the receipt
+    id.delete();
+
+    // Withdraw from main inventory
+    let (item, item_location) = storage_unit.withdraw_item<VaultAuth>(
+        character,
+        VaultAuth {},
+        type_id,
+        ctx,
+    );
+
+    // Deposit to redeemer's ephemeral inventory
+    let redeemer_cap_id = object::id(owner_cap);
+    storage_unit.deposit_to_owned<VaultAuth>(
+        character,
+        redeemer_cap_id,
+        item,
+        item_location,
+        VaultAuth {},
+        ctx,
+    );
+
+    event::emit(ReceiptRedeemedEvent {
+        receipt_id,
+        storage_unit_id,
+        type_id,
+        quantity,
+        redeemer: ctx.sender(),
+    });
+}
+
+// === View Functions ===
+
+/// Returns the storage unit ID this receipt is redeemable at
+public fun receipt_storage_unit_id(receipt: &DepositReceipt): ID {
+    receipt.storage_unit_id
+}
+
+/// Returns the item type this receipt represents
+public fun receipt_type_id(receipt: &DepositReceipt): u64 {
+    receipt.type_id
+}
+
+/// Returns the quantity of items this receipt represents
+public fun receipt_quantity(receipt: &DepositReceipt): u32 {
+    receipt.quantity
+}
+
+/// Returns the original depositor's address
+public fun receipt_depositor(receipt: &DepositReceipt): address {
+    receipt.depositor
+}

--- a/contracts/extension_examples/tests/vault_receipts_tests.move
+++ b/contracts/extension_examples/tests/vault_receipts_tests.move
@@ -1,0 +1,615 @@
+#[test_only]
+module extension_examples::vault_receipts_tests;
+
+use std::string::utf8;
+use std::unit_test::assert_eq;
+use sui::{clock, test_scenario as ts};
+use world::{
+    access::{OwnerCap, AdminACL},
+    character::{Self, Character},
+    energy::EnergyConfig,
+    network_node::{Self, NetworkNode},
+    object_registry::ObjectRegistry,
+    storage_unit::{Self, StorageUnit},
+};
+use extension_examples::vault_receipts::{Self, VaultAuth, DepositReceipt};
+
+// === Constants ===
+const OWNER_ITEM_ID: u32 = 1000u32;
+const DEPOSITOR_ITEM_ID: u32 = 2000u32;
+const REDEEMER_ITEM_ID: u32 = 3000u32;
+const LOCATION_HASH: vector<u8> = x"7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
+const MAX_CAPACITY: u64 = 100000;
+const STORAGE_TYPE_ID: u64 = 5555;
+const STORAGE_ITEM_ID: u64 = 90002;
+
+const LENS_TYPE_ID: u64 = 88070;
+const LENS_ITEM_ID: u64 = 1000004145108;
+const LENS_VOLUME: u64 = 50;
+const LENS_QUANTITY: u32 = 5;
+
+const MS_PER_SECOND: u64 = 1000;
+const NWN_TYPE_ID: u64 = 111000;
+const NWN_ITEM_ID: u64 = 5000;
+const FUEL_MAX_CAPACITY: u64 = 1000;
+const FUEL_BURN_RATE_IN_MS: u64 = 3600 * MS_PER_SECOND;
+const MAX_PRODUCTION: u64 = 100;
+const FUEL_TYPE_ID: u64 = 1;
+const FUEL_VOLUME: u64 = 10;
+
+// === Test Addresses ===
+fun governor(): address { @0xA }
+fun admin(): address { @0xB }
+fun owner(): address { @0xC }
+fun depositor(): address { @0xD }
+fun redeemer(): address { @0xE }
+
+// === Setup Helpers ===
+fun setup_world(ts: &mut ts::Scenario) {
+    world::test_helpers::setup_world(ts);
+    world::test_helpers::configure_assembly_energy(ts);
+    world::test_helpers::register_server_address(ts);
+}
+
+fun create_character(ts: &mut ts::Scenario, user: address, item_id: u32): ID {
+    ts::next_tx(ts, admin());
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let character = character::create_character(
+        &mut registry,
+        &admin_acl,
+        item_id,
+        utf8(b"tenant"),
+        100,
+        user,
+        utf8(b"name"),
+        ts.ctx(),
+    );
+    let id = object::id(&character);
+    character.share_character(&admin_acl, ts.ctx());
+    ts::return_shared(registry);
+    ts::return_shared(admin_acl);
+    id
+}
+
+fun create_storage_unit(ts: &mut ts::Scenario, character_id: ID): (ID, ID) {
+    ts::next_tx(ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let character = ts::take_shared_by_id<Character>(ts, character_id);
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+
+    let nwn = network_node::anchor(
+        &mut registry,
+        &character,
+        &admin_acl,
+        NWN_ITEM_ID,
+        NWN_TYPE_ID,
+        LOCATION_HASH,
+        FUEL_MAX_CAPACITY,
+        FUEL_BURN_RATE_IN_MS,
+        MAX_PRODUCTION,
+        ts.ctx(),
+    );
+    let nwn_id = object::id(&nwn);
+    nwn.share_network_node(&admin_acl, ts.ctx());
+
+    ts::return_shared(character);
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+    let character = ts::take_shared_by_id<Character>(ts, character_id);
+    let storage_unit_id = {
+        let admin_acl = ts::take_shared<AdminACL>(ts);
+        let storage_unit = storage_unit::anchor(
+            &mut registry,
+            &mut nwn,
+            &character,
+            &admin_acl,
+            STORAGE_ITEM_ID,
+            STORAGE_TYPE_ID,
+            MAX_CAPACITY,
+            LOCATION_HASH,
+            ts.ctx(),
+        );
+        let id = object::id(&storage_unit);
+        storage_unit.share_storage_unit(&admin_acl, ts.ctx());
+        ts::return_shared(admin_acl);
+        id
+    };
+    ts::return_shared(character);
+    ts::return_shared(registry);
+    ts::return_shared(nwn);
+    (storage_unit_id, nwn_id)
+}
+
+fun online_storage_unit(
+    ts: &mut ts::Scenario,
+    user: address,
+    character_id: ID,
+    storage_id: ID,
+    nwn_id: ID,
+) {
+    let clock = clock::create_for_testing(ts.ctx());
+    ts::next_tx(ts, user);
+    let mut character = ts::take_shared_by_id<Character>(ts, character_id);
+    let (owner_cap, receipt) = character.borrow_owner_cap<NetworkNode>(
+        ts::most_recent_receiving_ticket<OwnerCap<NetworkNode>>(&character_id),
+        ts.ctx(),
+    );
+    ts::next_tx(ts, user);
+    {
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+        nwn.deposit_fuel_test(&owner_cap, FUEL_TYPE_ID, FUEL_VOLUME, 10, &clock);
+        ts::return_shared(nwn);
+    };
+    ts::next_tx(ts, user);
+    {
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+        nwn.online(&owner_cap, &clock);
+        ts::return_shared(nwn);
+    };
+    character.return_owner_cap(owner_cap, receipt);
+
+    ts::next_tx(ts, user);
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(ts, storage_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+        let energy_config = ts::take_shared<EnergyConfig>(ts);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+    };
+
+    ts::return_shared(character);
+    clock.destroy_for_testing();
+}
+
+// === Success Tests ===
+
+/// Test the full deposit-and-redeem flow with different players:
+/// - Owner: creates SSU, authorizes VaultAuth
+/// - Depositor: deposits items, receives receipt
+/// - Redeemer: receives transferred receipt, redeems items
+#[test]
+fun deposit_and_redeem_by_different_player() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+
+    let owner_id = create_character(&mut ts, owner(), OWNER_ITEM_ID);
+    let depositor_id = create_character(&mut ts, depositor(), DEPOSITOR_ITEM_ID);
+    let redeemer_id = create_character(&mut ts, redeemer(), REDEEMER_ITEM_ID);
+
+    // Owner creates, onlines, and authorizes VaultAuth on the storage unit
+    let (storage_id, nwn_id) = create_storage_unit(&mut ts, owner_id);
+    online_storage_unit(&mut ts, owner(), owner_id, storage_id, nwn_id);
+
+    ts::next_tx(&mut ts, owner());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, owner_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&owner_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        storage_unit.authorize_extension<VaultAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    // Depositor: mint items into their ephemeral inventory
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        storage_unit.game_item_to_chain_inventory_test<Character>(
+            &character, &owner_cap,
+            LENS_ITEM_ID, LENS_TYPE_ID, LENS_VOLUME, LENS_QUANTITY,
+            ts.ctx(),
+        );
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    // Get owner_cap IDs for assertions
+    let depositor_owner_cap_id = {
+        ts::next_tx(&mut ts, admin());
+        let c = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let id = c.owner_cap_id();
+        ts::return_shared(c);
+        id
+    };
+    let redeemer_owner_cap_id = {
+        ts::next_tx(&mut ts, admin());
+        let c = ts::take_shared_by_id<Character>(&ts, redeemer_id);
+        let id = c.owner_cap_id();
+        ts::return_shared(c);
+        id
+    };
+    let storage_owner_cap_id = {
+        ts::next_tx(&mut ts, admin());
+        let su = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        let id = su.owner_cap_id();
+        ts::return_shared(su);
+        id
+    };
+
+    // Depositor: deposit items and receive receipt
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        let mut depositor_char = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = depositor_char.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+
+        let deposit_receipt = vault_receipts::deposit_for_receipt(
+            &mut storage_unit,
+            &depositor_char,
+            &owner_cap,
+            LENS_TYPE_ID,
+            ts.ctx(),
+        );
+
+        // Verify receipt properties
+        assert_eq!(vault_receipts::receipt_storage_unit_id(&deposit_receipt), storage_id);
+        assert_eq!(vault_receipts::receipt_type_id(&deposit_receipt), LENS_TYPE_ID);
+        assert_eq!(vault_receipts::receipt_quantity(&deposit_receipt), LENS_QUANTITY);
+        assert_eq!(vault_receipts::receipt_depositor(&deposit_receipt), depositor());
+
+        // Transfer receipt to redeemer
+        transfer::public_transfer(deposit_receipt, redeemer());
+
+        depositor_char.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(depositor_char);
+        ts::return_shared(storage_unit);
+    };
+
+    // Assert: items moved from depositor's ephemeral to main inventory
+    ts::next_tx(&mut ts, admin());
+    {
+        let su = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        // Main inventory has the items
+        assert_eq!(su.item_quantity(storage_owner_cap_id, LENS_TYPE_ID), LENS_QUANTITY);
+        // Depositor's ephemeral is empty
+        assert!(!su.contains_item(depositor_owner_cap_id, LENS_TYPE_ID));
+        ts::return_shared(su);
+    };
+
+    // Redeemer: redeem the receipt (depositor is offline)
+    ts::next_tx(&mut ts, redeemer());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        let mut redeemer_char = ts::take_shared_by_id<Character>(&ts, redeemer_id);
+        let (owner_cap, cap_receipt) = redeemer_char.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&redeemer_id),
+            ts.ctx(),
+        );
+
+        // Take the deposit receipt
+        let deposit_receipt = ts::take_from_sender<DepositReceipt>(&ts);
+
+        vault_receipts::redeem_receipt(
+            deposit_receipt,
+            &mut storage_unit,
+            &redeemer_char,
+            &owner_cap,
+            ts.ctx(),
+        );
+
+        redeemer_char.return_owner_cap(owner_cap, cap_receipt);
+        ts::return_shared(redeemer_char);
+        ts::return_shared(storage_unit);
+    };
+
+    // Assert: items moved from main to redeemer's ephemeral
+    ts::next_tx(&mut ts, admin());
+    {
+        let su = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        // Main inventory is empty
+        assert!(!su.contains_item(storage_owner_cap_id, LENS_TYPE_ID));
+        // Redeemer's ephemeral has the items
+        assert_eq!(su.item_quantity(redeemer_owner_cap_id, LENS_TYPE_ID), LENS_QUANTITY);
+        // Depositor's ephemeral still empty
+        assert!(!su.contains_item(depositor_owner_cap_id, LENS_TYPE_ID));
+        ts::return_shared(su);
+    };
+
+    ts::end(ts);
+}
+
+/// Test that the depositor can redeem their own receipt
+#[test]
+fun deposit_and_self_redeem() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+
+    let owner_id = create_character(&mut ts, owner(), OWNER_ITEM_ID);
+    let depositor_id = create_character(&mut ts, depositor(), DEPOSITOR_ITEM_ID);
+
+    // Setup storage unit
+    let (storage_id, nwn_id) = create_storage_unit(&mut ts, owner_id);
+    online_storage_unit(&mut ts, owner(), owner_id, storage_id, nwn_id);
+
+    // Authorize VaultAuth
+    ts::next_tx(&mut ts, owner());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, owner_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&owner_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        storage_unit.authorize_extension<VaultAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    // Mint items to depositor
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        storage_unit.game_item_to_chain_inventory_test<Character>(
+            &character, &owner_cap,
+            LENS_ITEM_ID, LENS_TYPE_ID, LENS_VOLUME, LENS_QUANTITY,
+            ts.ctx(),
+        );
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    let depositor_owner_cap_id = {
+        ts::next_tx(&mut ts, admin());
+        let c = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let id = c.owner_cap_id();
+        ts::return_shared(c);
+        id
+    };
+
+    // Deposit and get receipt
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        let mut depositor_char = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = depositor_char.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+
+        let deposit_receipt = vault_receipts::deposit_for_receipt(
+            &mut storage_unit,
+            &depositor_char,
+            &owner_cap,
+            LENS_TYPE_ID,
+            ts.ctx(),
+        );
+
+        // Keep receipt for self
+        transfer::public_transfer(deposit_receipt, depositor());
+
+        depositor_char.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(depositor_char);
+        ts::return_shared(storage_unit);
+    };
+
+    // Self-redeem
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        let mut depositor_char = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, cap_receipt) = depositor_char.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+
+        let deposit_receipt = ts::take_from_sender<DepositReceipt>(&ts);
+        vault_receipts::redeem_receipt(
+            deposit_receipt,
+            &mut storage_unit,
+            &depositor_char,
+            &owner_cap,
+            ts.ctx(),
+        );
+
+        depositor_char.return_owner_cap(owner_cap, cap_receipt);
+        ts::return_shared(depositor_char);
+        ts::return_shared(storage_unit);
+    };
+
+    // Verify items back in depositor's ephemeral
+    ts::next_tx(&mut ts, admin());
+    {
+        let su = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+        assert_eq!(su.item_quantity(depositor_owner_cap_id, LENS_TYPE_ID), LENS_QUANTITY);
+        ts::return_shared(su);
+    };
+
+    ts::end(ts);
+}
+
+// === Failure Tests ===
+
+#[test]
+#[expected_failure(abort_code = vault_receipts::EStorageUnitMismatch)]
+fun redeem_at_wrong_storage_unit() {
+    let mut ts = ts::begin(governor());
+    setup_world(&mut ts);
+
+    let owner_id = create_character(&mut ts, owner(), OWNER_ITEM_ID);
+    let depositor_id = create_character(&mut ts, depositor(), DEPOSITOR_ITEM_ID);
+
+    // Setup first storage unit
+    let (storage_id_1, nwn_id_1) = create_storage_unit(&mut ts, owner_id);
+    online_storage_unit(&mut ts, owner(), owner_id, storage_id_1, nwn_id_1);
+
+    // Authorize on first SSU
+    ts::next_tx(&mut ts, owner());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, owner_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&owner_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id_1);
+        storage_unit.authorize_extension<VaultAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    // Mint items
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id_1);
+        storage_unit.game_item_to_chain_inventory_test<Character>(
+            &character, &owner_cap,
+            LENS_ITEM_ID, LENS_TYPE_ID, LENS_VOLUME, LENS_QUANTITY,
+            ts.ctx(),
+        );
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+
+    // Deposit at first SSU
+    ts::next_tx(&mut ts, depositor());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id_1);
+        let mut depositor_char = ts::take_shared_by_id<Character>(&ts, depositor_id);
+        let (owner_cap, receipt) = depositor_char.borrow_owner_cap<Character>(
+            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+            ts.ctx(),
+        );
+
+        let deposit_receipt = vault_receipts::deposit_for_receipt(
+            &mut storage_unit,
+            &depositor_char,
+            &owner_cap,
+            LENS_TYPE_ID,
+            ts.ctx(),
+        );
+        transfer::public_transfer(deposit_receipt, depositor());
+
+        depositor_char.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(depositor_char);
+        ts::return_shared(storage_unit);
+    };
+
+    // Create second storage unit (different NWN + SSU)
+    ts::next_tx(&mut ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+    let character = ts::take_shared_by_id<Character>(&ts, owner_id);
+    let admin_acl = ts::take_shared<AdminACL>(&ts);
+
+    let nwn_2 = network_node::anchor(
+        &mut registry,
+        &character,
+        &admin_acl,
+        NWN_ITEM_ID + 1,
+        NWN_TYPE_ID,
+        LOCATION_HASH,
+        FUEL_MAX_CAPACITY,
+        FUEL_BURN_RATE_IN_MS,
+        MAX_PRODUCTION,
+        ts.ctx(),
+    );
+    let nwn_id_2 = object::id(&nwn_2);
+    nwn_2.share_network_node(&admin_acl, ts.ctx());
+
+    ts::return_shared(character);
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(&mut ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+    let mut nwn_2 = ts::take_shared_by_id<NetworkNode>(&ts, nwn_id_2);
+    let character = ts::take_shared_by_id<Character>(&ts, owner_id);
+    let storage_id_2 = {
+        let admin_acl = ts::take_shared<AdminACL>(&ts);
+        let storage_unit = storage_unit::anchor(
+            &mut registry,
+            &mut nwn_2,
+            &character,
+            &admin_acl,
+            STORAGE_ITEM_ID + 1,
+            STORAGE_TYPE_ID,
+            MAX_CAPACITY,
+            LOCATION_HASH,
+            ts.ctx(),
+        );
+        let id = object::id(&storage_unit);
+        storage_unit.share_storage_unit(&admin_acl, ts.ctx());
+        ts::return_shared(admin_acl);
+        id
+    };
+    ts::return_shared(character);
+    ts::return_shared(registry);
+    ts::return_shared(nwn_2);
+
+    // Online second SSU
+    online_storage_unit(&mut ts, owner(), owner_id, storage_id_2, nwn_id_2);
+
+    // Authorize on second SSU
+    ts::next_tx(&mut ts, owner());
+    {
+        let mut character = ts::take_shared_by_id<Character>(&ts, owner_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&owner_id),
+            ts.ctx(),
+        );
+        let mut storage_unit_2 = ts::take_shared_by_id<StorageUnit>(&ts, storage_id_2);
+        storage_unit_2.authorize_extension<VaultAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit_2);
+    };
+
+    // Try to redeem receipt at second SSU (should fail)
+    ts::next_tx(&mut ts, depositor());
+    let mut storage_unit_2 = ts::take_shared_by_id<StorageUnit>(&ts, storage_id_2);
+    let mut depositor_char = ts::take_shared_by_id<Character>(&ts, depositor_id);
+    let (owner_cap, _cap_receipt) = depositor_char.borrow_owner_cap<Character>(
+        ts::most_recent_receiving_ticket<OwnerCap<Character>>(&depositor_id),
+        ts.ctx(),
+    );
+
+    let deposit_receipt = ts::take_from_sender<DepositReceipt>(&ts);
+
+    // This should fail with EStorageUnitMismatch - no cleanup needed
+    vault_receipts::redeem_receipt(
+        deposit_receipt,
+        &mut storage_unit_2,
+        &depositor_char,
+        &owner_cap,
+        ts.ctx(),
+    );
+
+    abort 0
+}


### PR DESCRIPTION
Adds an example extension for deposit receipts, which are owned objects that allow you to claim items held within an inventory in the storage unit. 

As a result of these being owned objects, as long as the underlying accounting is correct (where there are sufficient items for every claim at a storage unit to be claimed) - owned objects are better for things like trading and other protocol integration. 

They also make it easier to build 3rd party services because free-floating protocols can facilitate the transfer or access control of items via these claims - rather than having to build on top of the extension interface and shared item inventory.