### PR TITLE
fix(docker): mount workspace in bake container and wait for node shutdown before commit

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,4 +21,4 @@ jobs:
             -v "${{ github.workspace }}:/app" \
             -w /app \
             -e CI=true \
-            world-integration
+            world-integration test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: world-contracts
+  SNAPSHOT_IMAGE_NAME: world-contracts-localnet-snapshot
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
@@ -66,6 +67,18 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
             type=raw,value=latest
+
+      - name: Extract snapshot image metadata (tags, labels)
+        id: meta-snapshot
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.SNAPSHOT_IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest
       
       - name: Build and push release image
         uses: docker/build-push-action@v5
@@ -77,3 +90,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Bake and push snapshot image (pre-baked container state)
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          OWNER: ${{ env.REPO_OWNER }}
+          IMAGE_NAME: ${{ env.SNAPSHOT_IMAGE_NAME }}
+          METADATA_TAGS: ${{ steps.meta-snapshot.outputs.tags }}
+          METADATA_LABELS: ${{ steps.meta-snapshot.outputs.labels }}
+        run: ./scripts/bake-snapshot-image.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ docker run --rm \
 
 On failure, check `deployments/<env>/deploy.log` for details.
 
+## Localnet snapshot image
+
+For a **pre-baked Sui localnet** Docker image (deployed contracts, Postgres-backed indexer, and object IDs for downstream integration tests), see **[`docker/README.md`](docker/README.md)**. It covers how to run the stack with [`docker/docker-compose-snapshot-image.yml`](docker/docker-compose-snapshot-image.yml) and where the image is published on GitHub Container Registry.
+
 ## Local Development
 
 ### Install Dependencies

--- a/docker/Dockerfile.integration
+++ b/docker/Dockerfile.integration
@@ -1,6 +1,7 @@
 # Localnet + Node + pnpm for CI integration tests. Run with -v $(pwd):/app.
 # Pin versions for reproducible CI. Override with build-args if needed.
 FROM docker.io/library/ubuntu:24.04
+
 ARG PNPM_VERSION=9
 # Sui version/network: testnet, devnet, mainnet, or a version tag.
 # Must match Move.toml/Move.lock rev (e.g. testnet-v1.66.2) so the CLI can parse the lockfile.
@@ -32,5 +33,10 @@ ENV SUI_CONFIG_DIR=/root/.sui
 
 COPY docker/entrypoint-integration.sh /entrypoint.sh
 RUN dos2unix /entrypoint.sh && chmod +x /entrypoint.sh
+
+COPY docker/entrypoint-snapshot-image.sh /entrypoint-snapshot-image.sh
+RUN dos2unix /entrypoint-snapshot-image.sh && chmod +x /entrypoint-snapshot-image.sh
+
+COPY docker/fullnode.yaml /fullnode.yaml
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# Snapshot image (local Sui + contracts)
+
+Pre-built Docker image with a Sui **localnet**, deployed **world** and **builder** packages, and (with Postgres) indexer and GraphQL. Use it to run integration tests against a fixed chain from your laptop or CI.
+
+## Run it locally
+
+See **[`docker-compose-snapshot-image.yml`](docker-compose-snapshot-image.yml)** for a working example: Postgres, the snapshot service, ports, and env vars wired up.
+
+From the repo root:
+
+```bash
+docker compose -f docker/docker-compose-snapshot-image.yml up
+```
+
+The compose file uses a **local** image tag (`world-contracts-localnet-snapshot:local`). To use a published build instead, change `image:` to the GHCR address below and add a tag.
+
+## Where to get the image
+
+Images are on **GitHub Container Registry**:
+
+`ghcr.io/evefrontier/world-contracts-localnet-snapshot:<tag>`
+
+Tags line up with releases (e.g. version numbers, `latest`). Check this repo’s **Packages** on GitHub for what’s available. Private packages need `docker login ghcr.io` first.
+
+## Object IDs on your machine (`extracted-object-ids.json`)
+
+Tests need the **package and object IDs** that exist on this chain. The image ships that list as JSON.
+
+**How it gets onto the host**
+
+The compose file mounts a host folder onto `/data/deployment` in the container. A bind mount starts out empty on your machine, which would hide the file that’s baked into the image. On container start, the entrypoint **copies** the baked JSON from `/opt/world-contracts/extracted-object-ids.json` into `/data/deployment/extracted-object-ids.json`, overwriting any existing file. That write goes through the mount, so you end up with a real file on the host:
+
+`deployments/localnet-snapshot/extracted-object-ids.json` (relative to the repo when you use the paths in the compose file).
+
+**What’s in the file**
+
+Small JSON with a `network` name and two groups of IDs:
+
+- **`world`** — the published world package id and important shared objects (governor cap, registries, config objects, etc.).
+- **`builder`** — the builder extension package id and related caps/config ids.
+
+Your services or tests read these hex IDs when calling the chain (e.g. which package to target, which objects to pass into transactions).

