### PR TITLE
fix: shadow permits vulnerability for jump permits

### DIFF
--- a/contracts/extension_examples/sources/corpse_gate_bounty.move
+++ b/contracts/extension_examples/sources/corpse_gate_bounty.move
@@ -4,12 +4,17 @@
 /// - withdraw an item from a player's `StorageUnit` (with owner auth)
 /// - validate it against a bounty rule (stored under `ExtensionConfig`)
 /// - deposit it into an owner `StorageUnit`
-/// - issue a `world::gate::JumpPermit` so the player can use the gate
+/// - issue a `world::gate::JumpPermitV2` so the player can use the gate
 module extension_examples::corpse_gate_bounty;
 
 use extension_examples::config::{Self, AdminCap, XAuth, ExtensionConfig};
 use sui::{clock::Clock, object::ID};
-use world::{access::OwnerCap, character::Character, gate::{Self, Gate}, storage_unit::StorageUnit};
+use world::{
+    access::OwnerCap,
+    character::Character,
+    gate::{Self, Gate, JumpPermit},
+    storage_unit::StorageUnit
+};
 
 // === Errors ===
 #[error(code = 0)]
@@ -27,7 +32,7 @@ public struct BountyConfig has drop, store {
 /// Dynamic-field key for `BountyConfig`.
 public struct BountyConfigKey has copy, drop, store {}
 
-/// Submit a corpse to get a `JumpPermit` for using the gate. Returns the new permit's object id.
+/// Submit a corpse to get a `JumpPermitV2` for using the gate. Returns the new permit's object id.
 public fun collect_corpse_bounty<T: key>(
     extension_config: &ExtensionConfig,
     storage_unit: &mut StorageUnit,
@@ -72,6 +77,27 @@ public fun collect_corpse_bounty<T: key>(
         character,
         config::x_auth(),
         expires_at_timestamp_ms,
+        ctx,
+    )
+}
+
+/// Migrates a legacy [`gate::JumpPermit`] into a [`gate::JumpPermitV2`] bound to this extension (`XAuth`).
+/// Both gates must be configured with `XAuth`.
+public fun migrate_jump_permit(
+    source_gate: &Gate,
+    destination_gate: &Gate,
+    character: &Character,
+    legacy_permit: JumpPermit,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    gate::migrate_jump_permit_to_v2<XAuth>(
+        source_gate,
+        destination_gate,
+        character,
+        legacy_permit,
+        clock,
+        config::x_auth(),
         ctx,
     )
 }

--- a/contracts/extension_examples/sources/tribe_permit.move
+++ b/contracts/extension_examples/sources/tribe_permit.move
@@ -1,10 +1,10 @@
 /// Example builder extension for `world::gate` using the typed-witness extension pattern.
 ///
 /// This module demonstrates how builders/players can enforce custom jump rules by issuing a
-/// `world::gate::JumpPermit` from extension logic:
+/// `world::gate::JumpPermitV2` from extension logic:
 /// - Gate owners configure a gate to use this extension by authorizing the witness type `XAuth`
 ///   on the gate (via `world::gate::authorize_extension<XAuth>`).
-/// - Once configured, travelers must use `world::gate::jump_with_permit`; default `jump` is not allowed.
+/// - Once configured, travelers must use `world::gate::jump_with_permit` (with a `JumpPermitV2`); default `jump` is not allowed.
 /// - This extension's `issue_jump_permit` entry point:
 ///   - checks a simple rule (character must belong to the configured starter `tribe`)
 ///   - sets an expiry window (currently 5 days from `Clock`)
@@ -16,7 +16,7 @@ module extension_examples::tribe_permit;
 
 use extension_examples::config::{Self, AdminCap, XAuth, ExtensionConfig};
 use sui::{clock::Clock, object::ID};
-use world::{character::Character, gate::{Self, Gate, JumpPermit}};
+use world::{character::Character, gate::{Self, Gate, JumpPermit, JumpPermitV2}};
 
 // === Errors ===
 #[error(code = 0)]
@@ -38,7 +38,7 @@ public fun tribe(extension_config: &ExtensionConfig): u32 {
 }
 
 // === Admin Functions ===
-/// Issue a `JumpPermit` to only starter tribes. Returns the new permit's object id.
+/// Issue a `JumpPermitV2` to only starter tribes. Returns the new permit's object id.
 public fun issue_jump_permit(
     extension_config: &ExtensionConfig,
     source_gate: &Gate,
@@ -66,9 +66,35 @@ public fun issue_jump_permit(
     )
 }
 
-/// Voids a jump permit via the extension. Caller must own the permit.
+/// Legacy entrypoint kept for API compatibility. Voids a legacy [`JumpPermit`] via the extension.
 public fun delete_jump_permit(source_gate: &Gate, jump_permit: JumpPermit) {
     gate::delete_jump_permit_with_auth<XAuth>(source_gate, jump_permit, config::x_auth());
+}
+
+/// Voids a [`JumpPermitV2`] via the extension. Caller must own the permit.
+public fun delete_jump_permit_v2(source_gate: &Gate, jump_permit: JumpPermitV2) {
+    gate::delete_jump_permit_v2_with_auth<XAuth>(source_gate, jump_permit, config::x_auth());
+}
+
+/// Migrates a legacy [`gate::JumpPermit`] owned by `character` into a [`JumpPermitV2`]
+/// bound to this extension. Both gates must be configured with same extension.
+public fun migrate_jump_permit(
+    source_gate: &Gate,
+    destination_gate: &Gate,
+    character: &Character,
+    legacy_permit: JumpPermit,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    gate::migrate_jump_permit_to_v2<XAuth>(
+        source_gate,
+        destination_gate,
+        character,
+        legacy_permit,
+        clock,
+        config::x_auth(),
+        ctx,
+    )
 }
 
 public fun set_tribe_config(

--- a/contracts/extension_examples/sources/tribe_permit.move
+++ b/contracts/extension_examples/sources/tribe_permit.move
@@ -4,7 +4,7 @@
 /// `world::gate::JumpPermitV2` from extension logic:
 /// - Gate owners configure a gate to use this extension by authorizing the witness type `XAuth`
 ///   on the gate (via `world::gate::authorize_extension<XAuth>`).
-/// - Once configured, travelers must use `world::gate::jump_with_permit` (with a `JumpPermitV2`); default `jump` is not allowed.
+/// - Once configured, travelers must use `world::gate::jump_with_permit_v2` (with a `JumpPermitV2`); default `jump` is not allowed.
 /// - This extension's `issue_jump_permit` entry point:
 ///   - checks a simple rule (character must belong to the configured starter `tribe`)
 ///   - sets an expiry window (currently 5 days from `Clock`)

--- a/contracts/world/sources/assemblies/gate.move
+++ b/contracts/world/sources/assemblies/gate.move
@@ -72,6 +72,14 @@ const EExtensionConfigFrozen: vector<u8> = b"Extension configuration is frozen";
 const EExtensionNotConfigured: vector<u8> = b"Extension must be configured before freezing";
 #[error(code = 19)]
 const ENoExtensionToRevoke: vector<u8> = b"No extension authorization to revoke";
+#[error(code = 20)]
+const EJumpPermitExtensionMismatch: vector<u8> =
+    b"Jump permit extension does not match gate extension";
+#[error(code = 21)]
+const EGateExtensionMismatch: vector<u8> = b"Linked gates use different extension types";
+#[error(code = 22)]
+const ELegacyJumpPermitMustBeMigrated: vector<u8> =
+    b"Legacy JumpPermit must be migrated to JumpPermitV2 before jumping";
 
 // === Structs ===
 public struct GateConfig has key {
@@ -92,7 +100,8 @@ public struct Gate has key {
     extension: Option<TypeName>,
 }
 
-// Note : Can add more fields later
+/// Legacy jump permit (pre–extension-binding). Still exists for old on-chain objects.
+/// New issuance produces [`JumpPermitV2`]. Migrate with [`migrate_jump_permit_to_v2`].
 public struct JumpPermit has key, store {
     id: UID,
     character_id: ID,
@@ -100,6 +109,15 @@ public struct JumpPermit has key, store {
     // Computed in a direction-agnostic way so the same permit works for A->B and B->A.
     route_hash: vector<u8>,
     expires_at_timestamp_ms: u64,
+}
+
+/// Jump permit bound to the extension type active on both gates at issuance.
+public struct JumpPermitV2 has key, store {
+    id: UID,
+    character_id: ID,
+    route_hash: vector<u8>,
+    expires_at_timestamp_ms: u64,
+    extension_type: TypeName,
 }
 
 // === Events ===
@@ -141,6 +159,18 @@ public struct JumpPermitIssuedEvent has copy, drop {
     source_gate_key: TenantItemId,
     destination_gate_id: ID,
     destination_gate_key: TenantItemId,
+    character_id: ID,
+    character_key: TenantItemId,
+    route_hash: vector<u8>,
+    expires_at_timestamp_ms: u64,
+    extension_type: TypeName,
+}
+
+public struct JumpPermitMigratedEvent has copy, drop {
+    legacy_jump_permit_id: ID,
+    new_jump_permit_id: ID,
+    source_gate_id: ID,
+    destination_gate_id: ID,
     character_id: ID,
     character_key: TenantItemId,
     route_hash: vector<u8>,
@@ -316,7 +346,7 @@ public fun unlink_gates(
     unlink(source_gate, destination_gate);
 }
 
-/// Issues a jump permit to the character's address. Emits `JumpPermitIssuedEvent` (for indexers and clients).
+/// Issues a [`JumpPermitV2`] to the character's address. Emits `JumpPermitIssuedEvent` (for indexers and clients).
 public fun issue_jump_permit<Auth: drop>(
     source_gate: &Gate,
     destination_gate: &Gate,
@@ -354,14 +384,19 @@ public fun issue_jump_permit_with_id<Auth: drop>(
     )
 }
 
-/// Deletes a jump permit by destroying it. Only the owner can call this (by passing their permit).
+/// Deletes a legacy jump permit by destroying it. Only the owner can call this (by passing their permit).
 public fun delete_jump_permit(jump_permit: JumpPermit) {
     let JumpPermit { id, .. } = jump_permit;
     id.delete();
 }
 
-/// Deletes a jump permit using the same extension Auth that can issue permits. The caller must have
-/// the permit (e.g. passed in by the owner, or held in extension logic).
+/// Deletes a [`JumpPermitV2`] by destroying it. Only the owner can call this.
+public fun delete_jump_permit_v2(jump_permit: JumpPermitV2) {
+    let JumpPermitV2 { id, .. } = jump_permit;
+    id.delete();
+}
+
+/// Deletes a legacy jump permit using the same extension Auth that can issue permits.
 public fun delete_jump_permit_with_auth<Auth: drop>(
     source_gate: &Gate,
     jump_permit: JumpPermit,
@@ -369,6 +404,21 @@ public fun delete_jump_permit_with_auth<Auth: drop>(
 ) {
     assert_gate_extension_matches<Auth>(source_gate);
     let JumpPermit { id, .. } = jump_permit;
+    id.delete();
+}
+
+/// Deletes a [`JumpPermitV2`] using extension auth; the permit must match the gate's extension.
+public fun delete_jump_permit_v2_with_auth<Auth: drop>(
+    source_gate: &Gate,
+    jump_permit: JumpPermitV2,
+    _: Auth,
+) {
+    assert_gate_extension_matches<Auth>(source_gate);
+    assert!(
+        jump_permit.extension_type == type_name::with_defining_ids<Auth>(),
+        EJumpPermitExtensionMismatch,
+    );
+    let JumpPermitV2 { id, .. } = jump_permit;
     id.delete();
 }
 
@@ -387,20 +437,93 @@ public fun jump(
     jump_internal(source_gate, destination_gate, character);
 }
 
-/// Jump from one gate to another using a jump permit.
-/// Requires extension logic to be configured and a valid Auth witness type from that extension.
+/// Legacy entrypoint kept for API compatibility only. Aborts unconditionally with
+/// `ELegacyJumpPermitMustBeMigrated`. Use [`migrate_jump_permit_to_v2`] + [`jump_with_permit_v2`].
 public fun jump_with_permit(
+    _source_gate: &Gate,
+    _destination_gate: &Gate,
+    _character: &Character,
+    _jump_permit: JumpPermit,
+    _admin_acl: &AdminACL,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
+) {
+    abort ELegacyJumpPermitMustBeMigrated
+}
+
+/// Jump from one gate to another using a [`JumpPermitV2`].
+/// Requires extension logic to be configured and a permit bound to the current gate extension.
+public fun jump_with_permit_v2(
     source_gate: &Gate,
     destination_gate: &Gate,
     character: &Character,
-    jump_permit: JumpPermit,
+    jump_permit: JumpPermitV2,
     admin_acl: &AdminACL,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
     admin_acl.verify_sponsor(ctx);
-    validate_jump_permit(source_gate, destination_gate, character, jump_permit, clock);
+    validate_jump_permit_v2(source_gate, destination_gate, character, jump_permit, clock);
     jump_internal(source_gate, destination_gate, character);
+}
+
+/// Converts a legacy [`JumpPermit`] into a [`JumpPermitV2`] bound to the **current** gate extension.
+/// The caller must supply the extension witness `Auth` matching the configured extension on both
+/// gates—this prevents upgrading shadow permits after the owner swaps to a different extension
+/// unless that new extension cooperates (witness is not forgeable across packages).
+public fun migrate_jump_permit_to_v2<Auth: drop>(
+    source_gate: &Gate,
+    destination_gate: &Gate,
+    character: &Character,
+    jump_permit: JumpPermit,
+    clock: &Clock,
+    _: Auth,
+    ctx: &mut TxContext,
+): ID {
+    assert_jump_permit_extension_authorization<Auth>(source_gate, destination_gate);
+    validate_legacy_jump_permit(
+        source_gate,
+        destination_gate,
+        character,
+        &jump_permit,
+        clock,
+    );
+
+    let legacy_jump_permit_id = object::id(&jump_permit);
+    let JumpPermit {
+        id: legacy_id,
+        character_id,
+        route_hash,
+        expires_at_timestamp_ms,
+    } = jump_permit;
+    legacy_id.delete();
+
+    let extension_type = type_name::with_defining_ids<Auth>();
+    let permit_uid = object::new(ctx);
+    let new_jump_permit_id = object::uid_to_inner(&permit_uid);
+
+    let new_permit = JumpPermitV2 {
+        id: permit_uid,
+        character_id,
+        route_hash,
+        expires_at_timestamp_ms,
+        extension_type,
+    };
+    transfer::transfer(new_permit, character.character_address());
+
+    event::emit(JumpPermitMigratedEvent {
+        legacy_jump_permit_id,
+        new_jump_permit_id,
+        source_gate_id: object::id(source_gate),
+        destination_gate_id: object::id(destination_gate),
+        character_id,
+        character_key: character::key(character),
+        route_hash,
+        expires_at_timestamp_ms,
+        extension_type,
+    });
+
+    new_jump_permit_id
 }
 
 /// Updates the gate's energy source and removes it from the UpdateEnergySources hot potato.
@@ -532,6 +655,14 @@ public fun jump_permit_id(permit: &JumpPermit): ID {
     object::id(permit)
 }
 
+public fun jump_permit_v2_id(permit: &JumpPermitV2): ID {
+    object::id(permit)
+}
+
+public fun jump_permit_v2_extension(permit: &JumpPermitV2): TypeName {
+    permit.extension_type
+}
+
 public fun status(gate: &Gate): &AssemblyStatus {
     &gate.status
 }
@@ -556,7 +687,7 @@ public fun linked_gate_id(gate: &Gate): Option<ID> {
 }
 
 /// Route hash for a jump permit: `blake2b256(bcs(source_id) || bcs(destination_id))`.
-/// Same encoding as `issue_jump_permit(source_gate, destination_gate, ...)` stores in `JumpPermit.route_hash`.
+/// Same encoding as `issue_jump_permit(source_gate, destination_gate, ...)` stores in [`JumpPermitV2.route_hash`] (and legacy [`JumpPermit.route_hash`]).
 /// `jump` accepts either argument order; swap the gates if you need the reversed hash.
 public fun route_hash(source_gate: &Gate, destination_gate: &Gate): vector<u8> {
     compute_route_hash(object::id(source_gate), object::id(destination_gate))
@@ -881,17 +1012,42 @@ fun jump_internal(source_gate: &Gate, destination_gate: &Gate, character: &Chara
     });
 }
 
-fun validate_jump_permit(
+fun validate_legacy_jump_permit(
     source_gate: &Gate,
     destination_gate: &Gate,
     character: &Character,
-    jump_permit: JumpPermit,
+    jump_permit: &JumpPermit,
+    clock: &Clock,
+) {
+    let source_gate_id = object::id(source_gate);
+    let destination_gate_id = object::id(destination_gate);
+    // Validate jump permit then invalidate it
+    assert!(jump_permit.expires_at_timestamp_ms > clock.timestamp_ms(), EJumpPermitExpired);
+    assert!(jump_permit.character_id == object::id(character), EInvalidJumpPermit);
+    assert!(
+        jump_permit.route_hash == compute_route_hash(source_gate_id, destination_gate_id)
+        || jump_permit.route_hash == compute_route_hash(destination_gate_id, source_gate_id),
+        EInvalidJumpPermit,
+    );
+}
+
+fun validate_jump_permit_v2(
+    source_gate: &Gate,
+    destination_gate: &Gate,
+    character: &Character,
+    jump_permit: JumpPermitV2,
     clock: &Clock,
 ) {
     let source_gate_id = object::id(source_gate);
     let destination_gate_id = object::id(destination_gate);
 
-    // Validate jump permit then invalidate it
+    assert!(option::is_some(&source_gate.extension), EExtensionNotConfigured);
+    assert!(option::is_some(&destination_gate.extension), EExtensionNotConfigured);
+    let src_ext = option::borrow(&source_gate.extension);
+    let dst_ext = option::borrow(&destination_gate.extension);
+    assert!(src_ext == dst_ext, EGateExtensionMismatch);
+    assert!(jump_permit.extension_type == *src_ext, EJumpPermitExtensionMismatch);
+
     assert!(jump_permit.expires_at_timestamp_ms > clock.timestamp_ms(), EJumpPermitExpired);
     assert!(jump_permit.character_id == object::id(character), EInvalidJumpPermit);
     assert!(
@@ -902,7 +1058,7 @@ fun validate_jump_permit(
 
     // TODO: We can allow the permit to be used multiple times and make the invalidation action chosen by the builder extension logic later.
     // Invalidate the permit by deleting the object
-    let JumpPermit { id, .. } = jump_permit;
+    let JumpPermitV2 { id, .. } = jump_permit;
     id.delete();
 }
 
@@ -967,15 +1123,16 @@ fun issue_jump_permit_internal<Auth: drop>(
     let permit_uid = object::new(ctx);
     let jump_permit_id = object::uid_to_inner(&permit_uid);
 
-    let jump_permit = JumpPermit {
+    let extension_type = type_name::with_defining_ids<Auth>();
+    let jump_permit = JumpPermitV2 {
         id: permit_uid,
         route_hash,
         character_id,
         expires_at_timestamp_ms,
+        extension_type,
     };
     transfer::transfer(jump_permit, character.character_address());
 
-    let extension_type = type_name::with_defining_ids<Auth>();
     event::emit(JumpPermitIssuedEvent {
         jump_permit_id,
         source_gate_id,
@@ -1017,9 +1174,54 @@ public fun test_jump_with_permit(
     source_gate: &Gate,
     destination_gate: &Gate,
     character: &Character,
-    jump_permit: JumpPermit,
+    jump_permit: JumpPermitV2,
     clock: &Clock,
 ) {
-    validate_jump_permit(source_gate, destination_gate, character, jump_permit, clock);
+    validate_jump_permit_v2(source_gate, destination_gate, character, jump_permit, clock);
     jump_internal(source_gate, destination_gate, character);
+}
+
+#[test_only]
+public fun issue_jump_permit_legacy_for_testing<Auth: drop>(
+    source_gate: &Gate,
+    destination_gate: &Gate,
+    character: &Character,
+    auth: Auth,
+    expires_at_timestamp_ms: u64,
+    ctx: &mut TxContext,
+): ID {
+    assert_jump_permit_extension_authorization<Auth>(source_gate, destination_gate);
+
+    let source_gate_id = object::id(source_gate);
+    let destination_gate_id = object::id(destination_gate);
+
+    let route_hash = compute_route_hash(source_gate_id, destination_gate_id);
+    let character_id = object::id(character);
+
+    let permit_uid = object::new(ctx);
+    let jump_permit_id = object::uid_to_inner(&permit_uid);
+
+    let jump_permit = JumpPermit {
+        id: permit_uid,
+        route_hash,
+        character_id,
+        expires_at_timestamp_ms,
+    };
+    transfer::transfer(jump_permit, character.character_address());
+
+    let extension_type = type_name::with_defining_ids<Auth>();
+    event::emit(JumpPermitIssuedEvent {
+        jump_permit_id,
+        source_gate_id,
+        source_gate_key: source_gate.key,
+        destination_gate_id,
+        destination_gate_key: destination_gate.key,
+        character_id,
+        character_key: character::key(character),
+        route_hash,
+        expires_at_timestamp_ms,
+        extension_type,
+    });
+
+    jump_permit_id
 }

--- a/contracts/world/tests/assemblies/gate_tests.move
+++ b/contracts/world/tests/assemblies/gate_tests.move
@@ -242,6 +242,14 @@ fun link_and_online_gates(
 }
 
 fun authorize_gate_extension(ts: &mut ts::Scenario, character_id: ID, gate_id: ID) {
+    authorize_gate_extension_with_auth<GateAuth>(ts, character_id, gate_id);
+}
+
+fun authorize_gate_extension_with_auth<Auth: drop>(
+    ts: &mut ts::Scenario,
+    character_id: ID,
+    gate_id: ID,
+) {
     ts::next_tx(ts, user_a());
     {
         let mut gate_obj = ts::take_shared_by_id<Gate>(ts, gate_id);
@@ -249,7 +257,7 @@ fun authorize_gate_extension(ts: &mut ts::Scenario, character_id: ID, gate_id: I
         let owner_cap_id = gate_obj.owner_cap_id();
         let gate_ticket = ts::receiving_ticket_by_id<OwnerCap<Gate>>(owner_cap_id);
         let (owner_cap, receipt) = character.borrow_owner_cap<Gate>(gate_ticket, ts.ctx());
-        gate_obj.authorize_extension<GateAuth>(&owner_cap);
+        gate_obj.authorize_extension<Auth>(&owner_cap);
         character.return_owner_cap(owner_cap, receipt);
         ts::return_shared(character);
         ts::return_shared(gate_obj);
@@ -1753,5 +1761,105 @@ fun revoke_extension_authorization_fails_after_freeze() {
         ts::return_shared(character);
         ts::return_shared(gate_obj);
     };
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = gate::EGateExtensionMismatch)]
+fun jump_with_permit_v2_fails_gate_extension_mismatch() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 801);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a permit while both gates share the same extension.
+    ts::next_tx(&mut ts, user_a());
+    let clock = clock::create_for_testing(ts.ctx());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    // Re-authorize destination gate with a different extension so src != dst.
+    authorize_gate_extension_with_auth<WrongGateAuth>(&mut ts, character_id, gate_b_id);
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    clock.destroy_for_testing();
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = gate::EJumpPermitExtensionMismatch)]
+fun jump_with_permit_v2_fails_permit_extension_mismatch() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 802);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a permit under GateAuth.
+    ts::next_tx(&mut ts, user_a());
+    let clock = clock::create_for_testing(ts.ctx());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    // Re-authorize both gates to a different extension. src == dst, but the permit's
+    // recorded extension_type no longer matches.
+    authorize_gate_extension_with_auth<WrongGateAuth>(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension_with_auth<WrongGateAuth>(&mut ts, character_id, gate_b_id);
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    clock.destroy_for_testing();
     ts::end(ts);
 }

--- a/contracts/world/tests/assemblies/gate_tests.move
+++ b/contracts/world/tests/assemblies/gate_tests.move
@@ -728,7 +728,6 @@ fun issue_jump_permit_fails_wrong_auth() {
 }
 
 #[test]
-#[expected_failure]
 fun test_jump_with_permit_consumes_permit() {
     let mut ts = ts::begin(governor());
     setup(&mut ts);
@@ -740,7 +739,9 @@ fun test_jump_with_permit_consumes_permit() {
 
     bring_network_node_online(&mut ts, character_id, nwn_id);
     link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    // V2 issuance requires both gates to share the same authorized extension.
     authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
 
     ts::next_tx(&mut ts, user_a());
     let clock = clock::create_for_testing(ts.ctx());
@@ -763,13 +764,13 @@ fun test_jump_with_permit_consumes_permit() {
     {
         let permit = ts::take_from_sender<JumpPermitV2>(&ts);
 
-        // First jump succeeds
+        // First jump consumes the permit
         gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
-
-        // Permit is deleted, taking another should fail.
-        let unexpected = ts::take_from_sender<JumpPermitV2>(&ts);
-        ts::return_to_sender(&ts, unexpected);
     };
+
+    // In a fresh tx the permit must be gone, proving it was consumed (deleted).
+    ts::next_tx(&mut ts, user_a());
+    assert!(!ts::has_most_recent_for_sender<JumpPermitV2>(&ts), 0);
 
     ts::return_shared(character);
     ts::return_shared(gate_a);
@@ -1848,6 +1849,70 @@ fun jump_with_permit_v2_fails_permit_extension_mismatch() {
     authorize_gate_extension_with_auth<WrongGateAuth>(&mut ts, character_id, gate_a_id);
     authorize_gate_extension_with_auth<WrongGateAuth>(&mut ts, character_id, gate_b_id);
 
+    ts::next_tx(&mut ts, user_a());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    clock.destroy_for_testing();
+    ts::end(ts);
+}
+
+// Shadow-permit scenario: a permit issued under an extension must not be usable
+// once that extension is revoked from the gate.
+#[test]
+#[expected_failure(abort_code = gate::EExtensionNotConfigured)]
+fun jump_with_permit_v2_fails_after_extension_revoked() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 803);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a valid permit while both gates are authorized.
+    ts::next_tx(&mut ts, user_a());
+    let clock = clock::create_for_testing(ts.ctx());
+    {
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+    };
+
+    // Revoke the source gate's extension after the permit was issued.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<Gate>(
+            ts::receiving_ticket_by_id<OwnerCap<Gate>>(gate_a.owner_cap_id()),
+            ts.ctx(),
+        );
+        gate_a.revoke_extension_authorization(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(gate_a);
+    };
+
+    // The previously issued permit must no longer be usable.
     ts::next_tx(&mut ts, user_a());
     {
         let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);

--- a/contracts/world/tests/assemblies/gate_tests.move
+++ b/contracts/world/tests/assemblies/gate_tests.move
@@ -7,7 +7,7 @@ use world::{
     access::{AdminACL, OwnerCap, ServerAddressRegistry},
     character::{Self, Character},
     energy::EnergyConfig,
-    gate::{Self, Gate, GateConfig, JumpPermit},
+    gate::{Self, Gate, GateConfig, JumpPermit, JumpPermitV2},
     location,
     network_node::{Self, NetworkNode},
     object_registry::ObjectRegistry,
@@ -332,7 +332,7 @@ fun test_jump_with_permit_succeeds() {
     // Jump A -> B (consume one ticket)
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
         gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
     };
 
@@ -345,9 +345,70 @@ fun test_jump_with_permit_succeeds() {
     // Jump B -> A (consume the second ticket)
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
         gate::test_jump_with_permit(&gate_b, &gate_a, &character, permit, &clock);
     };
+    ts::return_shared(character);
+    ts::return_shared(gate_a);
+    ts::return_shared(gate_b);
+    clock.destroy_for_testing();
+    ts::end(ts);
+}
+
+#[test]
+fun migrate_jump_permit_to_v2_succeeds() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 203);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    ts::next_tx(&mut ts, user_a());
+    let clock = clock::create_for_testing(ts.ctx());
+    let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+    let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+    let character = ts::take_shared_by_id<Character>(&ts, character_id);
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        gate::issue_jump_permit_legacy_for_testing<GateAuth>(
+            &gate_a,
+            &gate_b,
+            &character,
+            GateAuth {},
+            expires_at_timestamp_ms,
+            ts.ctx(),
+        );
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let legacy = ts::take_from_sender<JumpPermit>(&ts);
+        let _new_id = gate::migrate_jump_permit_to_v2<GateAuth>(
+            &gate_a,
+            &gate_b,
+            &character,
+            legacy,
+            &clock,
+            GateAuth {},
+            ts.ctx(),
+        );
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+    };
+
     ts::return_shared(character);
     ts::return_shared(gate_a);
     ts::return_shared(gate_b);
@@ -394,9 +455,9 @@ fun issue_jump_permit_with_id_matches_minted_object() {
 
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
-        assert_eq!(gate::jump_permit_id(&permit), permit_id);
-        gate::delete_jump_permit(permit);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        assert_eq!(gate::jump_permit_v2_id(&permit), permit_id);
+        gate::delete_jump_permit_v2(permit);
     };
 
     ts::return_shared(character);
@@ -516,8 +577,8 @@ fun delete_jump_permit_owner_succeeds() {
 
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
-        gate::delete_jump_permit(permit);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::delete_jump_permit_v2(permit);
     };
 
     ts::return_shared(character);
@@ -556,8 +617,8 @@ fun delete_jump_permit_with_auth_succeeds() {
 
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
-        gate_a.delete_jump_permit_with_auth<GateAuth>(permit, GateAuth {});
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::delete_jump_permit_v2_with_auth<GateAuth>(&gate_a, permit, GateAuth {});
     };
 
     ts::return_shared(character);
@@ -692,13 +753,13 @@ fun test_jump_with_permit_consumes_permit() {
     };
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
 
         // First jump succeeds
         gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
 
         // Permit is deleted, taking another should fail.
-        let unexpected = ts::take_from_sender<JumpPermit>(&ts);
+        let unexpected = ts::take_from_sender<JumpPermitV2>(&ts);
         ts::return_to_sender(&ts, unexpected);
     };
 
@@ -738,7 +799,7 @@ fun test_jump_with_permit_fails_expired_permit() {
     };
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
         gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
     };
     ts::return_shared(character);
@@ -778,8 +839,8 @@ fun delete_jump_permit_with_auth_fails_wrong_auth() {
 
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
-        gate_a.delete_jump_permit_with_auth<WrongGateAuth>(permit, WrongGateAuth {});
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::delete_jump_permit_v2_with_auth<WrongGateAuth>(&gate_a, permit, WrongGateAuth {});
     };
 
     ts::return_shared(character);
@@ -820,8 +881,8 @@ fun delete_jump_permit_fails_when_sender_does_not_own_permit() {
     // user_b does not own the permit (user_a does); take_from_sender aborts
     ts::next_tx(&mut ts, user_b());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
-        gate::delete_jump_permit(permit);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
+        gate::delete_jump_permit_v2(permit);
     };
 
     abort
@@ -1469,7 +1530,7 @@ fun jump_fails_when_ticket_issued_for_user_a_used_by_user_b() {
     // Move ticket to user_b
     ts::next_tx(&mut ts, user_a());
     {
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
         transfer::public_transfer(permit, user_b());
     };
 
@@ -1480,7 +1541,7 @@ fun jump_fails_when_ticket_issued_for_user_a_used_by_user_b() {
         let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
         let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
-        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        let permit = ts::take_from_sender<JumpPermitV2>(&ts);
         gate::test_jump_with_permit(&gate_a, &gate_b, &character_b, permit, &clock);
         ts::return_shared(character_b);
         ts::return_shared(gate_a);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jump-with-permit": "tsx ts-scripts/builder_extension/jump-with-permit.ts",
     "delete-jump-permit": "tsx ts-scripts/builder_extension/delete-jump-permit.ts",
     "delete-jump-permit-extension": "tsx ts-scripts/builder_extension/delete-jump-permit-extension.ts",
+    "migrate-jump-permit": "tsx ts-scripts/builder_extension/migrate-jump-permit.ts",
     "anchor-turret": "tsx ts-scripts/turret/anchor.ts",
     "online-turret": "tsx ts-scripts/turret/online.ts",
     "authorize-turret-extension": "tsx ts-scripts/builder_extension/authorize-turret.ts",

--- a/ts-scripts/builder_extension/delete-jump-permit-extension.ts
+++ b/ts-scripts/builder_extension/delete-jump-permit-extension.ts
@@ -36,7 +36,7 @@ async function voidJumpPermitViaExtension(ctx: ReturnType<typeof initializeConte
 
     const jumpPermitId = await getOwnedJumpPermitId(client, address, config.packageId);
     if (!jumpPermitId) {
-        throw new Error("You should own a JumpPermit object to void it via the extension");
+        throw new Error("You should own a JumpPermitV2 object to void it via the extension");
     }
 
     if (!BUILDER_PACKAGE_LATEST) {

--- a/ts-scripts/builder_extension/delete-jump-permit-extension.ts
+++ b/ts-scripts/builder_extension/delete-jump-permit-extension.ts
@@ -21,7 +21,7 @@ async function getOwnedJumpPermitId(
     owner: string,
     worldPackageId: string
 ): Promise<string | null> {
-    const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
+    const type = `${worldPackageId}::${MODULES.GATE}::JumpPermitV2`;
     const res = await client.getOwnedObjects({
         owner,
         filter: { StructType: type },
@@ -49,7 +49,7 @@ async function voidJumpPermitViaExtension(ctx: ReturnType<typeof initializeConte
     const tx = new Transaction();
     tx.setGasBudget(100_000_000);
     tx.moveCall({
-        target: `${BUILDER_PACKAGE_LATEST}::${extensionModule.TRIBE_PERMIT}::delete_jump_permit`,
+        target: `${BUILDER_PACKAGE_LATEST}::${extensionModule.TRIBE_PERMIT}::delete_jump_permit_v2`,
         arguments: [tx.object(sourceGateId), tx.object(jumpPermitId)],
     });
 

--- a/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
+++ b/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
@@ -34,7 +34,7 @@ async function issueJumpPermit(
 
     const tx = new Transaction();
     tx.moveCall({
-        target: `${builderPackageId}::${extensionModule.TRIBE_PERMIT}::issue_jump_permit_v2`,
+        target: `${builderPackageId}::${extensionModule.TRIBE_PERMIT}::issue_jump_permit`,
         arguments: [
             tx.object(extensionConfigId),
             tx.object(sourceGateId),

--- a/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
+++ b/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
@@ -34,7 +34,7 @@ async function issueJumpPermit(
 
     const tx = new Transaction();
     tx.moveCall({
-        target: `${builderPackageId}::${extensionModule.TRIBE_PERMIT}::issue_jump_permit`,
+        target: `${builderPackageId}::${extensionModule.TRIBE_PERMIT}::issue_jump_permit_v2`,
         arguments: [
             tx.object(extensionConfigId),
             tx.object(sourceGateId),

--- a/ts-scripts/builder_extension/jump-with-permit.ts
+++ b/ts-scripts/builder_extension/jump-with-permit.ts
@@ -25,7 +25,7 @@ async function getOwnedJumpPermitId(
     owner: string,
     worldPackageId: string
 ): Promise<string | null> {
-    const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
+    const type = `${worldPackageId}::${MODULES.GATE}::JumpPermitV2`;
     const res = await client.getOwnedObjects({
         owner,
         filter: { StructType: type },
@@ -64,7 +64,7 @@ async function jumpWithPermit(
     tx.setGasOwner(adminAddress);
 
     tx.moveCall({
-        target: `${config.packageId}::${MODULES.GATE}::jump_with_permit`,
+        target: `${config.packageId}::${MODULES.GATE}::jump_with_permit_v2`,
         arguments: [
             tx.object(sourceGateId),
             tx.object(destinationGateId),

--- a/ts-scripts/builder_extension/jump-with-permit.ts
+++ b/ts-scripts/builder_extension/jump-with-permit.ts
@@ -56,7 +56,7 @@ async function jumpWithPermit(
 
     const jumpPermitId = await getOwnedJumpPermitId(client, address, config.packageId);
     if (!jumpPermitId) {
-        throw new Error("You should own a JumpPermit object");
+        throw new Error("You should own a JumpPermitV2 object");
     }
 
     const tx = new Transaction();

--- a/ts-scripts/builder_extension/migrate-jump-permit.ts
+++ b/ts-scripts/builder_extension/migrate-jump-permit.ts
@@ -1,0 +1,121 @@
+import "dotenv/config";
+import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { MODULES } from "../utils/config";
+import { deriveObjectId } from "../utils/derive-object-id";
+import {
+    extractEvent,
+    getEnvConfig,
+    handleError,
+    hydrateWorldConfig,
+    initializeContext,
+    requireEnv,
+} from "../utils/helper";
+import {
+    CLOCK_OBJECT_ID,
+    GAME_CHARACTER_B_ID,
+    GATE_ITEM_ID_1,
+    GATE_ITEM_ID_2,
+} from "../utils/constants";
+import { MODULE as extensionModule } from "./modules";
+
+const BUILDER_PACKAGE_LATEST = process.env.UPGRADED_BUILDER_PACKAGE_ID || "";
+
+async function getOwnedLegacyJumpPermitIds(
+    client: SuiJsonRpcClient,
+    owner: string,
+    worldPackageId: string
+): Promise<string[]> {
+    const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
+    const ids: string[] = [];
+    let cursor: string | null | undefined;
+    do {
+        const res = await client.getOwnedObjects({
+            owner,
+            filter: { StructType: type },
+            cursor: cursor ?? undefined,
+        });
+        for (const obj of res.data) {
+            const id = obj.data?.objectId;
+            if (id) ids.push(id);
+        }
+        cursor = res.hasNextPage ? res.nextCursor : undefined;
+    } while (cursor);
+    return ids;
+}
+
+async function migrateJumpPermit(
+    ctx: ReturnType<typeof initializeContext>,
+    characterItemId: bigint,
+    sourceGateItemId: bigint,
+    destinationGateItemId: bigint
+) {
+    const { client, keypair, config, address } = ctx;
+
+    if (!BUILDER_PACKAGE_LATEST) {
+        throw new Error(
+            "Set UPGRADED_BUILDER_PACKAGE_ID; the migrate_jump_permit entry lives on the upgraded builder package."
+        );
+    }
+
+    const legacyPermitIds = await getOwnedLegacyJumpPermitIds(client, address, config.packageId);
+    if (legacyPermitIds.length === 0) {
+        console.log("No legacy JumpPermit objects to migrate for", address);
+        return;
+    }
+    console.log(`Found ${legacyPermitIds.length} legacy JumpPermit(s) to migrate`);
+
+    const characterId = deriveObjectId(config.objectRegistry, characterItemId, config.packageId);
+    const sourceGateId = deriveObjectId(config.objectRegistry, sourceGateItemId, config.packageId);
+    const destinationGateId = deriveObjectId(
+        config.objectRegistry,
+        destinationGateItemId,
+        config.packageId
+    );
+
+    for (const legacyPermitId of legacyPermitIds) {
+        const tx = new Transaction();
+        tx.setGasBudget(100_000_000);
+        tx.moveCall({
+            target: `${BUILDER_PACKAGE_LATEST}::${extensionModule.TRIBE_PERMIT}::migrate_jump_permit`,
+            arguments: [
+                tx.object(sourceGateId),
+                tx.object(destinationGateId),
+                tx.object(characterId),
+                tx.object(legacyPermitId),
+                tx.object(CLOCK_OBJECT_ID),
+            ],
+        });
+
+        const result = await client.signAndExecuteTransaction({
+            transaction: tx,
+            signer: keypair,
+            options: { showEffects: true, showObjectChanges: true, showEvents: true },
+        });
+
+        const migratedEvent = extractEvent<{
+            legacy_jump_permit_id: string;
+            new_jump_permit_id: string;
+            extension_type: { name: string };
+        }>(result, "::gate::JumpPermitMigratedEvent");
+
+        console.log(`Migrated ${legacyPermitId} -> ${migratedEvent?.new_jump_permit_id ?? "?"}`);
+        console.log("  digest:", result.digest);
+    }
+}
+
+async function main() {
+    console.log("============= Migrate Legacy JumpPermit -> JumpPermitV2 ==============\n");
+    try {
+        const env = getEnvConfig();
+        const playerKey = requireEnv("PLAYER_B_PRIVATE_KEY");
+        const ctx = initializeContext(env.network, playerKey);
+        await hydrateWorldConfig(ctx);
+
+        await migrateJumpPermit(ctx, BigInt(GAME_CHARACTER_B_ID), GATE_ITEM_ID_1, GATE_ITEM_ID_2);
+    } catch (error) {
+        handleError(error);
+    }
+}
+
+main();

--- a/ts-scripts/builder_extension/migrate-jump-permit.ts
+++ b/ts-scripts/builder_extension/migrate-jump-permit.ts
@@ -73,35 +73,49 @@ async function migrateJumpPermit(
         config.packageId
     );
 
+    let migrated = 0;
+    let skipped = 0;
     for (const legacyPermitId of legacyPermitIds) {
-        const tx = new Transaction();
-        tx.setGasBudget(100_000_000);
-        tx.moveCall({
-            target: `${BUILDER_PACKAGE_LATEST}::${extensionModule.TRIBE_PERMIT}::migrate_jump_permit`,
-            arguments: [
-                tx.object(sourceGateId),
-                tx.object(destinationGateId),
-                tx.object(characterId),
-                tx.object(legacyPermitId),
-                tx.object(CLOCK_OBJECT_ID),
-            ],
-        });
+        try {
+            const tx = new Transaction();
+            tx.setGasBudget(100_000_000);
+            tx.moveCall({
+                target: `${BUILDER_PACKAGE_LATEST}::${extensionModule.TRIBE_PERMIT}::migrate_jump_permit`,
+                arguments: [
+                    tx.object(sourceGateId),
+                    tx.object(destinationGateId),
+                    tx.object(characterId),
+                    tx.object(legacyPermitId),
+                    tx.object(CLOCK_OBJECT_ID),
+                ],
+            });
 
-        const result = await client.signAndExecuteTransaction({
-            transaction: tx,
-            signer: keypair,
-            options: { showEffects: true, showObjectChanges: true, showEvents: true },
-        });
+            const result = await client.signAndExecuteTransaction({
+                transaction: tx,
+                signer: keypair,
+                options: { showEffects: true, showObjectChanges: true, showEvents: true },
+            });
 
-        const migratedEvent = extractEvent<{
-            legacy_jump_permit_id: string;
-            new_jump_permit_id: string;
-            extension_type: { name: string };
-        }>(result, "::gate::JumpPermitMigratedEvent");
+            const migratedEvent = extractEvent<{
+                legacy_jump_permit_id: string;
+                new_jump_permit_id: string;
+                extension_type: { name: string };
+            }>(result, "::gate::JumpPermitMigratedEvent");
 
-        console.log(`Migrated ${legacyPermitId} -> ${migratedEvent?.new_jump_permit_id ?? "?"}`);
-        console.log("  digest:", result.digest);
+            console.log(
+                `Migrated ${legacyPermitId} -> ${migratedEvent?.new_jump_permit_id ?? "?"}`
+            );
+            console.log("  digest:", result.digest);
+            migrated++;
+        } catch (err) {
+            skipped++;
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(
+                `Skipping ${legacyPermitId}: ${message}. This permit likely belongs to a different route/character; re-run with the correct IDs.`
+            );
+        }
     }
+    console.log(`Done. Migrated ${migrated}, skipped ${skipped}.`);
 }
 
 async function main() {


### PR DESCRIPTION
**Contract Vulnerability:** 
The `world::gate` module currently allows `JumpPermit` objects to remain valid even if the gate's extension (`Auth` witness) has been revoked or upgraded. Because `validate_jump_permit` only checks the `route_hash` and expiration time, permits issued by a legacy extension can be used to bypass the logic of the current active extension.