### PR TITLE
Cross-SSU freight: reparent transit items before dropoff deposit

### DIFF
--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -278,6 +278,29 @@ public fun deposit_item<Auth: drop>(
     );
 }
 
+/// Completes a pickup → dropoff freight leg by rebinding `Item.parent_id` to this storage unit.
+///
+/// Requires the same `Auth` authorization as `deposit_item`. Callers must pass the real pickup
+/// SSU id as `expected_prior_parent` so the item's current `parent_id` is bound to that origin.
+/// Returns an `Item` with `parent_id == object::id(storage_unit)`; use `deposit_item`,
+/// `deposit_to_owned`, `deposit_to_open_inventory`, etc. as usual (their parent checks unchanged).
+public fun reparent_transit_item_for_freight_dropoff<Auth: drop>(
+    storage_unit: &StorageUnit,
+    item: Item,
+    expected_prior_parent: ID,
+    _: Auth,
+): Item {
+    let storage_unit_id = object::id(storage_unit);
+    assert!(
+        storage_unit.extension.contains(&type_name::with_defining_ids<Auth>()),
+        EExtensionNotAuthorized,
+    );
+    assert!(storage_unit.status.is_online(), ENotOnline);
+    assert!(inventory::parent_id(&item) == expected_prior_parent, EItemParentMismatch);
+    assert!(inventory::tenant(&item) == storage_unit.key.tenant(), ETenantMismatch);
+    inventory::reparent_transit_item(item, storage_unit_id)
+}
+
 public fun withdraw_item<Auth: drop>(
     storage_unit: &mut StorageUnit,
     character: &Character,

--- a/contracts/world/sources/assemblies/storage_unit.move
+++ b/contracts/world/sources/assemblies/storage_unit.move
@@ -282,12 +282,21 @@ public fun deposit_item<Auth: drop>(
 ///
 /// Requires the same `Auth` authorization as `deposit_item`. Callers must pass the real pickup
 /// SSU id as `expected_prior_parent` so the item's current `parent_id` is bound to that origin.
+///
+/// A server-signed `location_proof` for **`target_location_hash ==` this SSU's location** (see
+/// `location::verify_proximity_proof_from_bytes`) is required so reparenting cannot move cargo to
+/// an arbitrary SSU without referee-backed locality — same policy class as `burn_items_with_proof`.
+///
 /// Returns an `Item` with `parent_id == object::id(storage_unit)`; use `deposit_item`,
 /// `deposit_to_owned`, `deposit_to_open_inventory`, etc. as usual (their parent checks unchanged).
 public fun reparent_transit_item_for_freight_dropoff<Auth: drop>(
     storage_unit: &StorageUnit,
     item: Item,
     expected_prior_parent: ID,
+    server_registry: &ServerAddressRegistry,
+    location_proof: vector<u8>,
+    clock: &Clock,
+    ctx: &mut TxContext,
     _: Auth,
 ): Item {
     let storage_unit_id = object::id(storage_unit);
@@ -298,6 +307,13 @@ public fun reparent_transit_item_for_freight_dropoff<Auth: drop>(
     assert!(storage_unit.status.is_online(), ENotOnline);
     assert!(inventory::parent_id(&item) == expected_prior_parent, EItemParentMismatch);
     assert!(inventory::tenant(&item) == storage_unit.key.tenant(), ETenantMismatch);
+    location::verify_proximity_proof_from_bytes(
+        server_registry,
+        &storage_unit.location,
+        location_proof,
+        clock,
+        ctx,
+    );
     inventory::reparent_transit_item(item, storage_unit_id)
 }
 

--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -393,6 +393,28 @@ public(package) fun withdraw_item(
     }
 }
 
+/// Rebases only `parent_id` on a transit `Item` to `new_parent_id`; UID, quantities, tenant,
+/// `type_id`, volume, and `location` are unchanged.
+///
+/// **Why this exists:** Withdrawal from pickup SSU A sets `parent_id == object::id(A)`. An
+/// authorized dropoff SSU extension can call this (via
+/// `storage_unit::reparent_transit_item_for_freight_dropoff`) so the item satisfies existing
+/// `deposit_*` checks (`parent_id ==` that SSU) without weakening them. Proving the reparent
+/// matches a freight job stays in downstream packages.
+public(package) fun reparent_transit_item(item: Item, new_parent_id: ID): Item {
+    let Item { id, parent_id: _, tenant, type_id, item_id, volume, quantity, location } = item;
+    Item {
+        id,
+        parent_id: new_parent_id,
+        tenant,
+        type_id,
+        item_id,
+        volume,
+        quantity,
+        location,
+    }
+}
+
 /// Destroys the inventory, emitting an `ItemDestroyedEvent` per entry.
 public(package) fun delete(inventory: Inventory, assembly_id: ID, assembly_key: TenantItemId) {
     let Inventory {

--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -402,18 +402,9 @@ public(package) fun withdraw_item(
 /// at dropoff) so the item satisfies existing `deposit_*` checks (`parent_id ==` that SSU) without
 /// weakening them. Stronger haul policies (e.g. distance-bounded proofs) can be layered in the
 /// extension that issues the proof.
-public(package) fun reparent_transit_item(item: Item, new_parent_id: ID): Item {
-    let Item { id, parent_id: _, tenant, type_id, item_id, volume, quantity, location } = item;
-    Item {
-        id,
-        parent_id: new_parent_id,
-        tenant,
-        type_id,
-        item_id,
-        volume,
-        quantity,
-        location,
-    }
+public(package) fun reparent_transit_item(mut item: Item, new_parent_id: ID): Item {
+    item.parent_id = new_parent_id;
+    item
 }
 
 /// Destroys the inventory, emitting an `ItemDestroyedEvent` per entry.

--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -398,9 +398,10 @@ public(package) fun withdraw_item(
 ///
 /// **Why this exists:** Withdrawal from pickup SSU A sets `parent_id == object::id(A)`. An
 /// authorized dropoff SSU extension can call this (via
-/// `storage_unit::reparent_transit_item_for_freight_dropoff`) so the item satisfies existing
-/// `deposit_*` checks (`parent_id ==` that SSU) without weakening them. Proving the reparent
-/// matches a freight job stays in downstream packages.
+/// `storage_unit::reparent_transit_item_for_freight_dropoff`, after a server-signed location proof
+/// at dropoff) so the item satisfies existing `deposit_*` checks (`parent_id ==` that SSU) without
+/// weakening them. Stronger haul policies (e.g. distance-bounded proofs) can be layered in the
+/// extension that issues the proof.
 public(package) fun reparent_transit_item(item: Item, new_parent_id: ID): Item {
     let Item { id, parent_id: _, tenant, type_id, item_id, volume, quantity, location } = item;
     Item {

--- a/contracts/world/tests/assemblies/storage_unit_tests.move
+++ b/contracts/world/tests/assemblies/storage_unit_tests.move
@@ -9,6 +9,7 @@ use world::{
     fuel::FuelConfig,
     in_game_id,
     inventory::Item,
+    location,
     network_node::{Self, NetworkNode},
     object_registry::ObjectRegistry,
     storage_unit::{Self, StorageUnit},
@@ -2078,13 +2079,22 @@ fun test_freight_dropoff_reparent_then_deposit_succeeds() {
 
     ts::next_tx(&mut ts, user_a());
     {
+        let mut clock = clock::create_for_testing(ts.ctx());
+        clock.set_for_testing(1763408644000);
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
         let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
+        let proof = test_helpers::construct_location_proof(test_helpers::get_verified_location_hash());
+        let proof_bytes = bcs::to_bytes(&proof);
         let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
                 storage_a_id,
+                &server_registry,
+                proof_bytes,
+                &clock,
+                ts.ctx(),
                 SwapAuth {},
             );
         storage_unit.deposit_item<SwapAuth>(
@@ -2093,6 +2103,8 @@ fun test_freight_dropoff_reparent_then_deposit_succeeds() {
             SwapAuth {},
             ts.ctx(),
         );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
         ts::return_shared(character);
     };
@@ -2104,6 +2116,112 @@ fun test_freight_dropoff_reparent_then_deposit_succeeds() {
             storage_unit.item_quantity(storage_b_owner_cap_id, AMMO_TYPE_ID),
             AMMO_QUANTITY,
         );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
+/// Freight dropoff reparent requires a location proof bound to this SSU's location hash, not another.
+#[test]
+#[expected_failure(abort_code = location::EInvalidLocationHash)]
+fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_location_proof() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let (storage_b_id, nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut clock = clock::create_for_testing(ts.ctx());
+        clock.set_for_testing(1763408644000);
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
+        let proof =
+            test_helpers::construct_location_proof(
+                LOCATION_A_HASH,
+            );
+        let proof_bytes = bcs::to_bytes(&proof);
+        let _reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_a_id,
+                &server_registry,
+                proof_bytes,
+                &clock,
+                ts.ctx(),
+                SwapAuth {},
+            );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
     };
 
@@ -2187,14 +2305,22 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_expected_prior_par
 
     ts::next_tx(&mut ts, user_a());
     {
+        let mut clock = clock::create_for_testing(ts.ctx());
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
         let _reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
                 storage_b_id,
+                &server_registry,
+                vector[],
+                &clock,
+                ts.ctx(),
                 SwapAuth {},
             );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
     };
 
@@ -2277,14 +2403,22 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_extension_not_authorized
 
     ts::next_tx(&mut ts, user_a());
     {
+        let mut clock = clock::create_for_testing(ts.ctx());
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
         let _reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
                 storage_a_id,
+                &server_registry,
+                vector[],
+                &clock,
+                ts.ctx(),
                 SwapAuth {},
             );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
     };
 
@@ -2363,14 +2497,22 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_not_online() {
 
     ts::next_tx(&mut ts, user_a());
     {
+        let mut clock = clock::create_for_testing(ts.ctx());
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
         let _reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
                 storage_a_id,
+                &server_registry,
+                vector[],
+                &clock,
+                ts.ctx(),
                 SwapAuth {},
             );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
     };
 
@@ -2462,14 +2604,22 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_tenant_mismatch() {
 
     ts::next_tx(&mut ts, user_a());
     {
+        let mut clock = clock::create_for_testing(ts.ctx());
         let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
         let _reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
                 storage_a_id,
+                &server_registry,
+                vector[],
+                &clock,
+                ts.ctx(),
                 SwapAuth {},
             );
+        clock.destroy_for_testing();
+        ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
     };
 

--- a/contracts/world/tests/assemblies/storage_unit_tests.move
+++ b/contracts/world/tests/assemblies/storage_unit_tests.move
@@ -1998,6 +1998,484 @@ fun test_deposit_via_extension_fail_parent_id_mismatch() {
     ts::end(ts);
 }
 
+/// Cross-SSU freight happy path: withdraw from SSU A, reparent on SSU B with pickup id A,
+/// then deposit_item on B (parent_id checks unchanged).
+#[test]
+fun test_freight_dropoff_reparent_then_deposit_succeeds() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let (storage_b_id, nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+        ts::return_shared(character);
+    };
+
+    let storage_b_owner_cap_id = storage_owner_cap_id(&mut ts, storage_b_id);
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_a_id,
+                SwapAuth {},
+            );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        assert_eq!(
+            storage_unit.item_quantity(storage_b_owner_cap_id, AMMO_TYPE_ID),
+            AMMO_QUANTITY,
+        );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = storage_unit::EItemParentMismatch)]
+fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_expected_prior_parent() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let (storage_b_id, nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let _reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_b_id,
+                SwapAuth {},
+            );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = storage_unit::EExtensionNotAuthorized)]
+fun test_reparent_transit_item_for_freight_dropoff_fail_extension_not_authorized() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let (storage_b_id, nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let _reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_a_id,
+                SwapAuth {},
+            );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = storage_unit::ENotOnline)]
+fun test_reparent_transit_item_for_freight_dropoff_fail_not_online() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let (storage_b_id, _nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let _reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_a_id,
+                SwapAuth {},
+            );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = storage_unit::ETenantMismatch)]
+fun test_reparent_transit_item_for_freight_dropoff_fail_tenant_mismatch() {
+    let mut ts = ts::begin(governor());
+    setup_nwn(&mut ts);
+    let character_id = create_character(&mut ts, user_a(), CHARACTER_A_ITEM_ID);
+
+    let (storage_a_id, nwn_a_id) = create_storage_unit(
+        &mut ts,
+        character_id,
+        LOCATION_A_HASH,
+        STORAGE_A_ITEM_ID,
+        STORAGE_A_TYPE_ID,
+    );
+    online_storage_unit(&mut ts, user_a(), character_id, storage_a_id, nwn_a_id);
+    mint_ammo<StorageUnit>(&mut ts, storage_a_id, character_id, user_a());
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id),
+            ts.ctx(),
+        );
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        ts::return_shared(storage_unit);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    let item: Item;
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_a_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        item =
+            storage_unit.withdraw_item<SwapAuth>(
+                &character,
+                SwapAuth {},
+                AMMO_TYPE_ID,
+                AMMO_QUANTITY,
+                ts.ctx(),
+            );
+        ts::return_shared(storage_unit);
+        ts::return_shared(character);
+    };
+
+    let different_tenant = DIFFERENT_TENANT.to_string();
+    let character_id_diff_tenant = create_character_with_tenant(
+        &mut ts,
+        user_a(),
+        CHARACTER_B_ITEM_ID,
+        different_tenant,
+    );
+
+    let (storage_b_id, nwn_b_id) = create_storage_unit(
+        &mut ts,
+        character_id_diff_tenant,
+        test_helpers::get_verified_location_hash(),
+        STORAGE_A_ITEM_ID + 1,
+        STORAGE_A_TYPE_ID,
+    );
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
+        let energy_config = ts::take_shared<EnergyConfig>(&ts);
+        let mut character = ts::take_shared_by_id<Character>(&ts, character_id_diff_tenant);
+        let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
+            ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id_diff_tenant),
+            ts.ctx(),
+        );
+        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
+        storage_unit.authorize_extension<SwapAuth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(storage_unit);
+        ts::return_shared(nwn);
+        ts::return_shared(energy_config);
+        ts::return_shared(character);
+    };
+
+    ts::next_tx(&mut ts, user_a());
+    {
+        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let _reparented =
+            storage_unit::reparent_transit_item_for_freight_dropoff(
+                &storage_unit,
+                item,
+                storage_a_id,
+                SwapAuth {},
+            );
+        ts::return_shared(storage_unit);
+    };
+
+    ts::end(ts);
+}
+
 /// Test full swap flow using extension-to-owned functions (no AdminACL needed)
 /// Scenario: User B owns SSU with lens, User A has ammo in owned inventory.
 ///           Extension swaps ammo for lens using deposit_to_owned and withdraw_by_owner.

