### PR TITLE
feat: Expose keys for all assemblies

### DIFF
--- a/contracts/world/sources/assemblies/assembly.move
+++ b/contracts/world/sources/assemblies/assembly.move
@@ -3,18 +3,22 @@
 module world::assembly;
 
 use std::string::String;
-use sui::{derived_object, event};
-use world::{
-    access::{Self, AdminACL, OwnerCap},
-    character::Character,
-    energy::EnergyConfig,
-    in_game_id::{Self, TenantItemId},
-    location::{Self, Location, LocationRegistry},
-    metadata::{Self, Metadata},
-    network_node::{NetworkNode, OfflineAssemblies, HandleOrphanedAssemblies, UpdateEnergySources},
-    object_registry::ObjectRegistry,
-    status::{Self, AssemblyStatus}
+use sui::derived_object;
+use sui::event;
+use world::access::{Self, AdminACL, OwnerCap};
+use world::character::Character;
+use world::energy::EnergyConfig;
+use world::in_game_id::{Self, TenantItemId};
+use world::location::{Self, Location, LocationRegistry};
+use world::metadata::{Self, Metadata};
+use world::network_node::{
+    NetworkNode,
+    OfflineAssemblies,
+    HandleOrphanedAssemblies,
+    UpdateEnergySources
 };
+use world::object_registry::ObjectRegistry;
+use world::status::{Self, AssemblyStatus};
 
 // === Errors ===
 #[error(code = 0)]
@@ -156,6 +160,10 @@ public fun reveal_location(
 }
 
 // === View Functions ===
+public fun key(assembly: &Assembly): TenantItemId {
+    assembly.key
+}
+
 public fun status(assembly: &Assembly): &AssemblyStatus {
     &assembly.status
 }

--- a/contracts/world/sources/assemblies/gate.move
+++ b/contracts/world/sources/assemblies/gate.move
@@ -14,20 +14,29 @@
 /// Extension pattern: https://github.com/evefrontier/world-contracts/blob/main/docs/architechture.md#layer-3-player-extensions-moddability
 module world::gate;
 
-use std::{bcs, string::String, type_name::{Self, TypeName}};
-use sui::{clock::Clock, derived_object, event, hash, table::{Self, Table}};
-use world::{
-    access::{Self, OwnerCap, ServerAddressRegistry, AdminACL},
-    character::{Self, Character},
-    energy::EnergyConfig,
-    extension_freeze,
-    in_game_id::{Self, TenantItemId},
-    location::{Self, Location, LocationRegistry},
-    metadata::{Self, Metadata},
-    network_node::{NetworkNode, OfflineAssemblies, HandleOrphanedAssemblies, UpdateEnergySources},
-    object_registry::ObjectRegistry,
-    status::{Self, AssemblyStatus}
+use std::bcs;
+use std::string::String;
+use std::type_name::{Self, TypeName};
+use sui::clock::Clock;
+use sui::derived_object;
+use sui::event;
+use sui::hash;
+use sui::table::{Self, Table};
+use world::access::{Self, OwnerCap, ServerAddressRegistry, AdminACL};
+use world::character::{Self, Character};
+use world::energy::EnergyConfig;
+use world::extension_freeze;
+use world::in_game_id::{Self, TenantItemId};
+use world::location::{Self, Location, LocationRegistry};
+use world::metadata::{Self, Metadata};
+use world::network_node::{
+    NetworkNode,
+    OfflineAssemblies,
+    HandleOrphanedAssemblies,
+    UpdateEnergySources
 };
+use world::object_registry::ObjectRegistry;
+use world::status::{Self, AssemblyStatus};
 
 // === Errors ===
 #[error(code = 0)]
@@ -534,6 +543,10 @@ public fun jump_permit_id(permit: &JumpPermit): ID {
 
 public fun status(gate: &Gate): &AssemblyStatus {
     &gate.status
+}
+
+public fun key(gate: &Gate): TenantItemId {
+    gate.key
 }
 
 public fun location(gate: &Gate): &Location {

--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -27,21 +27,31 @@
 /// Future pattern: Storage Units (extension-controlled), Ships (owner-controlled)
 module world::storage_unit;
 
-use std::{bcs, string::String, type_name::{Self, TypeName}};
-use sui::{address, clock::Clock, derived_object, dynamic_field as df, event, hash};
-use world::{
-    access::{Self, OwnerCap, ServerAddressRegistry, AdminACL},
-    character::Character,
-    energy::EnergyConfig,
-    extension_freeze,
-    in_game_id::{Self, TenantItemId},
-    inventory::{Self, Inventory, Item},
-    location::{Self, Location, LocationRegistry},
-    metadata::{Self, Metadata},
-    network_node::{NetworkNode, OfflineAssemblies, HandleOrphanedAssemblies, UpdateEnergySources},
-    object_registry::ObjectRegistry,
-    status::{Self, AssemblyStatus, Status}
+use std::bcs;
+use std::string::String;
+use std::type_name::{Self, TypeName};
+use sui::address;
+use sui::clock::Clock;
+use sui::derived_object;
+use sui::dynamic_field as df;
+use sui::event;
+use sui::hash;
+use world::access::{Self, OwnerCap, ServerAddressRegistry, AdminACL};
+use world::character::Character;
+use world::energy::EnergyConfig;
+use world::extension_freeze;
+use world::in_game_id::{Self, TenantItemId};
+use world::inventory::{Self, Inventory, Item};
+use world::location::{Self, Location, LocationRegistry};
+use world::metadata::{Self, Metadata};
+use world::network_node::{
+    NetworkNode,
+    OfflineAssemblies,
+    HandleOrphanedAssemblies,
+    UpdateEnergySources
 };
+use world::object_registry::ObjectRegistry;
+use world::status::{Self, AssemblyStatus, Status};
 
 // === Errors ===
 #[error(code = 0)]
@@ -538,6 +548,10 @@ public fun reveal_location(
 // === View Functions ===
 public fun id(storage_unit: &StorageUnit): ID {
     object::id(storage_unit)
+}
+
+public fun key(storage_unit: &StorageUnit): TenantItemId {
+    storage_unit.key
 }
 
 public fun status(storage_unit: &StorageUnit): &AssemblyStatus {


### PR DESCRIPTION
Exposes the TenantItemId keys for each assembly type. They were already exposed for turrets but were missing from gates, storage units, and assemblies.