### PR TITLE
fix: remove admin acl from update energy source functions

### DIFF
--- a/contracts/world/sources/assemblies/assembly.move
+++ b/contracts/world/sources/assemblies/assembly.move
@@ -193,10 +193,7 @@ public fun update_energy_source_connected_assembly(
     assembly: &mut Assembly,
     mut update_energy_sources: UpdateEnergySources,
     network_node: &NetworkNode,
-    admin_acl: &AdminACL,
-    ctx: &TxContext,
 ): UpdateEnergySources {
-    admin_acl.verify_sponsor(ctx);
     if (update_energy_sources.update_energy_sources_ids_length() > 0) {
         let assembly_id = object::id(assembly);
         let found = update_energy_sources.remove_energy_sources_assembly_id(

--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -459,10 +459,7 @@ public fun update_energy_source_connected_storage_unit(
     storage_unit: &mut StorageUnit,
     mut update_energy_sources: UpdateEnergySources,
     network_node: &NetworkNode,
-    admin_acl: &AdminACL,
-    ctx: &TxContext,
 ): UpdateEnergySources {
-    admin_acl.verify_sponsor(ctx);
     if (update_energy_sources.update_energy_sources_ids_length() > 0) {
         let storage_unit_id = object::id(storage_unit);
         let found = update_energy_sources.remove_energy_sources_assembly_id(

--- a/contracts/world/tests/network_node/network_node_tests.move
+++ b/contracts/world/tests/network_node/network_node_tests.move
@@ -833,8 +833,6 @@ fun connect_assemblies_updates_energy_source() {
         let updated_energy_sources = assembly.update_energy_source_connected_assembly(
             update_energy_sources,
             &nwn2,
-            &admin_acl,
-            ts.ctx(),
         );
         updated_energy_sources.destroy_update_energy_sources();
 


### PR DESCRIPTION
- remove admin acl from updated connected energy source. This is technically not required becasue the `UpdateEnergySources` hotpotato can only be claimed by the admin