--- a/docker/docker-compose-snapshot-image.yml
+++ b/docker/docker-compose-snapshot-image.yml
@@ -1,0 +1,43 @@
+# This is an example of how to use the snapshot image to start a localnet with indexer and graphql.
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  sui:
+    image: world-contracts-localnet-snapshot:local
+    ports:
+      - 9000:9000
+      - 9123:9123
+      - 9125:9125
+    volumes:
+      # Host folder for object IDs. On first start the container copies the baked JSON from the
+      # image into this mount (see entrypoint-snapshot-image.sh), so the file appears on the host
+      # at ../deployments/localnet-snapshot/extracted-object-ids.json. Needs :rw for that seed step.
+      - ../deployments/localnet-snapshot:/data/deployment:rw
+    environment:
+      POSTGRES_CONNECTION_STRING: "postgres://postgres:postgres@postgres:5432/postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:9000/rpc.discover > /dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -39,8 +39,17 @@ EOF
 fi
 
 # ---------- start local node ----------
+echo "[ci] Creating data directory..."
+mkdir -p /data/sui-localnet
+
+echo "[ci] Running sui genesis..."
+sui genesis --working-dir /data/sui-localnet --with-faucet
+
+echo "[ci] Copying fullnode.yaml to data directory..."
+cp /fullnode.yaml /data/sui-localnet/fullnode.yaml
+
 echo "[ci] Starting local Sui node..."
-sui start --with-faucet --force-regenesis &
+sui start --network.config /data/sui-localnet --with-faucet &
 NODE_PID=$!
 trap 'kill "$NODE_PID" 2>/dev/null || true' EXIT
 
@@ -113,17 +122,60 @@ else
   echo "[ci] WARN: env.example not found, skipping .env generation" >&2
 fi
 
