### PR TITLE
refactor: Character OwnerCap as  wallet-owned

### DIFF
--- a/contracts/extension_examples/Move.lock
+++ b/contracts/extension_examples/Move.lock
@@ -5,24 +5,36 @@
 version = 4
 
 [pinned.testnet.MoveStdlib]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "testnet-v1.66.2" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "b38bca86f0323b3fe8b6b7f4ca0cd7ae7faebe4b" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.MoveStdlib_1]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "a9a6825eaf6273cc819ee3bcf65fd4909f7624a9" }
 use_environment = "testnet"
 manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
 deps = {}
 
 [pinned.testnet.Sui]
-source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.66.2" }
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "b38bca86f0323b3fe8b6b7f4ca0cd7ae7faebe4b" }
 use_environment = "testnet"
 manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
 deps = { MoveStdlib = "MoveStdlib" }
 
+[pinned.testnet.Sui_1]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "a9a6825eaf6273cc819ee3bcf65fd4909f7624a9" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib_1" }
+
 [pinned.testnet.World]
 source = { local = "../world" }
 use_environment = "testnet"
-manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
-deps = { std = "MoveStdlib", sui = "Sui" }
+manifest_digest = "ED881AEE5B6E33C7A9D149CD1133047E41D103FAD527778F56F099E07F5F9C95"
+deps = { Sui = "Sui_1" }
 
-[pinned.testnet.builder_extensions]
+[pinned.testnet.extension_examples]
 source = { root = true }
 use_environment = "testnet"
 manifest_digest = "E9574F71A43395992B500A1B8F01686D6B9EEA23A526CFB47C269A8372F3842B"