--- a/contracts/world/tests/assemblies/storage_unit_tests.move
+++ b/contracts/world/tests/assemblies/storage_unit_tests.move
@@ -2202,14 +2202,15 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_location_proof() {
     {
         let mut clock = clock::create_for_testing(ts.ctx());
         clock.set_for_testing(1763408644000);
-        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
         let proof =
             test_helpers::construct_location_proof(
                 LOCATION_A_HASH,
             );
         let proof_bytes = bcs::to_bytes(&proof);
-        let _reparented =
+        let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
@@ -2220,9 +2221,16 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_location_proof() {
                 ts.ctx(),
                 SwapAuth {},
             );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
         clock.destroy_for_testing();
         ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
+        ts::return_shared(character);
     };
 
     ts::end(ts);
@@ -2305,10 +2313,11 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_expected_prior_par
 
     ts::next_tx(&mut ts, user_a());
     {
-        let mut clock = clock::create_for_testing(ts.ctx());
-        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let clock = clock::create_for_testing(ts.ctx());
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
-        let _reparented =
+        let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
@@ -2319,9 +2328,16 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_wrong_expected_prior_par
                 ts.ctx(),
                 SwapAuth {},
             );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
         clock.destroy_for_testing();
         ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
+        ts::return_shared(character);
     };
 
     ts::end(ts);
