### PR TITLE
fix(ci): publish snapshot images to world-contracts with -snapshot tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: world-contracts
-  SNAPSHOT_IMAGE_NAME: world-contracts-localnet-snapshot
+  SNAPSHOT_IMAGE_NAME: world-contracts
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: world-contracts
-  SNAPSHOT_IMAGE_NAME: world-contracts
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
@@ -68,18 +67,6 @@ jobs:
             type=sha
             type=raw,value=latest
 
-      - name: Extract snapshot image metadata (tags, labels)
-        id: meta-snapshot
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.SNAPSHOT_IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest
-      
       - name: Build and push release image
         uses: docker/build-push-action@v5
         with:
@@ -95,7 +82,7 @@ jobs:
         env:
           REGISTRY: ${{ env.REGISTRY }}
           OWNER: ${{ env.REPO_OWNER }}
-          IMAGE_NAME: ${{ env.SNAPSHOT_IMAGE_NAME }}
-          METADATA_TAGS: ${{ steps.meta-snapshot.outputs.tags }}
-          METADATA_LABELS: ${{ steps.meta-snapshot.outputs.labels }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          METADATA_TAGS: ${{ steps.meta.outputs.tags }}
+          METADATA_LABELS: ${{ steps.meta.outputs.labels }}
         run: ./scripts/bake-snapshot-image.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ From the repo root:
 docker compose -f docker/docker-compose-snapshot-image.yml up
 ```
 
-The compose file uses a **local** image tag (`world-contracts-localnet-snapshot:local`). To use a published build instead, change `image:` to the GHCR address below and add a tag.
+The compose file defaults to the published **`latest-snapshot`** tag (`ghcr.io/evefrontier/world-contracts:latest-snapshot`). Change `image:` if you want another tag from GHCR (see below).
 
 ## Where to get the image
 
@@ -20,7 +20,7 @@ Images are on **GitHub Container Registry**:
 
 `ghcr.io/evefrontier/world-contracts:<tag>-snapshot`
 
-Tags line up with releases (e.g. version numbers, `latest`). Check this repo’s **Packages** on GitHub for what’s available. Private packages need `docker login ghcr.io` first.
+Tags line up with releases (e.g. version numbers, `latest`). Check this repo’s **Packages** on GitHub for what’s available.
 
 ## Object IDs on your machine (`extracted-object-ids.json`)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ The compose file uses a **local** image tag (`world-contracts-localnet-snapshot:
 
 Images are on **GitHub Container Registry**:
 
-`ghcr.io/evefrontier/world-contracts-localnet-snapshot:<tag>`
+`ghcr.io/evefrontier/world-contracts:<tag>-snapshot`
 
 Tags line up with releases (e.g. version numbers, `latest`). Check this repo’s **Packages** on GitHub for what’s available. Private packages need `docker login ghcr.io` first.
 

--- a/docker/docker-compose-snapshot-image.yml
+++ b/docker/docker-compose-snapshot-image.yml
@@ -18,7 +18,7 @@ services:
       retries: 5
 
   sui:
-    image: world-contracts-localnet-snapshot:local
+    image: ghcr.io/evefrontier/world-contracts:latest-snapshot
     ports:
       - 9000:9000
       - 9123:9123

--- a/scripts/bake-snapshot-image.sh
+++ b/scripts/bake-snapshot-image.sh
@@ -7,7 +7,7 @@ OWNER="${OWNER:-${GITHUB_REPOSITORY_OWNER:-}}"
 IMAGE_NAME="${IMAGE_NAME:-world-contracts}"
 TAG="${TAG:-${GITHUB_REF_NAME:-local}}"
 
-BAKER_IMAGE="${BAKER_IMAGE:-world-contracts-snapshot:baker}"
+BAKER_IMAGE="${BAKER_IMAGE:-${IMAGE_NAME}-snapshot:baker}"
 OUT_IMAGE="${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}"
 
 if [ -z "$OWNER" ]; then

--- a/scripts/bake-snapshot-image.sh
+++ b/scripts/bake-snapshot-image.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 REGISTRY="${REGISTRY:-ghcr.io}"
 OWNER="${OWNER:-${GITHUB_REPOSITORY_OWNER:-}}"
-IMAGE_NAME="${IMAGE_NAME:-world-contracts-localnet-snapshot}"
+IMAGE_NAME="${IMAGE_NAME:-world-contracts}"
 TAG="${TAG:-${GITHUB_REF_NAME:-local}}"
 
-BAKER_IMAGE="${BAKER_IMAGE:-world-contracts-localnet-snapshot:baker}"
+BAKER_IMAGE="${BAKER_IMAGE:-world-contracts-snapshot:baker}"
 OUT_IMAGE="${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}"
 
 if [ -z "$OWNER" ]; then
@@ -79,10 +79,10 @@ IMAGE_ID="$(docker commit "${commit_args[@]}" "$CID")"
 if [ -n "$METADATA_TAGS" ]; then
     while IFS= read -r ref; do
         [ -z "$ref" ] && continue
-        docker tag "$IMAGE_ID" "$ref"
-        docker push "$ref"
+        docker tag "$IMAGE_ID" "${ref}-snapshot"
+        docker push "${ref}-snapshot"
     done <<<"$METADATA_TAGS"
 else
-    docker tag "$IMAGE_ID" "$OUT_IMAGE"
-    docker push "$OUT_IMAGE"
+    docker tag "$IMAGE_ID" "${OUT_IMAGE}-snapshot"
+    docker push "${OUT_IMAGE}-snapshot"
 fi


### PR DESCRIPTION
GHCR packages are tied to this repository; a separate world-contracts-localnet-snapshot package does not exist. Use the world-contracts image name and distinguish snapshots with a -snapshot suffix on tags.

Update the release workflow, bake script defaults/tagging, and docker README accordingly.