### PR TITLE
Improvement: Add location registry to ts-scripts utils

### DIFF
--- a/ts-scripts/utils/config.ts
+++ b/ts-scripts/utils/config.ts
@@ -2,6 +2,7 @@ export type WorldObjectIds = {
     governorCap: string;
     serverAddressRegistry: string;
     objectRegistry: string;
+    locationRegistry: string,
     adminAcl: string;
     energyConfig: string;
     fuelConfig: string;
@@ -47,6 +48,7 @@ export function getConfig(network: Network = "localnet"): WorldConfig {
         governorCap: "",
         serverAddressRegistry: "",
         objectRegistry: "",
+        locationRegistry: "",
         adminAcl: "",
         energyConfig: "",
         fuelConfig: "",

--- a/ts-scripts/utils/extract-object-ids.ts
+++ b/ts-scripts/utils/extract-object-ids.ts
@@ -69,6 +69,13 @@ function extractWorldIds(
                 typeName(packageId, "object_registry", "ObjectRegistry")
             )
         ),
+        locationRegistry: requireId(
+            "LocationRegistry",
+            findCreatedObjectId(
+                objectChanges,
+                typeName(packageId, "location", "LocationRegistry")
+            )
+        ),
         energyConfig: requireId(
             "EnergyConfig",
             findCreatedObjectId(objectChanges, typeName(packageId, MODULES.ENERGY, "EnergyConfig"))

--- a/ts-scripts/utils/world-object-ids.ts
+++ b/ts-scripts/utils/world-object-ids.ts
@@ -82,6 +82,13 @@ export async function resolveWorldObjectIds(
                     typeName(publishedWorldPackageId, "object_registry", "ObjectRegistry")
                 )
             ),
+            locationRegistry: requireId(
+                "LocationRegistry",
+                findCreatedObjectId(
+                    worldObjectChanges,
+                    typeName(publishedWorldPackageId, "location", "LocationRegistry")
+                )
+            ),
             energyConfig: requireId(
                 "EnergyConfig",
                 findCreatedObjectId(


### PR DESCRIPTION
Adds the location registry to the world config in `ts-scripts/utils/` so it can be used by other scripts.