-# ---------- default: deploy + integration test (when no CMD) ----------
-if [ $# -eq 0 ]; then
-  echo "[ci] Localnet ready. Running deploy + integration tests..."
+if [ $# -eq 1 ]; then
+  echo "[ci] Localnet ready. Deploying and configuring world..."
+
   cd /app
   export CI="${CI:-true}"
+
   pnpm install --frozen-lockfile
   pnpm deploy-world localnet
   pnpm run configure-world localnet
   pnpm deploy-builder-ext localnet
-  chmod +x ./scripts/run-integration-test.sh
-  DELAY_SECONDS="${DELAY_SECONDS:-3}" ./scripts/run-integration-test.sh
+
+  if [ "$1" = "test" ]; then
+    echo "[ci] Running integration tests..."
+
+    chmod +x ./scripts/run-integration-test.sh
+    DELAY_SECONDS="${DELAY_SECONDS:-3}" ./scripts/run-integration-test.sh
+  elif [ "$1" = "snapshot" ]; then
+    echo "[ci] Building snapshot image..."
+
+    echo "[ci] Shutting down node..."
+    if kill -0 "$NODE_PID" 2>/dev/null; then
+      # Try graceful shutdown first (SIGTERM), with a bounded wait.
+      echo "[ci] Node process signaled for shutdown..."
+      kill "$NODE_PID" 2>/dev/null || true
+
+      SHUTDOWN_TIMEOUT="${SHUTDOWN_TIMEOUT:-60}"
+      while kill -0 "$NODE_PID" 2>/dev/null && [ "$SHUTDOWN_TIMEOUT" -gt 0 ]; do
+        echo "[ci] Waiting for node to shutdown... $SHUTDOWN_TIMEOUT seconds remaining"
+
+        sleep 1
+        SHUTDOWN_TIMEOUT=$((SHUTDOWN_TIMEOUT - 1))
+      done
+
+      if kill -0 "$NODE_PID" 2>/dev/null; then
+        echo "[ci] Node did not exit gracefully, forcing termination..."
+        kill -9 "$NODE_PID" 2>/dev/null || true
+      fi
+
+      # Ensure the process is fully reaped before proceeding.
+      echo "[ci] Making sure the node process is fully reaped..."
+      wait "$NODE_PID" 2>/dev/null || true
+    else
+      echo "[ci] Node process not running; skipping shutdown wait."
+    fi
+
+    echo "[ci] Replacing entrypoint with snapshot image entrypoint..."
+    mv /entrypoint-snapshot-image.sh /entrypoint.sh
+    chmod a+x /entrypoint.sh
+
+    # Unmounted copy used at runtime to seed an empty host bind mount at /data/deployment.
+    echo "[ci] Copying extracted object ids to /opt/world-contracts/extracted-object-ids.json..."
+    mkdir -p /opt/world-contracts
+    cp deployments/localnet/extracted-object-ids.json /opt/world-contracts/extracted-object-ids.json
+  fi
 else
   echo "[ci] Localnet ready. Running command..."
   exec "$@"

--- a/docker/entrypoint-snapshot-image.sh
+++ b/docker/entrypoint-snapshot-image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "${POSTGRES_CONNECTION_STRING:-}" ]; then
+    echo "ERROR: POSTGRES_CONNECTION_STRING is not set" >&2
+    exit 1
+fi
+
+echo "========================"
+echo "starting sui with indexer and graphql"
+echo "========================"
+
+# If /data/deployment is an empty host bind mount, it hides the baked layer; copy from a path that
+# is never mounted so the same file appears on the host and in-container.
+SEED=/opt/world-contracts/extracted-object-ids.json
+if [ -f "$SEED" ]; then
+    mkdir -p /data/deployment
+
+    cp -f "$SEED" /data/deployment/extracted-object-ids.json
+    echo "Seeded /data/deployment/extracted-object-ids.json from image (synced to host mount)."
+fi
+
+exec sui start --network.config /data/sui-localnet --with-faucet --with-indexer="$POSTGRES_CONNECTION_STRING" --with-graphql=0.0.0.0:9125

--- a/docker/fullnode.yaml
+++ b/docker/fullnode.yaml
@@ -1,0 +1,13 @@
+db-path: /data/sui-localnet/full_node_db
+
+network-address: /dns/localhost/tcp/8080/http
+metrics-address: 0.0.0.0:9184
+json-rpc-address: 0.0.0.0:9000
+
+enable-event-processing: true
+
+p2p-config:
+  listen-address: 0.0.0.0:8084
+
+genesis:
+  genesis-file-location: /data/sui-localnet/genesis.blob

--- a/scripts/bake-snapshot-image.sh
+++ b/scripts/bake-snapshot-image.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REGISTRY="${REGISTRY:-ghcr.io}"
+OWNER="${OWNER:-${GITHUB_REPOSITORY_OWNER:-}}"
+IMAGE_NAME="${IMAGE_NAME:-world-contracts-localnet-snapshot}"
+TAG="${TAG:-${GITHUB_REF_NAME:-local}}"
+
+BAKER_IMAGE="${BAKER_IMAGE:-world-contracts-localnet-snapshot:baker}"
+OUT_IMAGE="${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}"
+
+if [ -z "$OWNER" ]; then
+    echo "ERROR: OWNER is empty. Set OWNER or GITHUB_REPOSITORY_OWNER." >&2
+    exit 1
+fi
+
+if [ -z "$IMAGE_NAME" ]; then
+    echo "ERROR: IMAGE_NAME is empty. Set IMAGE_NAME to the desired image name." >&2
+    exit 1
+fi
+
+if [ -z "$TAG" ]; then
+    echo "ERROR: TAG is empty. Set TAG or GITHUB_REF_NAME." >&2
+    exit 1
+fi
+
+# Optional: pass through docker/metadata-action outputs (multiline strings).
+# - METADATA_TAGS: newline-separated image refs (e.g. ghcr.io/org/img:1.2.3)
+# - METADATA_LABELS: newline-separated key=value labels
+METADATA_TAGS="${METADATA_TAGS:-}"
+METADATA_LABELS="${METADATA_LABELS:-}"
+
+cleanup() {
+    if [ -n "${CID:-}" ]; then
+        docker rm "$CID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+# 1) Build the baker image (should run chain + deploy + exit 0)
+docker build -f docker/Dockerfile.integration -t "$BAKER_IMAGE" .
+
+# 2) Run bake container (mount workspace so pnpm install / deploy scripts can run)
+CID="$(docker run -d -v "$(pwd):/app" -w /app -e CI=true "$BAKER_IMAGE" snapshot)"
+
+# 3) Wait for it to finish
+STATUS="$(docker wait "$CID")"
+if [ "$STATUS" != "0" ]; then
+    docker logs "$CID" >&2 || true
+    exit 1
+fi
+
+# 4) Commit baked filesystem into an image
+commit_args=()
+if [ -n "$METADATA_LABELS" ]; then
+    while IFS= read -r label; do
+        [ -z "$label" ] && continue
+
+        if [[ "$label" == *"="* ]]; then
+            key=${label%%=*}
+            value=${label#*=}
+
+            # Escape backslashes and double quotes for safe inclusion in a double-quoted value.
+            value_escaped=${value//\\/\\\\}
+            value_escaped=${value_escaped//\"/\\\"}
+
+            commit_args+=(--change "LABEL ${key}=\"${value_escaped}\"")
+        else
+            # Fallback: no '=' present, preserve original behavior.
+            commit_args+=(--change "LABEL $label")
+        fi
+    done <<<"$METADATA_LABELS"
+fi
+
+IMAGE_ID="$(docker commit "${commit_args[@]}" "$CID")"
+
+# 5) Tag + push
+if [ -n "$METADATA_TAGS" ]; then
+    while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        docker tag "$IMAGE_ID" "$ref"
+        docker push "$ref"
+    done <<<"$METADATA_TAGS"
+else
+    docker tag "$IMAGE_ID" "$OUT_IMAGE"
+    docker push "$OUT_IMAGE"
+fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -37,12 +37,14 @@ publish() {
     local out_file=$2
     local env=$3
     local localnet_pubfile=${4:-}
-    local tmp
+    local tmp tmp_err
     tmp=$(mktemp)
-    trap "rm -f $tmp" RETURN
+    tmp_err=$(mktemp)
+    trap 'rm -f -- "$tmp" "$tmp_err"' RETURN
 
     sui client switch --env "$env"
 
+    # JSON goes to stdout; build progress often goes to stderr. Do not merge (2>&1) or extract-json breaks.
     if [[ "$env" == "localnet" ]]; then
         if [[ -n "$localnet_pubfile" ]]; then
             # Path is relative to contracts/$pkg (same as test-publish cwd); check from there.
@@ -50,12 +52,12 @@ publish() {
                 echo "Error: localnet pubfile not found or not readable: $localnet_pubfile (from contracts/$pkg)" >&2
                 exit 1
             fi
-            (cd "contracts/$pkg" && sui client test-publish --build-env testnet --pubfile-path "$localnet_pubfile" --json) > "$tmp" 2>&1 || true
+            (cd "contracts/$pkg" && sui client test-publish --build-env testnet --pubfile-path "$localnet_pubfile" --json) > "$tmp" 2> "$tmp_err" || true
         else
-            (cd "contracts/$pkg" && sui client test-publish --build-env testnet --json) > "$tmp" 2>&1 || true
+            (cd "contracts/$pkg" && sui client test-publish --build-env testnet --json) > "$tmp" 2> "$tmp_err" || true
         fi
     else
-        (cd "contracts/$pkg" && sui client publish --json) > "$tmp" 2>&1 || true
+        (cd "contracts/$pkg" && sui client publish --json) > "$tmp" 2> "$tmp_err" || true
     fi
 
     pnpm exec tsx ts-scripts/utils/extract-json.ts "$tmp" > "$out_file" || true
@@ -65,12 +67,17 @@ publish() {
         echo ""
         echo "--- Publish output ---"
         cat "$tmp"
+        if [[ -s "$tmp_err" ]]; then
+            echo ""
+            echo "--- Publish stderr ---"
+            cat "$tmp_err"
+        fi
     } >> "$log"
 
     if [[ ! -s "$out_file" ]]; then
         echo "" >&2
         echo "=== Publish failed. Raw output ===" >&2
-        cat "$tmp" >&2
+        cat "$tmp" "$tmp_err" >&2
         exit 1
     fi
 }


### PR DESCRIPTION
Add a release-time bake that builds world-contracts-localnet-snapshot from
the integration image: start localnet, deploy world + builder, commit the
container filesystem, and push semver/sha/latest tags alongside the main
image.

Runtime image starts Sui from baked genesis/state with indexer + GraphQL,
seeds extracted-object-ids.json into the host bind mount, and is documented
with docker-compose and README links from the repo root. Each start overwrites
the host file from the image (cp -f), so after pulling a newer snapshot image
and running again, the host always gets that image's IDs—not a stale
extracted-object-ids.json from an older chain/image.

Integration entrypoint now uses explicit genesis + fullnode config, and
accepts `test` (deploy + run tests) or `snapshot` (deploy + swap entrypoint
for bake). CI passes `test` explicitly.

Fix publish() in scripts/lib.sh so JSON stays on stdout and build noise on
stderr, keeping extract-json reliable during snapshot builds.

Why: pre-baking avoids deploy-on-every-startup (faster, less flaky) and
gives fixed chain state for integration tests (e.g. services repo) without
depending on live provisioning or accidental side effects.