### PR TITLE
Fix offline guard for extension withdraw in storage units

### DIFF
--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -237,6 +237,8 @@ public fun withdraw_item<Auth: drop>(
         storage_unit.extension.contains(&type_name::with_defining_ids<Auth>()),
         EExtensionNotAuthorized,
     );
+    assert!(storage_unit.status.is_online(), ENotOnline);
+
     let inventory = df::borrow_mut<ID, Inventory>(
         &mut storage_unit.id,
         storage_unit.owner_cap_id,

--- a/contracts/world/tests/assemblies/storage_unit_tests.move
+++ b/contracts/world/tests/assemblies/storage_unit_tests.move
@@ -1090,6 +1090,41 @@ fun test_deposit_via_extension_fail_not_authorized() {
     ts::end(ts);
 }
 
+#[test, expected_failure(abort_code = storage_unit::ENotOnline)]
+fun test_withdraw_via_extension_fail_offline() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_id, _nwn_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_id);
+    let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+    let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+        ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+        ts.ctx(),
+    );
+    storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+    character.return_owner_cap(owner_cap, receipt);
+
+    ts::next_tx(&mut ts, user_a());
+    let _item = storage_unit.withdraw_item<SwapAuth>(
+        &character,
+        SwapAuth {},
+        AMMO_TYPE_ID,
+        AMMO_QUANTITY,
+        ts.ctx(),
+    );
+    abort
+}
+
 /// Test that withdrawing by owner without proper owner capability fails
 /// Scenario: User B attempts to withdraw items from User A's storage unit using wrong OwnerCap
 /// Expected: Transaction aborts with EInventoryNotAuthorized error


### PR DESCRIPTION
## Summary
- add an online-state assertion in `storage_unit::withdraw_item<Auth>`
- add a regression test to verify extension withdraw aborts with `storage_unit::ENotOnline` when offline

## Test plan
- [x] Run lints for changed files (`storage_unit.move`, `storage_unit_tests.move`)
- [x] Run Move tests for storage unit scenarios