--- a/contracts/world/sources/access/access_control.move
+++ b/contracts/world/sources/access/access_control.move
@@ -97,7 +97,9 @@ fun init(ctx: &mut TxContext) {
 /// Security: Ownership is enforced by the Sui runtime. Only the current owner of the OwnerCap
 /// can call this function - if a non-owner attempts to move the object, the transaction will
 /// be rejected by the runtime before this function is even called.
+/// OwnerCap<Character> is non-transferable (wallet-owned, cannot be sold or moved).
 public fun transfer_owner_cap<T: key>(owner_cap: OwnerCap<T>, owner: address) {
+    assert!(!is_character_cap<T>(), ECharacterTransfer);
     transfer::transfer(owner_cap, owner);
 }
 
@@ -106,12 +108,7 @@ public fun transfer_owner_cap_to_address<T: key>(
     new_owner: address,
     ctx: &mut TxContext,
 ) {
-    // Only OwnerCap<Character> cannot be transferred to an address.
-    let cap_type = type_name::with_defining_ids<T>();
-    let is_character =
-        cap_type.module_string() == std::ascii::string(b"character")
-        && cap_type.datatype_string() == std::ascii::string(b"Character");
-    assert!(!is_character, ECharacterTransfer);
+    assert!(!is_character_cap<T>(), ECharacterTransfer);
     transfer<T>(owner_cap, ctx.sender(), new_owner);
 }
 
@@ -265,6 +262,12 @@ public fun delete_owner_cap<T: key>(owner_cap: OwnerCap<T>, admin_acl: &AdminACL
 }
 
 // === Private Functions ===
+fun is_character_cap<T: key>(): bool {
+    let cap_type = type_name::with_defining_ids<T>();
+    cap_type.module_string() == std::ascii::string(b"character")
+        && cap_type.datatype_string() == std::ascii::string(b"Character")
+}
+
 fun transfer<T: key>(owner_cap: OwnerCap<T>, previous_owner: address, new_owner: address) {
     event::emit(OwnerCapTransferred {
         owner_cap_id: object::id(&owner_cap),

--- a/contracts/world/sources/character/character.move
+++ b/contracts/world/sources/character/character.move
@@ -136,8 +136,14 @@ public fun create_character(
     let character_uid = derived_object::claim(registry.borrow_registry_id(), character_key);
     let character_id = object::uid_to_inner(&character_uid);
 
-    let owner_cap = access::create_owner_cap_by_id<Character>(character_id, admin_acl, ctx);
-    let owner_cap_id = object::id(&owner_cap);
+    // Character OwnerCap is held by the wallet (character_address) for easy query-by-wallet.
+    // Non-transferability is enforced in the access layer;
+    let owner_cap_id = access::create_and_transfer_owner_cap<Character>(
+        character_id,
+        admin_acl,
+        character_address,
+        ctx,
+    );
 
     let character = Character {
         id: character_uid,
@@ -155,9 +161,6 @@ public fun create_character(
         ),
         owner_cap_id,
     };
-
-    // Character OwnerCap is held by the wallet (character_address) for easy query-by-wallet.
-    access::transfer_owner_cap(owner_cap, character_address);
 
     event::emit(CharacterCreatedEvent {
         character_id: object::id(&character),

--- a/contracts/world/sources/character/character.move
+++ b/contracts/world/sources/character/character.move
@@ -156,7 +156,8 @@ public fun create_character(
         owner_cap_id,
     };
 
-    access::transfer_owner_cap(owner_cap, object::id_address(&character));
+    // Character OwnerCap is held by the wallet (character_address) for easy query-by-wallet.
+    access::transfer_owner_cap(owner_cap, character_address);
 
     event::emit(CharacterCreatedEvent {
         character_id: object::id(&character),

--- a/contracts/world/tests/access/access_tests.move
+++ b/contracts/world/tests/access/access_tests.move
@@ -1,34 +1,101 @@
 #[test_only]
 module world::access_tests;
 
-use std::unit_test::assert_eq;
+use std::{string::utf8, unit_test::assert_eq};
 use sui::test_scenario as ts;
 use world::{
     access::{Self, AdminACL, OwnerCap},
+    assembly::{Self, Assembly},
     character::{Self, Character},
+    network_node::{Self, NetworkNode},
     object_registry::ObjectRegistry,
-    test_helpers::{Self, TestObject, governor, admin, user_a, user_b}
+    test_helpers::{Self, TestObject, governor, admin, user_a, user_b, tenant}
 };
 
-fun setup_character_for_receipt_tests(ts: &mut ts::Scenario) {
-    ts::next_tx(ts, admin());
-    {
+const LOCATION_HASH: vector<u8> =
+    x"7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
+const ASSEMBLY_TYPE_ID: u64 = 8888;
+const ASSEMBLY_ITEM_ID: u64 = 1001;
+const NWN_TYPE_ID: u64 = 111000;
+const NWN_ITEM_ID: u64 = 5000;
+const FUEL_MAX_CAPACITY: u64 = 1000;
+const FUEL_BURN_RATE_IN_MS: u64 = 3600 * 1000;
+const MAX_PRODUCTION: u64 = 100;
+
+fun setup_character_with_assembly(ts: &mut ts::Scenario): ID {
+    test_helpers::setup_world(ts);
+    test_helpers::configure_fuel(ts);
+    test_helpers::configure_assembly_energy(ts);
+
+    let character_id = {
+        ts::next_tx(ts, admin());
         let admin_acl = ts::take_shared<AdminACL>(ts);
         let mut registry = ts::take_shared<ObjectRegistry>(ts);
         let character = character::create_character(
             &mut registry,
             &admin_acl,
             2000,
-            b"TEST".to_string(),
+            tenant(),
             100,
             user_a(),
-            b"name".to_string(),
+            utf8(b"name"),
             ts.ctx(),
         );
+        let id = object::id(&character);
         character.share_character(&admin_acl, ts.ctx());
         ts::return_shared(registry);
         ts::return_shared(admin_acl);
+        id
     };
+
+    let nwn_id = {
+        ts::next_tx(ts, admin());
+        let mut registry = ts::take_shared<ObjectRegistry>(ts);
+        let character = ts::take_shared_by_id<Character>(ts, character_id);
+        let admin_acl = ts::take_shared<AdminACL>(ts);
+        let nwn = network_node::anchor(
+            &mut registry,
+            &character,
+            &admin_acl,
+            NWN_ITEM_ID,
+            NWN_TYPE_ID,
+            LOCATION_HASH,
+            FUEL_MAX_CAPACITY,
+            FUEL_BURN_RATE_IN_MS,
+            MAX_PRODUCTION,
+            ts.ctx(),
+        );
+        let id = object::id(&nwn);
+        nwn.share_network_node(&admin_acl, ts.ctx());
+        ts::return_shared(character);
+        ts::return_shared(admin_acl);
+        ts::return_shared(registry);
+        id
+    };
+
+    ts::next_tx(ts, admin());
+    {
+        let character = ts::take_shared_by_id<Character>(ts, character_id);
+        let mut registry = ts::take_shared<ObjectRegistry>(ts);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+        let admin_acl = ts::take_shared<AdminACL>(ts);
+        let assembly = assembly::anchor(
+            &mut registry,
+            &mut nwn,
+            &character,
+            &admin_acl,
+            ASSEMBLY_ITEM_ID,
+            ASSEMBLY_TYPE_ID,
+            LOCATION_HASH,
+            ts.ctx(),
+        );
+        assembly.share_assembly(&admin_acl, ts.ctx());
+        ts::return_shared(character);
+        ts::return_shared(admin_acl);
+        ts::return_shared(registry);
+        ts::return_shared(nwn);
+    };
+    character_id
 }
 
 /// Tests creating, transferring, and deleting an owner cap
@@ -147,24 +214,11 @@ fun character_owner_cap_transfer_fail() {
         ts::return_shared(admin_acl);
     };
 
-    // Transfer Character OwnerCap should fail
+    // Character OwnerCap is wallet-owned (user_a); transferring it to an address must fail
     ts::next_tx(&mut ts, user_a());
     {
-        let mut character = ts::take_shared<Character>(&ts);
-        let character_id = object::id(&character);
-        let access_cap_ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(
-            &character_id,
-        );
-        let (owner_cap, receipt) = character.borrow_owner_cap<Character>(
-            access_cap_ticket,
-            ts.ctx(),
-        );
-        access::transfer_owner_cap_with_receipt<Character>(
-            owner_cap,
-            receipt,
-            user_b(),
-            ts.ctx(),
-        );
+        let owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
+        access::transfer_owner_cap_to_address<Character>(owner_cap, user_b(), ts.ctx());
     };
     abort
 }
@@ -174,21 +228,20 @@ fun character_owner_cap_transfer_fail() {
 #[expected_failure(abort_code = access::EOwnerCapIdMismatch)]
 fun transfer_owner_cap_with_receipt_mismatched_cap_id_fails() {
     let mut ts = ts::begin(governor());
-    test_helpers::setup_world(&mut ts);
-    setup_character_for_receipt_tests(&mut ts);
+    let character_id = setup_character_with_assembly(&mut ts);
 
     ts::next_tx(&mut ts, user_a());
     {
         let mut character = ts::take_shared<Character>(&ts);
         let character_addr = object::id_address(&character);
-        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(&object::id(&character));
-        let (owner_cap, real_receipt) = character.borrow_owner_cap<Character>(ticket, ts.ctx());
+        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Assembly>>(&character_id);
+        let (owner_cap, real_receipt) = character.borrow_owner_cap<Assembly>(ticket, ts.ctx());
         ts::return_shared(character);
 
         access::destroy_receipt_for_testing(real_receipt);
         let wrong_cap_id = object::id_from_address(@0x1);
         let fake_receipt = access::create_return_receipt(wrong_cap_id, character_addr);
-        access::transfer_owner_cap_with_receipt<Character>(
+        access::transfer_owner_cap_with_receipt<Assembly>(
             owner_cap,
             fake_receipt,
             user_b(),
@@ -203,15 +256,14 @@ fun transfer_owner_cap_with_receipt_mismatched_cap_id_fails() {
 #[expected_failure(abort_code = access::EOwnerIdMismatch)]
 fun return_owner_cap_to_object_mismatched_owner_id_fails() {
     let mut ts = ts::begin(governor());
-    test_helpers::setup_world(&mut ts);
-    setup_character_for_receipt_tests(&mut ts);
+    let character_id = setup_character_with_assembly(&mut ts);
 
     ts::next_tx(&mut ts, user_a());
     {
         let mut character = ts::take_shared<Character>(&ts);
         let character_addr = object::id_address(&character);
-        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(&object::id(&character));
-        let (owner_cap, real_receipt) = character.borrow_owner_cap<Character>(ticket, ts.ctx());
+        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Assembly>>(&character_id);
+        let (owner_cap, real_receipt) = character.borrow_owner_cap<Assembly>(ticket, ts.ctx());
         ts::return_shared(character);
 
         access::destroy_receipt_for_testing(real_receipt);
@@ -226,15 +278,14 @@ fun return_owner_cap_to_object_mismatched_owner_id_fails() {
 #[expected_failure(abort_code = access::EOwnerCapIdMismatch)]
 fun return_owner_cap_to_object_mismatched_cap_id_fails() {
     let mut ts = ts::begin(governor());
-    test_helpers::setup_world(&mut ts);
-    setup_character_for_receipt_tests(&mut ts);
+    let character_id = setup_character_with_assembly(&mut ts);
 
     ts::next_tx(&mut ts, user_a());
     {
         let mut character = ts::take_shared<Character>(&ts);
         let character_addr = object::id_address(&character);
-        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(&object::id(&character));
-        let (owner_cap, real_receipt) = character.borrow_owner_cap<Character>(ticket, ts.ctx());
+        let ticket = ts::most_recent_receiving_ticket<OwnerCap<Assembly>>(&character_id);
+        let (owner_cap, real_receipt) = character.borrow_owner_cap<Assembly>(ticket, ts.ctx());
         ts::return_shared(character);
 
         access::destroy_receipt_for_testing(real_receipt);

--- a/contracts/world/tests/access/access_tests.move
+++ b/contracts/world/tests/access/access_tests.move
@@ -214,11 +214,45 @@ fun character_owner_cap_transfer_fail() {
         ts::return_shared(admin_acl);
     };
 
-    // Character OwnerCap is wallet-owned (user_a); transferring it to an address must fail
+    // transfer_owner_cap_to_address: Character OwnerCap cannot be transferred
     ts::next_tx(&mut ts, user_a());
     {
         let owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
         access::transfer_owner_cap_to_address<Character>(owner_cap, user_b(), ts.ctx());
+    };
+    abort
+}
+
+/// Direct transfer_owner_cap also rejects OwnerCap<Character> (non-transferable on all paths).
+#[test]
+#[expected_failure(abort_code = access::ECharacterTransfer)]
+fun character_owner_cap_direct_transfer_fail() {
+    let mut ts = ts::begin(governor());
+    test_helpers::setup_world(&mut ts);
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let admin_acl = ts::take_shared<AdminACL>(&ts);
+        let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+        let character = character::create_character(
+            &mut registry,
+            &admin_acl,
+            1006,
+            b"TEST".to_string(),
+            100,
+            user_a(),
+            b"name".to_string(),
+            ts.ctx(),
+        );
+        character.share_character(&admin_acl, ts.ctx());
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
+        access::transfer_owner_cap<Character>(owner_cap, user_b());
     };
     abort
 }

--- a/contracts/world/tests/assemblies/storage_unit_tests.move
+++ b/contracts/world/tests/assemblies/storage_unit_tests.move
@@ -330,6 +330,50 @@ fun mint_lens<T: key>(ts: &mut ts::Scenario, storage_id: ID, character_id: ID, u
     };
 }
 
+/// Mint lens to character's owned inventory (Character OwnerCap is wallet-owned).
+fun mint_lens_character(ts: &mut ts::Scenario, storage_id: ID, character_id: ID, user: address) {
+    ts::next_tx(ts, user);
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(ts, storage_id);
+        let character = ts::take_shared_by_id<Character>(ts, character_id);
+        let owner_cap = ts::take_from_address<OwnerCap<Character>>(ts, user);
+        storage_unit.game_item_to_chain_inventory_test<Character>(
+            &character,
+            &owner_cap,
+            LENS_ITEM_ID,
+            LENS_TYPE_ID,
+            LENS_VOLUME,
+            LENS_QUANTITY,
+            ts.ctx(),
+        );
+        ts::return_to_sender(ts, owner_cap);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+}
+
+/// Mint ammo to character's owned inventory (Character OwnerCap is wallet-owned).
+fun mint_ammo_character(ts: &mut ts::Scenario, storage_id: ID, character_id: ID, user: address) {
+    ts::next_tx(ts, user);
+    {
+        let character = ts::take_shared_by_id<Character>(ts, character_id);
+        let owner_cap = ts::take_from_address<OwnerCap<Character>>(ts, user);
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(ts, storage_id);
+        storage_unit.game_item_to_chain_inventory_test<Character>(
+            &character,
+            &owner_cap,
+            AMMO_ITEM_ID,
+            AMMO_TYPE_ID,
+            AMMO_VOLUME,
+            AMMO_QUANTITY,
+            ts.ctx(),
+        );
+        ts::return_to_sender(ts, owner_cap);
+        ts::return_shared(character);
+        ts::return_shared(storage_unit);
+    };
+}
+
 fun create_character(ts: &mut ts::Scenario, user: address, item_id: u32): ID {
     create_character_with_tenant(ts, user, item_id, tenant())
 }
@@ -562,7 +606,7 @@ fun test_mint_multiple_items_in_owned_inventory() {
     let character_owner_cap_id = character_owner_cap_id(&mut ts, character_b_id);
 
     // Mint lens for user B
-    mint_lens<Character>(&mut ts, storage_id, character_b_id, user_b());
+    mint_lens_character(&mut ts, storage_id, character_b_id, user_b());
     ts::next_tx(&mut ts, admin());
     {
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
@@ -574,7 +618,7 @@ fun test_mint_multiple_items_in_owned_inventory() {
     };
 
     // Mint Ammo for user B
-    mint_ammo<Character>(&mut ts, storage_id, character_b_id, user_b());
+    mint_ammo_character(&mut ts, storage_id, character_b_id, user_b());
     ts::next_tx(&mut ts, admin());
     {
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
@@ -782,7 +826,7 @@ fun test_swap_ammo_for_lens() {
 
     // Mint Ammo for user A
     // minting ammo automatically creates a epehemeral inventory for user A
-    mint_ammo<Character>(&mut ts, storage_id, character_a_id, user_a());
+    mint_ammo_character(&mut ts, storage_id, character_a_id, user_a());
 
     // User B authorizes the swap extension for their storage to swap lens for ammo
     ts::next_tx(&mut ts, user_b());
@@ -826,11 +870,8 @@ fun test_swap_ammo_for_lens() {
     ts::next_tx(&mut ts, user_a());
     {
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
-        let mut character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
-        let (owner_cap_a, receipt_a) = character_a.borrow_owner_cap<Character>(
-            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&character_a_id),
-            ts.ctx(),
-        );
+        let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
+        let owner_cap_a = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
 
         swap_ammo_for_lens_extension(
             &mut storage_unit,
@@ -839,7 +880,7 @@ fun test_swap_ammo_for_lens() {
             ts.ctx(),
         );
 
-        character_a.return_owner_cap(owner_cap_a, receipt_a);
+        ts::return_to_sender(&ts, owner_cap_a);
         ts::return_shared(character_a);
         ts::return_shared(storage_unit);
     };
@@ -1252,7 +1293,7 @@ fun test_swap_fail_extension_not_authorized() {
     mint_lens<StorageUnit>(&mut ts, storage_id, character_id, user_a());
 
     let _character_owner_cap_id = character_owner_cap_id(&mut ts, character_b_id);
-    mint_ammo<Character>(&mut ts, storage_id, character_b_id, user_b());
+    mint_ammo_character(&mut ts, storage_id, character_b_id, user_b());
 
     //Skipped authorisation
 
@@ -1260,11 +1301,8 @@ fun test_swap_fail_extension_not_authorized() {
     ts::next_tx(&mut ts, user_b());
     {
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
-        let mut character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
-        let (owner_cap_b, receipt_b) = character_b.borrow_owner_cap<Character>(
-            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&character_b_id),
-            ts.ctx(),
-        );
+        let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
+        let owner_cap_b = ts::take_from_address<OwnerCap<Character>>(&ts, user_b());
 
         swap_ammo_for_lens_extension(
             &mut storage_unit,
@@ -1273,8 +1311,8 @@ fun test_swap_fail_extension_not_authorized() {
             ts.ctx(),
         );
 
+        ts::return_to_sender(&ts, owner_cap_b);
         ts::return_shared(storage_unit);
-        character_b.return_owner_cap(owner_cap_b, receipt_b);
         ts::return_shared(character_b);
     };
     ts::end(ts);
@@ -1949,7 +1987,7 @@ fun test_swap_via_extension_to_owned() {
     mint_lens<StorageUnit>(&mut ts, storage_id, character_b_id, user_b());
 
     let character_owner_cap_id = character_owner_cap_id(&mut ts, character_a_id);
-    mint_ammo<Character>(&mut ts, storage_id, character_a_id, user_a());
+    mint_ammo_character(&mut ts, storage_id, character_a_id, user_a());
 
     // User B authorizes extension
     ts::next_tx(&mut ts, user_b());
@@ -1977,15 +2015,12 @@ fun test_swap_via_extension_to_owned() {
         ts::return_shared(storage_unit);
     };
 
-    // User A performs swap via extension-to-owned (no admin_acl needed)
+    // User A performs swap via extension-to-owned
     ts::next_tx(&mut ts, user_a());
     {
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
-        let mut character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
-        let (owner_cap_a, receipt_a) = character_a.borrow_owner_cap<Character>(
-            ts::most_recent_receiving_ticket<OwnerCap<Character>>(&character_a_id),
-            ts.ctx(),
-        );
+        let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
+        let owner_cap_a = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
 
         swap_ammo_for_lens_via_extension(
             &mut storage_unit,
@@ -1994,7 +2029,7 @@ fun test_swap_via_extension_to_owned() {
             ts.ctx(),
         );
 
-        character_a.return_owner_cap(owner_cap_a, receipt_a);
+        ts::return_to_sender(&ts, owner_cap_a);
         ts::return_shared(character_a);
         ts::return_shared(storage_unit);
     };

--- a/contracts/world/tests/character/character_tests.move
+++ b/contracts/world/tests/character/character_tests.move
@@ -546,23 +546,46 @@ fun create_character_without_admin_cap() {
 
 /// Tests that renaming a character without proper owner capability fails
 /// Scenario: User B attempts to rename User A's character using wrong OwnerCap
-/// Expected: Transaction aborts because user_b doesn't have the Character OwnerCap (it's with user_a).
+/// User B tries to rename User A's character using User B's own OwnerCap (wrong cap).
+/// Expected: Transaction aborts with ECharacterNotAuthorized (cap authorizes B's character, not A's).
 #[test]
-#[expected_failure]
+#[expected_failure(abort_code = character::ECharacterNotAuthorized)]
 fun test_rename_character_without_owner_cap() {
     let mut ts = ts::begin(governor());
     setup_world(&mut ts);
-    setup_character(&mut ts, 1, 100, b"test");
+    setup_character(&mut ts, 1, 100, b"char_a");
+
+    let character_a_id: ID;
+    ts::next_tx(&mut ts, admin());
+    {
+        let character_a = ts::take_shared<Character>(&ts);
+        character_a_id = character::id(&character_a);
+        ts::return_shared(character_a);
+
+        let admin_acl = ts::take_shared<AdminACL>(&ts);
+        let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+        let character_b = character::create_character(
+            &mut registry,
+            &admin_acl,
+            2u32,
+            tenant(),
+            100,
+            user_b(),
+            utf8(b"char_b"),
+            ts::ctx(&mut ts),
+        );
+        character_b.share_character(&admin_acl, ts::ctx(&mut ts));
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
 
     ts::next_tx(&mut ts, user_b());
     {
-        let mut character = ts::take_shared<Character>(&ts);
-        let _owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_b());
-        let character_key = character.key();
-        let metadata = character.mutable_metadata();
-        metadata.update_name(character_key, utf8(b"new_name"));
-        abort
-    }
+        let mut character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
+        let owner_cap_b = ts::take_from_address<OwnerCap<Character>>(&ts, user_b());
+        character_a.update_metadata_name(&owner_cap_b, utf8(b"new_name"));
+    };
+    abort
 }
 
 /// Tests that updating tribe_id to 0 is not allowed (validation in update_tribe)

--- a/contracts/world/tests/character/character_tests.move
+++ b/contracts/world/tests/character/character_tests.move
@@ -5,7 +5,7 @@ module world::character_tests;
 use std::{string::utf8, unit_test::assert_eq};
 use sui::{derived_object, test_scenario as ts};
 use world::{
-    access::{Self, AdminACL, OwnerCap},
+    access::{AdminACL, OwnerCap},
     character::{Self, Character},
     in_game_id as character_id,
     object_registry::ObjectRegistry,
@@ -255,21 +255,10 @@ fun rename_character() {
     ts::next_tx(&mut ts, user_a());
     {
         let mut character = ts::take_shared<Character>(&ts);
-        let character_id = object::id(&character);
-        let access_cap_ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(
-            &character_id,
-        );
-        let (owner_cap, receipt) = character.borrow_owner_cap<Character>(
-            access_cap_ticket,
-            ts.ctx(),
-        );
-
-        let character_key = character.key();
-        let metadata = character.mutable_metadata();
-        metadata.update_name(character_key, utf8(b"new_name"));
-        assert_eq!(metadata.name(), utf8(b"new_name"));
-
-        character.return_owner_cap(owner_cap, receipt);
+        let owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_a());
+        character.update_metadata_name(&owner_cap, utf8(b"new_name"));
+        assert_eq!(character::name(&character), utf8(b"new_name"));
+        ts::return_to_sender(&ts, owner_cap);
         ts::return_shared(character);
     };
 
@@ -557,7 +546,7 @@ fun create_character_without_admin_cap() {
 
 /// Tests that renaming a character without proper owner capability fails
 /// Scenario: User B attempts to rename User A's character using wrong OwnerCap
-/// Expected: Transaction aborts because OwnerCap doesn't authorize access to the character
+/// Expected: Transaction aborts because user_b doesn't have the Character OwnerCap (it's with user_a).
 #[test]
 #[expected_failure]
 fun test_rename_character_without_owner_cap() {
@@ -568,15 +557,7 @@ fun test_rename_character_without_owner_cap() {
     ts::next_tx(&mut ts, user_b());
     {
         let mut character = ts::take_shared<Character>(&ts);
-        let character_id = object::id(&character);
-        let access_cap_ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(
-            &character_id,
-        );
-        let (_owner_cap, _receipt) = character.borrow_owner_cap<Character>(
-            access_cap_ticket,
-            ts.ctx(),
-        );
-
+        let _owner_cap = ts::take_from_address<OwnerCap<Character>>(&ts, user_b());
         let character_key = character.key();
         let metadata = character.mutable_metadata();
         metadata.update_name(character_key, utf8(b"new_name"));
@@ -628,58 +609,4 @@ fun update_tribe_without_admin_cap() {
     }
 }
 
-/// Tests that returning an owner cap to a different character than it was borrowed from fails.
-/// Scenario: Borrow from character A, then try to return to character B using the same receipt.
-/// Expected: Transaction aborts with EOwnerIdMismatch.
-#[test]
-#[expected_failure(abort_code = access::EOwnerIdMismatch)]
-fun return_owner_cap_to_different_character_fails() {
-    let mut ts = ts::begin(governor());
-    setup_world(&mut ts);
-    setup_character(&mut ts, 1, 100, b"char_a");
-
-    let character_a_id: ID;
-    let character_b_id: ID;
-
-    ts::next_tx(&mut ts, admin());
-    {
-        let character_from_setup = ts::take_shared<Character>(&ts);
-        character_a_id = character::id(&character_from_setup);
-        ts::return_shared(character_from_setup);
-
-        let admin_acl = ts::take_shared<AdminACL>(&ts);
-        let mut registry = ts::take_shared<ObjectRegistry>(&ts);
-        let character_b = character::create_character(
-            &mut registry,
-            &admin_acl,
-            2u32,
-            tenant(),
-            100,
-            user_a(),
-            utf8(b"char_b"),
-            ts::ctx(&mut ts),
-        );
-        character_b_id = character::id(&character_b);
-        character_b.share_character(&admin_acl, ts::ctx(&mut ts));
-        ts::return_shared(registry);
-        ts::return_shared(admin_acl);
-    };
-
-    ts::next_tx(&mut ts, user_a());
-    {
-        let mut character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
-        let access_cap_ticket = ts::most_recent_receiving_ticket<OwnerCap<Character>>(
-            &character_a_id,
-        );
-        let (owner_cap, receipt) = character_a.borrow_owner_cap<Character>(
-            access_cap_ticket,
-            ts.ctx(),
-        );
-        ts::return_shared(character_a);
-
-        let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
-        character::return_owner_cap(&character_b, owner_cap, receipt);
-        ts::return_shared(character_b);
-    };
-    ts.end();
-}
+// Receipt validation (return to wrong owner) is covered by access_tests::return_owner_cap_to_object_mismatched_owner_id_fails.

--- a/ts-scripts/builder_extension/collect-corpse-bounty.ts
+++ b/ts-scripts/builder_extension/collect-corpse-bounty.ts
@@ -61,12 +61,7 @@ async function collectCorpseBounty(
     tx.setSender(address);
     tx.setGasOwner(adminAddress);
 
-    const [ownerCap, receipt] = tx.moveCall({
-        target: `${config.packageId}::${MODULES.CHARACTER}::borrow_owner_cap`,
-        typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
-        arguments: [tx.object(characterId), tx.object(playerOwnerCapId)],
-    });
-
+    // Character OwnerCap is wallet-owned; pass it directly (no borrow/return)
     tx.moveCall({
         target: `${builderPackageId}::${extensionModule.CORPSE_GATE_BOUNTY}::collect_corpse_bounty`,
         typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
@@ -76,16 +71,10 @@ async function collectCorpseBounty(
             tx.object(sourceGateId!),
             tx.object(destinationGateId!),
             tx.object(characterId!),
-            ownerCap,
+            tx.object(playerOwnerCapId),
             tx.pure.u64(ITEM_A_TYPE_ID),
             tx.object(CLOCK_OBJECT_ID),
         ],
-    });
-
-    tx.moveCall({
-        target: `${config.packageId}::${MODULES.CHARACTER}::return_owner_cap`,
-        typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
-        arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
     const result = await executeSponsoredTransaction(

--- a/ts-scripts/storage-unit/deposit-to-ephemeral-inventory.ts
+++ b/ts-scripts/storage-unit/deposit-to-ephemeral-inventory.ts
@@ -42,12 +42,7 @@ async function gameItemToChain(
     tx.setSender(playerAddress);
     tx.setGasOwner(adminAddress);
 
-    const [ownerCap, receipt] = tx.moveCall({
-        target: `${config.packageId}::${MODULES.CHARACTER}::borrow_owner_cap`,
-        typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
-        arguments: [tx.object(characterId), tx.object(ownerCapId)],
-    });
-
+    // Character OwnerCap is wallet-owned; pass it directly (no borrow/return)
     tx.moveCall({
         target: `${config.packageId}::${MODULES.STORAGE_UNIT}::game_item_to_chain_inventory`,
         typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
@@ -55,18 +50,12 @@ async function gameItemToChain(
             tx.object(storageUnit),
             tx.object(config.adminAcl),
             tx.object(characterId),
-            ownerCap,
+            tx.object(ownerCapId),
             tx.pure.u64(itemId),
             tx.pure.u64(typeId),
             tx.pure.u64(volume),
             tx.pure.u32(quantity),
         ],
-    });
-
-    tx.moveCall({
-        target: `${config.packageId}::${MODULES.CHARACTER}::return_owner_cap`,
-        typeArguments: [`${config.packageId}::${MODULES.CHARACTER}::Character`],
-        arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
     const result = await executeSponsoredTransaction(


### PR DESCRIPTION
**Motivation**
- Character OwnerCap was moved to the wallet (character_address) so clients can query “characters by wallet” (e.g. address.objects(filter: { type: "…::access::OwnerCap" }) and use authorized_object_id). The cap must stay non-transferable so it cannot be sold or moved to another address.

**Changes**
- modified relevant code, tests, and ts scripts