### PR TITLE
Fix release behavior for unconfigured energy assembly types

### DIFF
--- a/contracts/world/sources/primitives/energy.move
+++ b/contracts/world/sources/primitives/energy.move
@@ -58,12 +58,12 @@ public struct EnergyReleasedEvent has copy, drop {
 
 // === View Functions ===
 /// Returns the energy required for an assembly type id
-public fun assembly_energy(energy_config: &EnergyConfig, type_id: u64): u64 {
+public fun assembly_energy(energy_config: &EnergyConfig, type_id: u64): Option<u64> {
     assert!(type_id != 0, ETypeIdEmpty);
     if (energy_config.assembly_energy.contains(type_id)) {
-        *energy_config.assembly_energy.borrow(type_id)
+        option::some(*energy_config.assembly_energy.borrow(type_id))
     } else {
-        0
+        option::none()
     }
 }
 
@@ -167,7 +167,9 @@ public(package) fun reserve_energy(
     assert!(type_id != 0, ETypeIdEmpty);
     assert!(energy_source.current_energy_production > 0, ENotProducingEnergy);
 
-    let energy_required = assembly_energy(energy_config, type_id);
+    let energy_required = energy_config
+        .assembly_energy(type_id)
+        .extract_or!(abort EIncorrectAssemblyType);
     let available = available_energy(energy_source);
     assert!(available >= energy_required, EInsufficientAvailableEnergy);
 
@@ -191,7 +193,7 @@ public(package) fun release_energy(
     assert!(type_id != 0, ETypeIdEmpty);
 
     // If no energy is reserved, nothing to release (may have been released by stop_energy_production)
-    let energy_required = assembly_energy(energy_config, type_id);
+    let energy_required = energy_config.assembly_energy(type_id).extract_or!(0u64);
     if (
         energy_source.total_reserved_energy == 0 || energy_source.total_reserved_energy < energy_required
     ) {

--- a/contracts/world/tests/primitives/energy_tests.move
+++ b/contracts/world/tests/primitives/energy_tests.move
@@ -53,9 +53,9 @@ fun set_and_get_assembly_energy_configs() {
         let energy_2 = energy_config.assembly_energy(assembly_type_2());
         let energy_3 = energy_config.assembly_energy(assembly_type_3());
 
-        assert_eq!(energy_1, assembly_type_1_energy());
-        assert_eq!(energy_2, assembly_type_2_energy());
-        assert_eq!(energy_3, assembly_type_3_energy());
+        assert_eq!(energy_1, option::some(assembly_type_1_energy()));
+        assert_eq!(energy_2, option::some(assembly_type_2_energy()));
+        assert_eq!(energy_3, option::some(assembly_type_3_energy()));
 
         ts::return_shared(energy_config);
     };
@@ -82,7 +82,7 @@ fun set_energy_config_updates_existing() {
     {
         let energy_config = ts::take_shared<EnergyConfig>(&ts);
         let energy = energy_config.assembly_energy(assembly_type_1());
-        assert_eq!(energy, 75);
+        assert_eq!(energy, option::some(75));
 
         ts::return_shared(energy_config);
     };
@@ -110,8 +110,8 @@ fun remove_energy_config() {
         let energy_config = ts::take_shared<EnergyConfig>(&ts);
         let energy_1 = energy_config.assembly_energy(assembly_type_1());
         let energy_3 = energy_config.assembly_energy(assembly_type_3());
-        assert_eq!(energy_1, assembly_type_1_energy());
-        assert_eq!(energy_3, assembly_type_3_energy());
+        assert_eq!(energy_1, option::some(assembly_type_1_energy()));
+        assert_eq!(energy_3, option::some(assembly_type_3_energy()));
 
         ts::return_shared(energy_config);
     };
@@ -464,6 +464,22 @@ fun reserve_energy_with_empty_type_id() {
 }
 
 #[test]
+#[expected_failure(abort_code = energy::EIncorrectAssemblyType)]
+fun reserve_energy_with_unconfigured_type() {
+    let mut ts = ts::begin(user_a());
+    test_helpers::setup_world(&mut ts);
+    let nwn_id = create_network_node(&mut ts, MAX_PRODUCTION);
+
+    ts::next_tx(&mut ts, admin());
+    let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_id);
+    nwn.energy.start_energy_production(nwn_id);
+    let energy_config = ts::take_shared<EnergyConfig>(&ts);
+    nwn.energy.reserve_energy(nwn_id, &energy_config, 9999);
+
+    abort
+}
+
+#[test]
 #[expected_failure(abort_code = energy::ETypeIdEmpty)]
 fun set_energy_config_with_empty_type_id() {
     let mut ts = ts::begin(user_a());
@@ -555,6 +571,32 @@ fun release_energy_with_empty_type_id() {
         let energy_config = ts::take_shared<EnergyConfig>(&ts);
         nwn.energy.reserve_energy(nwn_id, &energy_config, assembly_type_1());
         nwn.energy.release_energy(nwn_id, &energy_config, 0);
+
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+fun release_energy_with_unconfigured_type() {
+    let mut ts = ts::begin(user_a());
+    test_helpers::setup_world(&mut ts);
+    test_helpers::configure_assembly_energy(&mut ts);
+    let nwn_id = create_network_node(&mut ts, MAX_PRODUCTION);
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        nwn.energy.start_energy_production(nwn_id);
+        nwn.energy.reserve_energy(nwn_id, &energy_config, assembly_type_1());
+        let reserved_before = nwn.energy.total_reserved_energy();
+
+        // Unconfigured type should be a no-op and not abort.
+        nwn.energy.release_energy(nwn_id, &energy_config, 9999);
+        assert_eq!(nwn.energy.total_reserved_energy(), reserved_before);
 
         ts::return_shared(nwn);
         ts::return_shared(energy_config);


### PR DESCRIPTION
## Summary
- return `Option<u64>` from `energy::assembly_energy` to represent missing configuration explicitly
- keep `reserve_energy` strict by aborting with `EIncorrectAssemblyType` for unconfigured assembly types
- make `release_energy` a safe no-op for unconfigured assembly types to avoid cleanup-time aborts

## Test plan
- [x] Run lints for changed files
- [x] Run targeted Move tests locally (`reserve_energy_with_unconfigured_type`, `release_energy_with_unconfigured_type`) 