### PR TITLE
feat!: add inventory_key discriminator to item deposit/withdraw events

### DIFF
--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -270,9 +270,10 @@ public fun deposit_item<Auth: drop>(
         &mut storage_unit.id,
         storage_unit.owner_cap_id,
     );
-    inventory.deposit_item(
+    inventory.deposit_item_to_inventory(
         storage_unit_id,
         storage_unit.key,
+        storage_unit.owner_cap_id,
         character,
         item,
     );
@@ -298,9 +299,10 @@ public fun withdraw_item<Auth: drop>(
         storage_unit.owner_cap_id,
     );
 
-    inventory.withdraw_item(
+    inventory.withdraw_item_from_inventory(
         storage_unit_id,
         storage_unit.key,
+        storage_unit.owner_cap_id,
         character,
         type_id,
         quantity,
@@ -332,9 +334,10 @@ public fun deposit_to_open_inventory<Auth: drop>(
 
     let key = open_storage_key(storage_unit);
     let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, key);
-    inventory.deposit_item(
+    inventory.deposit_item_to_inventory(
         storage_unit_id,
         storage_unit.key,
+        key,
         character,
         item,
     );
@@ -360,9 +363,10 @@ public fun withdraw_from_open_inventory<Auth: drop>(
     assert!(df::exists_(&storage_unit.id, key), EOpenStorageNotInitialized);
 
     let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, key);
-    inventory.withdraw_item(
+    inventory.withdraw_item_from_inventory(
         storage_unit_id,
         storage_unit.key,
+        key,
         character,
         type_id,
         quantity,
@@ -409,9 +413,10 @@ public fun deposit_to_owned<Auth: drop>(
         &mut storage_unit.id,
         owner_cap_id,
     );
-    inventory.deposit_item(
+    inventory.deposit_item_to_inventory(
         storage_unit_id,
         storage_unit.key,
+        owner_cap_id,
         character,
         item,
     );
@@ -437,9 +442,10 @@ public fun deposit_by_owner<T: key>(
         owner_cap_id,
     );
 
-    inventory.deposit_item(
+    inventory.deposit_item_to_inventory(
         storage_unit_id,
         storage_unit.key,
+        owner_cap_id,
         character,
         item,
     );
@@ -464,9 +470,10 @@ public fun withdraw_by_owner<T: key>(
         owner_cap_id,
     );
 
-    inventory.withdraw_item(
+    inventory.withdraw_item_from_inventory(
         storage_unit_id,
         storage_unit.key,
+        owner_cap_id,
         character,
         type_id,
         quantity,

--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -270,7 +270,7 @@ public fun deposit_item<Auth: drop>(
         &mut storage_unit.id,
         storage_unit.owner_cap_id,
     );
-    inventory.deposit_item_to_inventory(
+    inventory.deposit_item(
         storage_unit_id,
         storage_unit.key,
         storage_unit.owner_cap_id,
@@ -299,7 +299,7 @@ public fun withdraw_item<Auth: drop>(
         storage_unit.owner_cap_id,
     );
 
-    inventory.withdraw_item_from_inventory(
+    inventory.withdraw_item(
         storage_unit_id,
         storage_unit.key,
         storage_unit.owner_cap_id,
@@ -334,7 +334,7 @@ public fun deposit_to_open_inventory<Auth: drop>(
 
     let key = open_storage_key(storage_unit);
     let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, key);
-    inventory.deposit_item_to_inventory(
+    inventory.deposit_item(
         storage_unit_id,
         storage_unit.key,
         key,
@@ -363,7 +363,7 @@ public fun withdraw_from_open_inventory<Auth: drop>(
     assert!(df::exists_(&storage_unit.id, key), EOpenStorageNotInitialized);
 
     let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, key);
-    inventory.withdraw_item_from_inventory(
+    inventory.withdraw_item(
         storage_unit_id,
         storage_unit.key,
         key,
@@ -413,7 +413,7 @@ public fun deposit_to_owned<Auth: drop>(
         &mut storage_unit.id,
         owner_cap_id,
     );
-    inventory.deposit_item_to_inventory(
+    inventory.deposit_item(
         storage_unit_id,
         storage_unit.key,
         owner_cap_id,
@@ -442,7 +442,7 @@ public fun deposit_by_owner<T: key>(
         owner_cap_id,
     );
 
-    inventory.deposit_item_to_inventory(
+    inventory.deposit_item(
         storage_unit_id,
         storage_unit.key,
         owner_cap_id,
@@ -470,7 +470,7 @@ public fun withdraw_by_owner<T: key>(
         owner_cap_id,
     );
 
-    inventory.withdraw_item_from_inventory(
+    inventory.withdraw_item(
         storage_unit_id,
         storage_unit.key,
         owner_cap_id,

--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -316,52 +316,6 @@ public(package) fun deposit_item(
     inventory: &mut Inventory,
     assembly_id: ID,
     assembly_key: TenantItemId,
-    character: &Character,
-    item: Item,
-) {
-    let Item { id, parent_id: _, tenant, type_id, item_id, volume, quantity, location } = item;
-    id.delete();
-    location.remove();
-
-    // Use stored volume when the type_id already exists (volume is static per type_id).
-    let effective_volume = if (inventory.items.contains(&type_id)) {
-        inventory.items[&type_id].volume
-    } else {
-        volume
-    };
-
-    let req_capacity = calculate_volume(effective_volume, quantity);
-    let remaining = inventory.max_capacity - inventory.used_capacity;
-    assert!(req_capacity <= remaining, EInventoryInsufficientCapacity);
-    inventory.used_capacity = inventory.used_capacity + req_capacity;
-
-    let entry = ItemEntry { tenant, type_id, item_id, volume, quantity };
-
-    let dep_item_id = if (inventory.items.contains(&type_id)) {
-        let existing = &mut inventory.items[&type_id];
-        let existing_item_id = existing.item_id;
-        existing.join(entry);
-        existing_item_id
-    } else {
-        inventory.items.insert(type_id, entry);
-        item_id
-    };
-
-    event::emit(ItemDepositedEvent {
-        assembly_id,
-        assembly_key,
-        character_id: character.id(),
-        character_key: character.key(),
-        item_id: dep_item_id,
-        type_id,
-        quantity,
-    });
-}
-
-public(package) fun deposit_item_to_inventory(
-    inventory: &mut Inventory,
-    assembly_id: ID,
-    assembly_key: TenantItemId,
     inventory_key: ID,
     character: &Character,
     item: Item,
@@ -413,63 +367,6 @@ public(package) fun deposit_item_to_inventory(
 //
 // `assembly_id` doubles as the `parent_id` on the resulting `Item`.
 public(package) fun withdraw_item(
-    inventory: &mut Inventory,
-    assembly_id: ID,
-    assembly_key: TenantItemId,
-    character: &Character,
-    type_id: u64,
-    quantity: u32,
-    location_hash: vector<u8>,
-    ctx: &mut TxContext,
-): Item {
-    assert!(inventory.items.contains(&type_id), EItemDoesNotExist);
-    assert!(quantity > 0, ESplitQuantityInvalid);
-
-    let entry = &inventory.items[&type_id];
-    assert!(entry.quantity >= quantity, EInventoryInsufficientQuantity);
-    let volume = entry.volume;
-    let item_id = entry.item_id;
-    let tenant = entry.tenant;
-
-    let capacity_freed = calculate_volume(volume, quantity);
-    inventory.used_capacity = inventory.used_capacity - capacity_freed;
-
-    if (entry.quantity == quantity) {
-        inventory.items.remove(&type_id);
-    } else {
-        let entry_mut = &mut inventory.items[&type_id];
-        entry_mut.quantity = entry_mut.quantity - quantity;
-    };
-
-    event::emit(ItemWithdrawnEvent {
-        assembly_id,
-        assembly_key,
-        character_id: character.id(),
-        character_key: character.key(),
-        item_id,
-        type_id,
-        quantity,
-    });
-
-    Item {
-        id: object::new(ctx),
-        parent_id: assembly_id,
-        tenant,
-        type_id,
-        item_id,
-        volume,
-        quantity,
-        location: location::attach(location_hash),
-    }
-}
-
-// Withdraws items from the inventory and wraps them into a transit `Item`.
-//
-// `location_hash` is injected by the parent layer (e.g. StorageUnit) — it is not
-// stored in `ItemEntry` since it is just-in-time metadata for the transit `Item`.
-//
-// `assembly_id` doubles as the `parent_id` on the resulting `Item`.
-public(package) fun withdraw_item_from_inventory(
     inventory: &mut Inventory,
     assembly_id: ID,
     assembly_key: TenantItemId,

--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -136,9 +136,31 @@ public struct ItemDepositedEvent has copy, drop {
     quantity: u32,
 }
 
+public struct ItemDepositedEventV2 has copy, drop {
+    assembly_id: ID,
+    assembly_key: TenantItemId,
+    inventory_key: ID,
+    character_id: ID,
+    character_key: TenantItemId,
+    item_id: u64,
+    type_id: u64,
+    quantity: u32,
+}
+
 public struct ItemWithdrawnEvent has copy, drop {
     assembly_id: ID,
     assembly_key: TenantItemId,
+    character_id: ID,
+    character_key: TenantItemId,
+    item_id: u64,
+    type_id: u64,
+    quantity: u32,
+}
+
+public struct ItemWithdrawnEventV2 has copy, drop {
+    assembly_id: ID,
+    assembly_key: TenantItemId,
+    inventory_key: ID,
     character_id: ID,
     character_key: TenantItemId,
     item_id: u64,
@@ -336,6 +358,54 @@ public(package) fun deposit_item(
     });
 }
 
+public(package) fun deposit_item_to_inventory(
+    inventory: &mut Inventory,
+    assembly_id: ID,
+    assembly_key: TenantItemId,
+    inventory_key: ID,
+    character: &Character,
+    item: Item,
+) {
+    let Item { id, parent_id: _, tenant, type_id, item_id, volume, quantity, location } = item;
+    id.delete();
+    location.remove();
+
+    // Use stored volume when the type_id already exists (volume is static per type_id).
+    let effective_volume = if (inventory.items.contains(&type_id)) {
+        inventory.items[&type_id].volume
+    } else {
+        volume
+    };
+
+    let req_capacity = calculate_volume(effective_volume, quantity);
+    let remaining = inventory.max_capacity - inventory.used_capacity;
+    assert!(req_capacity <= remaining, EInventoryInsufficientCapacity);
+    inventory.used_capacity = inventory.used_capacity + req_capacity;
+
+    let entry = ItemEntry { tenant, type_id, item_id, volume, quantity };
+
+    let dep_item_id = if (inventory.items.contains(&type_id)) {
+        let existing = &mut inventory.items[&type_id];
+        let existing_item_id = existing.item_id;
+        existing.join(entry);
+        existing_item_id
+    } else {
+        inventory.items.insert(type_id, entry);
+        item_id
+    };
+
+    event::emit(ItemDepositedEventV2 {
+        assembly_id,
+        assembly_key,
+        inventory_key,
+        character_id: character.id(),
+        character_key: character.key(),
+        item_id: dep_item_id,
+        type_id,
+        quantity,
+    });
+}
+
 // Withdraws items from the inventory and wraps them into a transit `Item`.
 //
 // `location_hash` is injected by the parent layer (e.g. StorageUnit) — it is not
@@ -374,6 +444,65 @@ public(package) fun withdraw_item(
     event::emit(ItemWithdrawnEvent {
         assembly_id,
         assembly_key,
+        character_id: character.id(),
+        character_key: character.key(),
+        item_id,
+        type_id,
+        quantity,
+    });
+
+    Item {
+        id: object::new(ctx),
+        parent_id: assembly_id,
+        tenant,
+        type_id,
+        item_id,
+        volume,
+        quantity,
+        location: location::attach(location_hash),
+    }
+}
+
+// Withdraws items from the inventory and wraps them into a transit `Item`.
+//
+// `location_hash` is injected by the parent layer (e.g. StorageUnit) — it is not
+// stored in `ItemEntry` since it is just-in-time metadata for the transit `Item`.
+//
+// `assembly_id` doubles as the `parent_id` on the resulting `Item`.
+public(package) fun withdraw_item_from_inventory(
+    inventory: &mut Inventory,
+    assembly_id: ID,
+    assembly_key: TenantItemId,
+    inventory_key: ID,
+    character: &Character,
+    type_id: u64,
+    quantity: u32,
+    location_hash: vector<u8>,
+    ctx: &mut TxContext,
+): Item {
+    assert!(inventory.items.contains(&type_id), EItemDoesNotExist);
+    assert!(quantity > 0, ESplitQuantityInvalid);
+
+    let entry = &inventory.items[&type_id];
+    assert!(entry.quantity >= quantity, EInventoryInsufficientQuantity);
+    let volume = entry.volume;
+    let item_id = entry.item_id;
+    let tenant = entry.tenant;
+
+    let capacity_freed = calculate_volume(volume, quantity);
+    inventory.used_capacity = inventory.used_capacity - capacity_freed;
+
+    if (entry.quantity == quantity) {
+        inventory.items.remove(&type_id);
+    } else {
+        let entry_mut = &mut inventory.items[&type_id];
+        entry_mut.quantity = entry_mut.quantity - quantity;
+    };
+
+    event::emit(ItemWithdrawnEventV2 {
+        assembly_id,
+        assembly_key,
+        inventory_key,
         character_id: character.id(),
         character_key: character.key(),
         item_id,

--- a/contracts/world/tests/primitives/inventory_tests.move
+++ b/contracts/world/tests/primitives/inventory_tests.move
@@ -421,9 +421,10 @@ public fun deposit_item_merges_quantity_when_same_type_id() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inv_b = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_b_id);
-        let item = inv_b.withdraw_item(
+        let item = inv_b.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_b_id,
             &character_b,
             AMMO_TYPE_ID,
             3u32,
@@ -431,7 +432,13 @@ public fun deposit_item_merges_quantity_when_same_type_id() {
             ts.ctx(),
         );
         let inv_a = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        inv_a.deposit_item(assembly_id, assembly_key, &character_a, item);
+        inv_a.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_a_id,
+            &character_a,
+            item,
+        );
         ts::return_shared(character_a);
         ts::return_shared(character_b);
         ts::return_shared(storage_unit);
@@ -507,9 +514,10 @@ public fun deposit_items() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_a_id,
             &character_a,
             AMMO_TYPE_ID,
             AMMO_QUANTITY,
@@ -526,7 +534,13 @@ public fun deposit_items() {
             &mut storage_unit.id,
             character_b_id,
         );
-        eph_inventory.deposit_item(assembly_id, assembly_key, &character_b, item);
+        eph_inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_b_id,
+            &character_b,
+            item,
+        );
         ts::return_shared(character_a);
         ts::return_shared(character_b);
 
@@ -648,9 +662,10 @@ fun withdraw_partial_quantity() {
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
 
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             5u32,
@@ -670,7 +685,13 @@ fun withdraw_partial_quantity() {
 
         // Deposit back to clean up the item
         let inv_mut = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inv_mut.deposit_item(assembly_id, assembly_key, &character, item);
+        inv_mut.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
 
         ts::return_shared(storage_unit);
         ts::return_shared(character);
@@ -709,9 +730,10 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             3u32,
@@ -738,7 +760,13 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
 
         let inv_ref = df::borrow<ID, Inventory>(&storage_unit.id, character_id);
         assert_eq!(inv_ref.item_quantity(AMMO_TYPE_ID), AMMO_QUANTITY);
@@ -758,9 +786,10 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             AMMO_QUANTITY,
@@ -786,7 +815,13 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
 
         let inv_ref = df::borrow<ID, Inventory>(&storage_unit.id, character_id);
         assert_eq!(inv_ref.item_quantity(AMMO_TYPE_ID), AMMO_QUANTITY);
@@ -939,9 +974,10 @@ fun deposit_ignores_volume_change() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inv_b = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_b_id);
-        let item = inv_b.withdraw_item(
+        let item = inv_b.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_b_id,
             &character_b,
             AMMO_TYPE_ID,
             3u32,
@@ -949,7 +985,13 @@ fun deposit_ignores_volume_change() {
             ts.ctx(),
         );
         let inv_a = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        inv_a.deposit_item(assembly_id, assembly_key, &character_a, item);
+        inv_a.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_a_id,
+            &character_a,
+            item,
+        );
         ts::return_shared(character_a);
         ts::return_shared(character_b);
         ts::return_shared(storage_unit);
@@ -990,9 +1032,10 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             5u32,
@@ -1016,7 +1059,13 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
 
         let inv_ref = df::borrow<ID, Inventory>(&storage_unit.id, character_id);
         assert_eq!(inv_ref.item_quantity(AMMO_TYPE_ID), 10);
@@ -1035,9 +1084,10 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             10u32,
@@ -1051,7 +1101,13 @@ fun round_trip_capacity_consistent_with_static_volume() {
         assert_eq!(inv_ref.inventory_item_length(), 0);
 
         let inv_mut = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inv_mut.deposit_item(assembly_id, assembly_key, &character, item);
+        inv_mut.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
 
         ts::return_shared(storage_unit);
         ts::return_shared(character);
@@ -1229,9 +1285,10 @@ fun deposit_item_fail_insufficient_capacity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_a_id,
             &character_a,
             AMMO_TYPE_ID,
             AMMO_QUANTITY,
@@ -1253,7 +1310,13 @@ fun deposit_item_fail_insufficient_capacity() {
             &mut storage_unit.id,
             character_b_id,
         );
-        eph_inventory.deposit_item(assembly_id, assembly_key, &character_b, item);
+        eph_inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_b_id,
+            &character_b,
+            item,
+        );
         ts::return_shared(storage_unit);
         ts::return_shared(character_b);
     };
@@ -1280,9 +1343,10 @@ fun withdraw_item_fail_item_not_found() {
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         // This should abort with EItemDoesNotExist
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             1222,
             AMMO_QUANTITY,
@@ -1290,7 +1354,13 @@ fun withdraw_item_fail_item_not_found() {
             ts.ctx(),
         );
         // Unreachable code below - needed to satisfy Move's type checker
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
         ts::return_shared(storage_unit);
         ts::return_shared(character);
     };
@@ -1318,16 +1388,23 @@ fun withdraw_fail_zero_quantity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             0u32,
             LOCATION_A_HASH,
             ts.ctx(),
         );
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
         ts::return_shared(storage_unit);
         ts::return_shared(character);
     };
@@ -1355,16 +1432,23 @@ fun withdraw_fail_exceeds_quantity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item(
+        let item = inventory.withdraw_item_from_inventory(
             assembly_id,
             assembly_key,
+            character_id,
             &character,
             AMMO_TYPE_ID,
             15u32,
             LOCATION_A_HASH,
             ts.ctx(),
         );
-        inventory.deposit_item(assembly_id, assembly_key, &character, item);
+        inventory.deposit_item_to_inventory(
+            assembly_id,
+            assembly_key,
+            character_id,
+            &character,
+            item,
+        );
         ts::return_shared(storage_unit);
         ts::return_shared(character);
     };

--- a/contracts/world/tests/primitives/inventory_tests.move
+++ b/contracts/world/tests/primitives/inventory_tests.move
@@ -421,7 +421,7 @@ public fun deposit_item_merges_quantity_when_same_type_id() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inv_b = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_b_id);
-        let item = inv_b.withdraw_item_from_inventory(
+        let item = inv_b.withdraw_item(
             assembly_id,
             assembly_key,
             character_b_id,
@@ -432,7 +432,7 @@ public fun deposit_item_merges_quantity_when_same_type_id() {
             ts.ctx(),
         );
         let inv_a = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        inv_a.deposit_item_to_inventory(
+        inv_a.deposit_item(
             assembly_id,
             assembly_key,
             character_a_id,
@@ -514,7 +514,7 @@ public fun deposit_items() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_a_id,
@@ -534,7 +534,7 @@ public fun deposit_items() {
             &mut storage_unit.id,
             character_b_id,
         );
-        eph_inventory.deposit_item_to_inventory(
+        eph_inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_b_id,
@@ -662,7 +662,7 @@ fun withdraw_partial_quantity() {
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
 
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -685,7 +685,7 @@ fun withdraw_partial_quantity() {
 
         // Deposit back to clean up the item
         let inv_mut = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inv_mut.deposit_item_to_inventory(
+        inv_mut.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -730,7 +730,7 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -760,7 +760,7 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -786,7 +786,7 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -815,7 +815,7 @@ fun round_trip_split_join_df_quantities() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -974,7 +974,7 @@ fun deposit_ignores_volume_change() {
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let character_b = ts::take_shared_by_id<Character>(&ts, character_b_id);
         let inv_b = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_b_id);
-        let item = inv_b.withdraw_item_from_inventory(
+        let item = inv_b.withdraw_item(
             assembly_id,
             assembly_key,
             character_b_id,
@@ -985,7 +985,7 @@ fun deposit_ignores_volume_change() {
             ts.ctx(),
         );
         let inv_a = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        inv_a.deposit_item_to_inventory(
+        inv_a.deposit_item(
             assembly_id,
             assembly_key,
             character_a_id,
@@ -1032,7 +1032,7 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1059,7 +1059,7 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1084,7 +1084,7 @@ fun round_trip_capacity_consistent_with_static_volume() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1101,7 +1101,7 @@ fun round_trip_capacity_consistent_with_static_volume() {
         assert_eq!(inv_ref.inventory_item_length(), 0);
 
         let inv_mut = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        inv_mut.deposit_item_to_inventory(
+        inv_mut.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1285,7 +1285,7 @@ fun deposit_item_fail_insufficient_capacity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character_a = ts::take_shared_by_id<Character>(&ts, character_a_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_a_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_a_id,
@@ -1310,7 +1310,7 @@ fun deposit_item_fail_insufficient_capacity() {
             &mut storage_unit.id,
             character_b_id,
         );
-        eph_inventory.deposit_item_to_inventory(
+        eph_inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_b_id,
@@ -1343,7 +1343,7 @@ fun withdraw_item_fail_item_not_found() {
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         // This should abort with EItemDoesNotExist
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1354,7 +1354,7 @@ fun withdraw_item_fail_item_not_found() {
             ts.ctx(),
         );
         // Unreachable code below - needed to satisfy Move's type checker
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1388,7 +1388,7 @@ fun withdraw_fail_zero_quantity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1398,7 +1398,7 @@ fun withdraw_fail_zero_quantity() {
             LOCATION_A_HASH,
             ts.ctx(),
         );
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1432,7 +1432,7 @@ fun withdraw_fail_exceeds_quantity() {
         let assembly_key = in_game_id::create_key(STORAGE_ITEM_ID, tenant());
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let inventory = df::borrow_mut<ID, Inventory>(&mut storage_unit.id, character_id);
-        let item = inventory.withdraw_item_from_inventory(
+        let item = inventory.withdraw_item(
             assembly_id,
             assembly_key,
             character_id,
@@ -1442,7 +1442,7 @@ fun withdraw_fail_exceeds_quantity() {
             LOCATION_A_HASH,
             ts.ctx(),
         );
-        inventory.deposit_item_to_inventory(
+        inventory.deposit_item(
             assembly_id,
             assembly_key,
             character_id,


### PR DESCRIPTION
Related Issue: #154 

## What

Adds `ItemDepositedEventV2` and `ItemWithdrawnEventV2` to `inventory.move`, each carrying a new `inventory_key: ID` field that identifies the specific dynamic-field slot that was written to. All seven call sites in `storage_unit.move` are updated to use the new function signatures, and all test call sites in `inventory_tests.move` are updated accordingly.

## Why

`ItemDepositedEvent` and `ItemWithdrawnEvent` contained no field identifying *which* inventory slot was involved. Because off-chain subscribers had no way to distinguish the player-visible hangar slot from the extension-controlled open inventory without buffering all events for the full transaction and heuristically sorting them.

With `inventory_key` present in the event, a subscriber can:

- Filter events to a specific slot (owner cap, character cap, or open-inventory key) without any cross-event correlation.
- Compute the open-inventory key locally from a known SSU ID via `blake2b256(storage_unit_id ‖ "open_inventory")` — no additional RPC calls required.
- Dispatch each event immediately, eliminating tx-level buffering on the client.

## How

**`inventory.move`**
- Added `ItemDepositedEventV2` and `ItemWithdrawnEventV2` structs with `inventory_key: ID` between `assembly_key` and `character_id`.
- Original `deposit_item` / `withdraw_item` are retained - but using new fn signature

**`storage_unit.move`** — all seven call sites updated to the V2 functions with the correct key:

| Call site | `inventory_key` passed |
|---|---|
| `deposit_item<Auth>` | `storage_unit.owner_cap_id` |
| `withdraw_item<Auth>` | `storage_unit.owner_cap_id` |
| `deposit_to_open_inventory<Auth>` | `open_storage_key(storage_unit)` |
| `withdraw_from_open_inventory<Auth>` | `open_storage_key(storage_unit)` |
| `deposit_to_owned<Auth>` | `character.owner_cap_id()` |
| `deposit_by_owner<T>` | `object::id(owner_cap)` |
| `withdraw_by_owner<T>` | `object::id(owner_cap)` |

**`inventory_tests.move`** — all 24 direct `deposit_item` / `withdraw_item` calls updated to the new variants, passing the same ID used as the DF key when borrowing each inventory.

## Breaking changes

BREAKING CHANGE: `storage_unit.move` no longer emits `ItemDepositedEvent` / `ItemWithdrawnEvent` from any of its entry points — it now emits `ItemDepositedEventV2` / `ItemWithdrawnEventV2` exclusively. Off-chain subscribers must migrate event listeners to the V2 types to continue receiving deposit/withdraw notifications.