@@ -2403,10 +2419,11 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_extension_not_authorized
 
     ts::next_tx(&mut ts, user_a());
     {
-        let mut clock = clock::create_for_testing(ts.ctx());
-        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let clock = clock::create_for_testing(ts.ctx());
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
-        let _reparented =
+        let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
@@ -2417,9 +2434,16 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_extension_not_authorized
                 ts.ctx(),
                 SwapAuth {},
             );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
         clock.destroy_for_testing();
         ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
+        ts::return_shared(character);
     };
 
     ts::end(ts);
@@ -2497,10 +2521,11 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_not_online() {
 
     ts::next_tx(&mut ts, user_a());
     {
-        let mut clock = clock::create_for_testing(ts.ctx());
-        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let clock = clock::create_for_testing(ts.ctx());
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
         let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
-        let _reparented =
+        let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
@@ -2511,9 +2536,16 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_not_online() {
                 ts.ctx(),
                 SwapAuth {},
             );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
         clock.destroy_for_testing();
         ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
+        ts::return_shared(character);
     };
 
     ts::end(ts);
@@ -2583,31 +2615,35 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_tenant_mismatch() {
         STORAGE_A_TYPE_ID,
     );
 
+    online_storage_unit(
+        &mut ts,
+        user_a(),
+        character_id_diff_tenant,
+        storage_b_id,
+        nwn_b_id,
+    );
+
     ts::next_tx(&mut ts, user_a());
     {
         let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
-        let mut nwn = ts::take_shared_by_id<NetworkNode>(&ts, nwn_b_id);
-        let energy_config = ts::take_shared<EnergyConfig>(&ts);
         let mut character = ts::take_shared_by_id<Character>(&ts, character_id_diff_tenant);
         let (owner_cap, receipt) = character.borrow_owner_cap<StorageUnit>(
             ts::most_recent_receiving_ticket<OwnerCap<StorageUnit>>(&character_id_diff_tenant),
             ts.ctx(),
         );
-        storage_unit.online(&mut nwn, &energy_config, &owner_cap);
         storage_unit.authorize_extension<SwapAuth>(&owner_cap);
         character.return_owner_cap(owner_cap, receipt);
         ts::return_shared(storage_unit);
-        ts::return_shared(nwn);
-        ts::return_shared(energy_config);
         ts::return_shared(character);
     };
 
     ts::next_tx(&mut ts, user_a());
     {
-        let mut clock = clock::create_for_testing(ts.ctx());
-        let storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let clock = clock::create_for_testing(ts.ctx());
+        let mut storage_unit = ts::take_shared_by_id<StorageUnit>(&ts, storage_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id_diff_tenant);
         let server_registry = ts::take_shared<ServerAddressRegistry>(&ts);
-        let _reparented =
+        let reparented =
             storage_unit::reparent_transit_item_for_freight_dropoff(
                 &storage_unit,
                 item,
@@ -2618,9 +2654,16 @@ fun test_reparent_transit_item_for_freight_dropoff_fail_tenant_mismatch() {
                 ts.ctx(),
                 SwapAuth {},
             );
+        storage_unit.deposit_item<SwapAuth>(
+            &character,
+            reparented,
+            SwapAuth {},
+            ts.ctx(),
+        );
         clock.destroy_for_testing();
         ts::return_shared(server_registry);
         ts::return_shared(storage_unit);
+        ts::return_shared(character);
     };
 
     ts::end(ts);


### PR DESCRIPTION
## Summary

Adds a package helper on `inventory` and a public, extension-gated entrypoint on `storage_unit` so a transit `Item` withdrawn from SSU A can have `parent_id` rebound to dropoff SSU B before calling existing `deposit_item` / `deposit_to_owned` / `deposit_to_open_inventory` paths.

## Problem

`withdraw_item` sets `Item.parent_id` to the pickup SSU. All extension deposit paths assert `parent_id ==` the target SSU, so depositing on another SSU aborts with `EItemParentMismatch` (see existing test `test_deposit_via_extension_fail_parent_id_mismatch`). That behavior is unchanged if callers skip reparent.

## Solution

- `inventory::reparent_transit_item` — `public(package)`; updates only `parent_id`, preserves UID and the rest of the struct.
- `storage_unit::reparent_transit_item_for_freight_dropoff<Auth>` — same extension + online + tenant checks as deposits; requires `inventory::parent_id(&item) == expected_prior_parent` (pickup SSU id); returns an `Item` with `parent_id == object::id(dropoff_ssu)` so existing deposit functions keep their parent checks.

Freight/job proof stays in downstream packages; world only exposes safe reparent + unchanged deposits.

## Tests

- Happy path: withdraw A → reparent on B with `expected_prior_parent = id(A)` → `deposit_item` on B.
- Negative: wrong `expected_prior_parent`; extension not authorized; SSU offline; tenant mismatch.