### PR TITLE
[Draft][RFC] feat: refinery assembly + recipe primitive

### DIFF
--- a/contracts/world/docs/data/item_type_ids.md
+++ b/contracts/world/docs/data/item_type_ids.md
@@ -1,0 +1,55 @@
+# Item type_id reference for the 21 refinery schemas
+
+Source: live query of EVE Frontier WorldAPI (`/v2/types`) at
+`https://world-api-utopia.uat.pub.evefrontier.com/v2/types`, 2026-05-15.
+
+All 39 unique items referenced by the 21 schemas in [`refinery_schemas.md`](./refinery_schemas.md):
+
+| type_id | Name | Group | Category | Volume | Portion |
+|---|---|---|---|---|---|
+| 77728 | Sophrogon | Mineral | Material | 1 | 10000 |
+| 77729 | Rough Old Crude Matter | Rift | Asteroid | 1 | 10000 |
+| 77800 | Feldspar Crystals | Char Ores | Asteroid | 1 | 10000 |
+| 77801 | Nickel-Iron Veins | Mineral | Material | 0.10000000149011612 | 10000 |
+| 77803 | Silicon Dust | Mineral | Material | 0.10000000149011612 | 10000 |
+| 77804 | Tholin Aggregates | Mineral | Material | 0.10000000149011612 | 10000 |
+| 77805 | Platinum-Group Veins | Mineral | Material | 0.009999999776482582 | 10000 |
+| 77810 | Platinum-Palladium Matrix | Slag Ores | Asteroid | 1 | 10000 |
+| 77811 | Hydrated Sulfide Matrix | Comet Ores | Asteroid | 1 | 10000 |
+| 78423 | Water Ice | Mineral | Material | 0.10000000149011612 | 10000 |
+| 78426 | Iridosmine Nodules | Ingot Ores | Asteroid | 1 | 10000 |
+| 78434 | Rough Young Crude Matter | Rift | Asteroid | 1 | 10000 |
+| 78435 | Eupraxite | Mineral | Material | 1 | 10000 |
+| 78446 | Methane Ice Shards | Dewdrop Ores | Asteroid | 1 | 10000 |
+| 78447 | Primitive Kerogen Matrix | Ember Ores | Asteroid | 1 | 10000 |
+| 78448 | Aromatic Carbon Veins | Glint Ores | Asteroid | 1 | 10000 |
+| 78449 | Tholin Nodules | Soot Ores | Asteroid | 1 | 10000 |
+| 78516 | EU-40 Fuel | Crude Fuel | Commodity | 0.2800000011920929 | 357143 |
+| 83839 | Salt | Mineral | Material | 0.10000000149011612 | 10000 |
+| 84182 | Reinforced Alloys | Manufacturing Component | Material | 10 | 2000 |
+| 84210 | Carbon Weave | Manufacturing Component | Material | 15 | 2000 |
+| 84868 | SOF-40 Fuel | Crude Fuel | Commodity | 0.2800000011920929 | 357143 |
+| 88234 | Troilite Sulfide Grains | Mineral | Material | 0.10000000149011612 | 10000 |
+| 88235 | Feldspar Crystal Shards | Mineral | Material | 0.10000000149011612 | 10000 |
+| 88319 | D2 Fuel | Hydrogen Fuel | Commodity | 0.2800000011920929 | 357143 |
+| 88335 | D1 Fuel | Hydrogen Fuel | Commodity | 0.2800000011920929 | 357143 |
+| 88561 | Thermal Composites | Manufacturing Component | Material | 10 | 2000 |
+| 88764 | Salvaged Materials | Salvage | Commodity | 5 | 10000 |
+| 88765 | Mummified Clone | Salvage | Commodity | 0.20000000298023224 | 10000 |
+| 88781 | Chitinous Organics | Manufacturing Component | Material | 10 | 2000 |
+| 88782 | Aromatic Carbon Weave | Manufacturing Component | Material | 0.10000000149011612 | 2000 |
+| 88783 | Kerogen Tar | Manufacturing Component | Material | 0.30000001192092896 | 2000 |
+| 89258 | Hydrocarbon Residue | Mineral | Material | 1 | 10000 |
+| 89259 | Silica Grains | Mineral | Material | 1 | 10000 |
+| 89260 | Iron-Rich Nodules | Mineral | Material | 1 | 10000 |
+| 92394 | Fine Young Crude Matter | Rift | Asteroid | 1 | 10000 |
+| 92414 | Fine Old Crude Matter | Rift | Asteroid | 1 | 10000 |
+| 92422 | Brine | Mineral | Material | 0.10000000149011612 | 10000 |
+| 99001 | Palladium | Manufacturing Component | Material | 5 | 1 |
+
+## Notes
+
+- The WorldAPI lives at the Utopia (sandbox) URL; type definitions are game-data constants and should be identical across Stillness and Utopia.
+- `volume` (m³) and `portion_size` (mint batch) are useful for `recipe::register_recipe` and `inventory::mint_items` constraints.
+- Categories `Mineral`, `Char Ores`, `Comet Ores`, etc. map directly to the `category` field shown in the in-game refinery SCHEMA tab.
+- Asteroids (raw inputs) have `categoryName=Asteroid`; refined products are `categoryName=Material` or `Commodity`.

--- a/contracts/world/docs/data/refinery_schemas.md
+++ b/contracts/world/docs/data/refinery_schemas.md
@@ -1,0 +1,85 @@
+# Refinery Schemas — Observed in-game (Stillness, Refinery 1)
+
+Source: in-game UI screenshots from player `artokun`, 2026-05-15.
+Total reported by UI: **21** schemas. Catalogued below: **21 / 21 ✓**.
+
+Categories observed: `Mineral`, `Glint Ores`, `Hydrogen Fuel`, `Char Ores`,
+`Dewdrop Ores`, `Salvage`, `Slag Ores`, `Ember Ores`, `Rift`, `Soot Ores`,
+`Comet Ores`, `Ingot Ores`.
+
+## Schemas
+
+| # | Name | Category | Input | Run | Outputs |
+|---|---|---|---|---|---|
+|  1 | Silica Grains             | Mineral       | Silica Grains × 20             |  9s | Silicon Dust × 150 + Feldspar Crystal Shards × 50 |
+|  2 | Aromatic Carbon Veins     | Glint Ores    | Aromatic Carbon Veins × 100    | 15s | Chitinous Organics × 1 + Aromatic Carbon Weave × 4 + Kerogen Tar × 8 |
+|  3 | D2 Fuel                   | Hydrogen Fuel | D2 Fuel × 200                  |  3s | Salt × 1 |
+|  4 | Eupraxite                 | Mineral       | Eupraxite × 10                 | 25s | EU-40 Fuel × 600 |
+|  5 | Feldspar Crystals         | Char Ores     | Feldspar Crystals × 40         |  3s | Hydrocarbon Residue × 10 + Silica Grains × 30 |
+|  6 | Iron-Rich Nodules         | Mineral       | Iron-Rich Nodules × 10         |  9s | Platinum-Group Veins × 20 + Nickel-Iron Veins × 198 |
+|  7 | Methane Ice Shards        | Dewdrop Ores  | Methane Ice Shards × 100       | 15s | Chitinous Organics × 1 + Tholin Aggregates × 126 + Water Ice × 349 |
+|  8 | Mummified Clone           | Salvage       | Mummified Clone × 5            |  3s | Aromatic Carbon Weave × 1 + Kerogen Tar × 1 + Water Ice × 50 |
+|  9 | Platinum-Palladium Matrix | Slag Ores     | Platinum-Palladium Matrix × 40 |  3s | Silica Grains × 16 + Iron-Rich Nodules × 30 + Palladium × 8 |
+| 10 | Primitive Kerogen Matrix  | Ember Ores    | Primitive Kerogen Matrix × 100 | 15s | Chitinous Organics × 1 + Kerogen Tar × 16 |
+| 11 | Rough Old Crude Matter    | Rift          | Rough Old Crude Matter × 30    | 20s | Salt × 16 + Sophrogon × 28 |
+| 12 | Rough Young Crude Matter  | Rift          | Rough Young Crude Matter × 30  | 20s | Salt × 1 + Eupraxite × 28 |
+| 13 | Salvaged Materials        | Salvage       | Salvaged Materials × 10        |  4s | Carbon Weave × 1 + Thermal Composites × 2 + Reinforced Alloys × 6 |
+| 14 | Sophrogon                 | Mineral       | Sophrogon × 10                 | 25s | SOF-40 Fuel × 600 |
+| 15 | Tholin Nodules            | Soot Ores     | Tholin Nodules × 100           | 15s | Chitinous Organics × 1 + Aromatic Carbon Weave × 8 |
+| 16 | Water Ice                 | Mineral       | Water Ice × 275                |  8s | D1 Fuel × 75 |
+| 17 | Fine Old Crude Matter     | Rift          | Fine Old Crude Matter × 30     | 20s | Sophrogon × 6 + Brine × 26 |
+| 18 | Fine Young Crude Matter   | Rift          | Fine Young Crude Matter × 30   | 20s | Eupraxite × 6 + Brine × 26 |
+| 19 | Hydrated Sulfide Matrix   | Comet Ores    | Hydrated Sulfide Matrix × 40   |  3s | Hydrocarbon Residue × 20 + Water Ice × 300 |
+| 20 | Hydrocarbon Residue       | Mineral       | Hydrocarbon Residue × 20       |  9s | Troilite Sulfide Grains × 20 + Tholin Aggregates × 180 |
+| 21 | Iridosmine Nodules        | Ingot Ores    | Iridosmine Nodules × 40        |  5s | Iron-Rich Nodules × 40 |
+
+## Cross-references / refining graph
+
+Multi-stage refining paths (an output of one recipe is an input of another):
+
+- **Iron-Rich Nodules** — input #6, output of #9, #21
+- **Silica Grains** — input #1, output of #5, #9
+- **Sophrogon** — input #14, output of #11, #17
+- **Water Ice** — input #16, output of #7, #8, #19
+- **Eupraxite** — input #4, output of #12, #18
+- **Hydrocarbon Residue** — input #20, output of #5, #19
+- **Tholin Aggregates** — output of #7, #20 (no input recipe → terminal product)
+- **Aromatic Carbon Weave** — output of #2, #8, #15 (terminal)
+
+Common multi-source outputs: **Chitinous Organics** (#2, #7, #10, #15),
+**Kerogen Tar** (#2, #8, #10), **Salt** (#3, #11, #12), **Brine** (#17, #18).
+
+## Implications for the proposed `world::recipe` registry
+
+- The "input ≠ output **within a single recipe**" constraint enforced by
+  `validate_recipe_args` holds for **all 21 observed schemas**.
+- Multiple recipes can share output types — the registry already supports
+  this (keyed by `input_type_id` only, no output uniqueness check).
+- Multi-stage refining paths exist (e.g. Iridosmine Nodules → Iron-Rich
+  Nodules → Platinum-Group Veins + Nickel-Iron Veins). The single-active-job
+  per refinery v1 constraint still works — players queue stages manually,
+  or future work adds chained recipes.
+- Run-time tiers observed: **3s, 4s, 5s, 8s, 9s, 15s, 20s, 25s**. All fit
+  in `u64` ms (the field type in this PR).
+- Output quantities range from 1 (rare components) to 600 (fuel batches).
+  Both fit in `u32`.
+
+## Open questions
+
+- **type_ids for these item names.** The dapp-kit sandbox doc lists a few:
+  Feldspar Crystals (77800), Hydrated Sulfide Matrix (77811), Carbon Weave
+  (84210), Printed Circuits (84180), Reinforced Alloys (84182), Thermal
+  Composites (88561), Building Foam (89089). The full mapping (~50+ unique
+  items across these 21 schemas) needs the WorldAPI / GraphQL.
+- **Categories** (`Mineral`, `Glint Ores`, etc.) — intrinsic to the input
+  item type, or orthogonal tags? If intrinsic, no schema field needed; if
+  orthogonal, `Recipe.category: String` should be added.
+- **Does the existence of a schema depend on the refinery's `type_id`?**
+  Refinery 1 here is type_id 88063 and shows all 21 schemas. Different
+  refinery hardware may expose different subsets — needs another refinery's
+  schema list to confirm. If so, the registry needs a per-refinery-type
+  whitelist (or recipe.refinery_type_ids: vector<u64>).
+- **"Required items available" tag** (visible on #20 in the player's
+  screenshot) — server-side UI affordance computed from the refinery's
+  current input inventory. The on-chain `recipe` doesn't need to encode
+  this; clients compute it themselves from inventory state.

--- a/contracts/world/docs/data/seed_recipes.move.example
+++ b/contracts/world/docs/data/seed_recipes.move.example
@@ -1,0 +1,204 @@
+// Seed-data example: register all 21 refinery schemas observed in-game on Stillness.
+// This is NOT a module — it's a reference snippet to be incorporated into a
+// migration script (Move test, or TypeScript that builds a Transaction calling
+// recipe::register_recipe for each entry). type_ids sourced from EVE Frontier
+// WorldAPI /v2/types, 2026-05-15.
+
+// Example shape, per schema:
+//
+//   recipe::register_recipe(
+//       registry, admin_acl, name,
+//       input_type_id, input_quantity,
+//       output_type_ids, output_quantities,
+//       processing_time_ms, ctx,
+//   );
+
+// Silica Grains
+recipe::register_recipe(
+    registry, admin_acl, b"Silica Grains".to_string(),
+    89259u64, 20u32,                       // Silica Grains
+    vector[77803u64, 88235u64],  // Silicon Dust, Feldspar Crystal Shards
+    vector[150u32, 50u32],
+    9000u64, ctx,
+);
+
+// Aromatic Carbon Veins
+recipe::register_recipe(
+    registry, admin_acl, b"Aromatic Carbon Veins".to_string(),
+    78448u64, 100u32,                       // Aromatic Carbon Veins
+    vector[88781u64, 88782u64, 88783u64],  // Chitinous Organics, Aromatic Carbon Weave, Kerogen Tar
+    vector[1u32, 4u32, 8u32],
+    15000u64, ctx,
+);
+
+// D2 Fuel
+recipe::register_recipe(
+    registry, admin_acl, b"D2 Fuel".to_string(),
+    88319u64, 200u32,                       // D2 Fuel
+    vector[83839u64],  // Salt
+    vector[1u32],
+    3000u64, ctx,
+);
+
+// Eupraxite
+recipe::register_recipe(
+    registry, admin_acl, b"Eupraxite".to_string(),
+    78435u64, 10u32,                       // Eupraxite
+    vector[78516u64],  // EU-40 Fuel
+    vector[600u32],
+    25000u64, ctx,
+);
+
+// Feldspar Crystals
+recipe::register_recipe(
+    registry, admin_acl, b"Feldspar Crystals".to_string(),
+    77800u64, 40u32,                       // Feldspar Crystals
+    vector[89258u64, 89259u64],  // Hydrocarbon Residue, Silica Grains
+    vector[10u32, 30u32],
+    3000u64, ctx,
+);
+
+// Iron-Rich Nodules
+recipe::register_recipe(
+    registry, admin_acl, b"Iron-Rich Nodules".to_string(),
+    89260u64, 10u32,                       // Iron-Rich Nodules
+    vector[77805u64, 77801u64],  // Platinum-Group Veins, Nickel-Iron Veins
+    vector[20u32, 198u32],
+    9000u64, ctx,
+);
+
+// Methane Ice Shards
+recipe::register_recipe(
+    registry, admin_acl, b"Methane Ice Shards".to_string(),
+    78446u64, 100u32,                       // Methane Ice Shards
+    vector[88781u64, 77804u64, 78423u64],  // Chitinous Organics, Tholin Aggregates, Water Ice
+    vector[1u32, 126u32, 349u32],
+    15000u64, ctx,
+);
+
+// Mummified Clone
+recipe::register_recipe(
+    registry, admin_acl, b"Mummified Clone".to_string(),
+    88765u64, 5u32,                       // Mummified Clone
+    vector[88782u64, 88783u64, 78423u64],  // Aromatic Carbon Weave, Kerogen Tar, Water Ice
+    vector[1u32, 1u32, 50u32],
+    3000u64, ctx,
+);
+
+// Platinum-Palladium Matrix
+recipe::register_recipe(
+    registry, admin_acl, b"Platinum-Palladium Matrix".to_string(),
+    77810u64, 40u32,                       // Platinum-Palladium Matrix
+    vector[89259u64, 89260u64, 99001u64],  // Silica Grains, Iron-Rich Nodules, Palladium
+    vector[16u32, 30u32, 8u32],
+    3000u64, ctx,
+);
+
+// Primitive Kerogen Matrix
+recipe::register_recipe(
+    registry, admin_acl, b"Primitive Kerogen Matrix".to_string(),
+    78447u64, 100u32,                       // Primitive Kerogen Matrix
+    vector[88781u64, 88783u64],  // Chitinous Organics, Kerogen Tar
+    vector[1u32, 16u32],
+    15000u64, ctx,
+);
+
+// Rough Old Crude Matter
+recipe::register_recipe(
+    registry, admin_acl, b"Rough Old Crude Matter".to_string(),
+    77729u64, 30u32,                       // Rough Old Crude Matter
+    vector[83839u64, 77728u64],  // Salt, Sophrogon
+    vector[16u32, 28u32],
+    20000u64, ctx,
+);
+
+// Rough Young Crude Matter
+recipe::register_recipe(
+    registry, admin_acl, b"Rough Young Crude Matter".to_string(),
+    78434u64, 30u32,                       // Rough Young Crude Matter
+    vector[83839u64, 78435u64],  // Salt, Eupraxite
+    vector[1u32, 28u32],
+    20000u64, ctx,
+);
+
+// Salvaged Materials
+recipe::register_recipe(
+    registry, admin_acl, b"Salvaged Materials".to_string(),
+    88764u64, 10u32,                       // Salvaged Materials
+    vector[84210u64, 88561u64, 84182u64],  // Carbon Weave, Thermal Composites, Reinforced Alloys
+    vector[1u32, 2u32, 6u32],
+    4000u64, ctx,
+);
+
+// Sophrogon
+recipe::register_recipe(
+    registry, admin_acl, b"Sophrogon".to_string(),
+    77728u64, 10u32,                       // Sophrogon
+    vector[84868u64],  // SOF-40 Fuel
+    vector[600u32],
+    25000u64, ctx,
+);
+
+// Tholin Nodules
+recipe::register_recipe(
+    registry, admin_acl, b"Tholin Nodules".to_string(),
+    78449u64, 100u32,                       // Tholin Nodules
+    vector[88781u64, 88782u64],  // Chitinous Organics, Aromatic Carbon Weave
+    vector[1u32, 8u32],
+    15000u64, ctx,
+);
+
+// Water Ice
+recipe::register_recipe(
+    registry, admin_acl, b"Water Ice".to_string(),
+    78423u64, 275u32,                       // Water Ice
+    vector[88335u64],  // D1 Fuel
+    vector[75u32],
+    8000u64, ctx,
+);
+
+// Fine Old Crude Matter
+recipe::register_recipe(
+    registry, admin_acl, b"Fine Old Crude Matter".to_string(),
+    92414u64, 30u32,                       // Fine Old Crude Matter
+    vector[77728u64, 92422u64],  // Sophrogon, Brine
+    vector[6u32, 26u32],
+    20000u64, ctx,
+);
+
+// Fine Young Crude Matter
+recipe::register_recipe(
+    registry, admin_acl, b"Fine Young Crude Matter".to_string(),
+    92394u64, 30u32,                       // Fine Young Crude Matter
+    vector[78435u64, 92422u64],  // Eupraxite, Brine
+    vector[6u32, 26u32],
+    20000u64, ctx,
+);
+
+// Hydrated Sulfide Matrix
+recipe::register_recipe(
+    registry, admin_acl, b"Hydrated Sulfide Matrix".to_string(),
+    77811u64, 40u32,                       // Hydrated Sulfide Matrix
+    vector[89258u64, 78423u64],  // Hydrocarbon Residue, Water Ice
+    vector[20u32, 300u32],
+    3000u64, ctx,
+);
+
+// Hydrocarbon Residue
+recipe::register_recipe(
+    registry, admin_acl, b"Hydrocarbon Residue".to_string(),
+    89258u64, 20u32,                       // Hydrocarbon Residue
+    vector[88234u64, 77804u64],  // Troilite Sulfide Grains, Tholin Aggregates
+    vector[20u32, 180u32],
+    9000u64, ctx,
+);
+
+// Iridosmine Nodules
+recipe::register_recipe(
+    registry, admin_acl, b"Iridosmine Nodules".to_string(),
+    78426u64, 40u32,                       // Iridosmine Nodules
+    vector[89260u64],  // Iron-Rich Nodules
+    vector[40u32],
+    5000u64, ctx,
+);
+

--- a/contracts/world/sources/assemblies/refinery.move
+++ b/contracts/world/sources/assemblies/refinery.move
@@ -1,0 +1,615 @@
+/// This module handles the functionality of the in-game Refinery Assembly.
+///
+/// A Refinery is a programmable on-chain industrial structure. It consumes input
+/// items, runs a timed processing job per a registered `Recipe`, and produces
+/// output items into the same inventory.
+///
+/// Like the StorageUnit, behaviour is customizable via the typed witness pattern
+/// (see `authorize_extension`). Two access modes are supported:
+///
+/// 1. **Extension-based access**
+///    - `deposit_input<Auth>`, `withdraw_input<Auth>`, `start_job<Auth>`, `claim_outputs<Auth>`
+///    - Allows custom contracts to drive the refinery on behalf of the owner
+///
+/// 2. **Owner-direct access**
+///    - `*_by_owner` variants, gated by `OwnerCap` + sender == character address
+///
+/// # Job model (v1)
+///
+/// At most **one** active job per refinery at any time. `start_job`:
+///   - looks up the recipe by `input_type_id`
+///   - consumes `recipe.input_quantity` from the input inventory
+///   - records `started_at_ms` / `finishes_at_ms` on the refinery
+///   - emits `JobStartedEvent`
+///
+/// `claim_outputs`:
+///   - asserts no remaining processing time
+///   - mints each output type into the inventory in place (per-type quantity from the recipe)
+///   - clears the active job slot
+///   - emits `JobClaimedEvent`
+///
+/// Input and output items share one inventory keyed by `owner_cap_id` — recipes are
+/// forbidden from naming the input as an output (enforced in `world::recipe`), so
+/// there is no ambiguity.
+///
+/// Future: multi-input recipes, variable yield, parallel jobs, throughput modifiers.
+module world::refinery;
+
+use std::{string::String, type_name::{Self, TypeName}};
+use sui::{clock::Clock, derived_object, dynamic_field as df, event};
+use world::{
+    access::{Self, OwnerCap, AdminACL},
+    character::Character,
+    extension_freeze,
+    in_game_id::{Self, TenantItemId},
+    inventory::{Self, Inventory, Item},
+    location::{Self, Location},
+    metadata::{Self, Metadata},
+    network_node::NetworkNode,
+    object_registry::ObjectRegistry,
+    recipe::{Self, RecipeRegistry},
+    status::{Self, AssemblyStatus}
+};
+
+// === Errors ===
+#[error(code = 0)]
+const ERefineryTypeIdEmpty: vector<u8> = b"Refinery TypeId is empty";
+#[error(code = 1)]
+const ERefineryItemIdEmpty: vector<u8> = b"Refinery ItemId is empty";
+#[error(code = 2)]
+const ERefineryAlreadyExists: vector<u8> = b"Refinery with the same Item Id already exists";
+#[error(code = 3)]
+const EExtensionNotAuthorized: vector<u8> =
+    b"Access only authorized for the custom contract of the registered type";
+#[error(code = 4)]
+const EInventoryNotAuthorized: vector<u8> = b"Inventory Access not authorized";
+#[error(code = 5)]
+const ENotOnline: vector<u8> = b"Refinery is not online";
+#[error(code = 6)]
+const ETenantMismatch: vector<u8> = b"Item cannot be transferred across tenants";
+#[error(code = 7)]
+const ESenderCannotAccessCharacter: vector<u8> = b"Address cannot access Character";
+#[error(code = 8)]
+const EItemParentMismatch: vector<u8> = b"Item was not withdrawn from this refinery";
+#[error(code = 9)]
+const EJobInProgress: vector<u8> = b"Refinery already has an active job";
+#[error(code = 10)]
+const ENoActiveJob: vector<u8> = b"Refinery has no active job";
+#[error(code = 11)]
+const EJobNotComplete: vector<u8> = b"Active job has not finished processing";
+#[error(code = 12)]
+const ERecipeNotFound: vector<u8> = b"No recipe registered for the requested input type";
+// (note: EInsufficientInput removed — inventory::withdraw_item already aborts with
+//  EInventoryInsufficientQuantity when there isn't enough input.)
+#[error(code = 14)]
+const EExtensionConfigFrozen: vector<u8> = b"Extension configuration is frozen";
+#[error(code = 15)]
+const EExtensionNotConfigured: vector<u8> = b"Extension must be configured before freezing";
+#[error(code = 16)]
+const ENoExtensionToRevoke: vector<u8> = b"No extension authorization to revoke";
+
+// === Structs ===
+
+public struct Refinery has key {
+    id: UID,
+    key: TenantItemId,
+    owner_cap_id: ID,
+    type_id: u64,
+    status: AssemblyStatus,
+    location: Location,
+    inventory_keys: vector<ID>,
+    energy_source_id: Option<ID>,
+    metadata: Option<Metadata>,
+    extension: Option<TypeName>,
+    active_job: Option<Job>,
+}
+
+/// Snapshot of a running processing job. Stored inline on `Refinery` to keep the
+/// "one job at a time" invariant trivial to enforce. Output recipe details are
+/// snapshotted at start so admins changing a recipe mid-flight don't change
+/// already-running jobs.
+public struct Job has copy, drop, store {
+    input_type_id: u64,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    started_at_ms: u64,
+    finishes_at_ms: u64,
+}
+
+// === Events ===
+
+public struct RefineryCreatedEvent has copy, drop {
+    refinery_id: ID,
+    assembly_key: TenantItemId,
+    owner_cap_id: ID,
+    type_id: u64,
+    max_capacity: u64,
+    location_hash: vector<u8>,
+}
+
+public struct ExtensionAuthorizedEvent has copy, drop {
+    refinery_id: ID,
+    assembly_key: TenantItemId,
+    owner_cap_id: ID,
+    extension_type: TypeName,
+    previous_extension: Option<TypeName>,
+}
+
+public struct ExtensionRevokedEvent has copy, drop {
+    refinery_id: ID,
+    assembly_key: TenantItemId,
+    owner_cap_id: ID,
+    extension_type: TypeName,
+}
+
+public struct JobStartedEvent has copy, drop {
+    refinery_id: ID,
+    assembly_key: TenantItemId,
+    character_id: ID,
+    input_type_id: u64,
+    input_quantity: u32,
+    started_at_ms: u64,
+    finishes_at_ms: u64,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+}
+
+public struct JobClaimedEvent has copy, drop {
+    refinery_id: ID,
+    assembly_key: TenantItemId,
+    character_id: ID,
+    input_type_id: u64,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    claimed_at_ms: u64,
+}
+
+// === Anchor / share ===
+
+public fun anchor(
+    registry: &mut ObjectRegistry,
+    network_node: &mut NetworkNode,
+    character: &Character,
+    admin_acl: &AdminACL,
+    item_id: u64,
+    type_id: u64,
+    max_capacity: u64,
+    location_hash: vector<u8>,
+    ctx: &mut TxContext,
+): Refinery {
+    assert!(type_id != 0, ERefineryTypeIdEmpty);
+    assert!(item_id != 0, ERefineryItemIdEmpty);
+
+    let refinery_key = in_game_id::create_key(item_id, character.tenant());
+    assert!(!registry.object_exists(refinery_key), ERefineryAlreadyExists);
+
+    let assembly_uid = derived_object::claim(registry.borrow_registry_id(), refinery_key);
+    let assembly_id = object::uid_to_inner(&assembly_uid);
+    let network_node_id = object::id(network_node);
+
+    let owner_cap = access::create_owner_cap_by_id<Refinery>(assembly_id, admin_acl, ctx);
+    let owner_cap_id = object::id(&owner_cap);
+
+    let mut refinery = Refinery {
+        id: assembly_uid,
+        key: refinery_key,
+        owner_cap_id,
+        type_id,
+        status: status::anchor(assembly_id, refinery_key),
+        location: location::attach(location_hash),
+        inventory_keys: vector[],
+        energy_source_id: option::some(network_node_id),
+        metadata: option::some(
+            metadata::create_metadata(
+                assembly_id,
+                refinery_key,
+                b"".to_string(),
+                b"".to_string(),
+                b"".to_string(),
+            ),
+        ),
+        extension: option::none(),
+        active_job: option::none(),
+    };
+
+    access::transfer_owner_cap(owner_cap, object::id_address(character));
+
+    network_node.connect_assembly(assembly_id);
+
+    let inv = inventory::create(max_capacity);
+    refinery.inventory_keys.push_back(owner_cap_id);
+    df::add(&mut refinery.id, owner_cap_id, inv);
+
+    event::emit(RefineryCreatedEvent {
+        refinery_id: assembly_id,
+        assembly_key: refinery_key,
+        owner_cap_id,
+        type_id,
+        max_capacity,
+        location_hash,
+    });
+
+    refinery
+}
+
+public fun share_refinery(refinery: Refinery, admin_acl: &AdminACL, ctx: &TxContext) {
+    admin_acl.verify_sponsor(ctx);
+    transfer::share_object(refinery);
+}
+
+// === Extension ===
+
+public fun authorize_extension<Auth: drop>(
+    refinery: &mut Refinery,
+    owner_cap: &OwnerCap<Refinery>,
+) {
+    check_owner_cap(refinery, owner_cap);
+    assert!(!extension_freeze::is_extension_frozen(&refinery.id), EExtensionConfigFrozen);
+
+    let new_type = type_name::with_defining_ids<Auth>();
+    let previous = refinery.extension;
+    refinery.extension = option::some(new_type);
+
+    event::emit(ExtensionAuthorizedEvent {
+        refinery_id: object::id(refinery),
+        assembly_key: refinery.key,
+        owner_cap_id: refinery.owner_cap_id,
+        extension_type: new_type,
+        previous_extension: previous,
+    });
+}
+
+public fun revoke_extension_authorization(
+    refinery: &mut Refinery,
+    owner_cap: &OwnerCap<Refinery>,
+) {
+    check_owner_cap(refinery, owner_cap);
+    assert!(!extension_freeze::is_extension_frozen(&refinery.id), EExtensionConfigFrozen);
+    assert!(refinery.extension.is_some(), ENoExtensionToRevoke);
+    let removed = refinery.extension.extract();
+
+    event::emit(ExtensionRevokedEvent {
+        refinery_id: object::id(refinery),
+        assembly_key: refinery.key,
+        owner_cap_id: refinery.owner_cap_id,
+        extension_type: removed,
+    });
+}
+
+public fun freeze_extension_config(refinery: &mut Refinery, owner_cap: &OwnerCap<Refinery>) {
+    check_owner_cap(refinery, owner_cap);
+    assert!(refinery.extension.is_some(), EExtensionNotConfigured);
+    let refinery_id = object::id(refinery);
+    extension_freeze::freeze_extension_config(&mut refinery.id, refinery_id);
+}
+
+// === Online / offline ===
+
+public fun online(refinery: &mut Refinery, owner_cap: &OwnerCap<Refinery>) {
+    check_owner_cap(refinery, owner_cap);
+    let refinery_id = object::id(refinery);
+    refinery.status.online(refinery_id, refinery.key);
+}
+
+public fun offline(refinery: &mut Refinery, owner_cap: &OwnerCap<Refinery>) {
+    check_owner_cap(refinery, owner_cap);
+    let refinery_id = object::id(refinery);
+    refinery.status.offline(refinery_id, refinery.key);
+}
+
+// === Inventory: extension-gated ===
+
+public fun deposit_input<Auth: drop>(
+    refinery: &mut Refinery,
+    character: &Character,
+    item: Item,
+    _: Auth,
+    _: &mut TxContext,
+) {
+    check_extension_authorized<Auth>(refinery);
+    assert!(refinery.status.is_online(), ENotOnline);
+    let refinery_id = object::id(refinery);
+    assert!(inventory::tenant(&item) == refinery.key.tenant(), ETenantMismatch);
+    assert!(inventory::parent_id(&item) == refinery_id, EItemParentMismatch);
+
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+    inventory::deposit_item(inv, refinery_id, refinery.key, character, item);
+}
+
+public fun withdraw_input<Auth: drop>(
+    refinery: &mut Refinery,
+    character: &Character,
+    _: Auth,
+    type_id: u64,
+    quantity: u32,
+    ctx: &mut TxContext,
+): Item {
+    check_extension_authorized<Auth>(refinery);
+    assert!(refinery.status.is_online(), ENotOnline);
+    let refinery_id = object::id(refinery);
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+    inventory::withdraw_item(
+        inv,
+        refinery_id,
+        refinery.key,
+        character,
+        type_id,
+        quantity,
+        refinery.location.hash(),
+        ctx,
+    )
+}
+
+// === Inventory: owner-direct ===
+
+public fun deposit_input_by_owner<T: key>(
+    refinery: &mut Refinery,
+    item: Item,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    ctx: &mut TxContext,
+) {
+    assert!(character.character_address() == ctx.sender(), ESenderCannotAccessCharacter);
+    check_owner_cap_generic(refinery, owner_cap);
+    let refinery_id = object::id(refinery);
+    assert!(refinery.status.is_online(), ENotOnline);
+    assert!(inventory::tenant(&item) == refinery.key.tenant(), ETenantMismatch);
+    assert!(inventory::parent_id(&item) == refinery_id, EItemParentMismatch);
+
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+    inventory::deposit_item(inv, refinery_id, refinery.key, character, item);
+}
+
+public fun withdraw_input_by_owner<T: key>(
+    refinery: &mut Refinery,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    type_id: u64,
+    quantity: u32,
+    ctx: &mut TxContext,
+): Item {
+    assert!(character.character_address() == ctx.sender(), ESenderCannotAccessCharacter);
+    check_owner_cap_generic(refinery, owner_cap);
+    let refinery_id = object::id(refinery);
+    assert!(refinery.status.is_online(), ENotOnline);
+
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+    inventory::withdraw_item(
+        inv,
+        refinery_id,
+        refinery.key,
+        character,
+        type_id,
+        quantity,
+        refinery.location.hash(),
+        ctx,
+    )
+}
+
+// === Jobs ===
+
+/// Extension-gated. Looks up a recipe by `input_type_id`, consumes
+/// `recipe.input_quantity` from inventory, and records the job start.
+public fun start_job<Auth: drop>(
+    refinery: &mut Refinery,
+    character: &Character,
+    recipes: &RecipeRegistry,
+    clock: &Clock,
+    input_type_id: u64,
+    _: Auth,
+    ctx: &mut TxContext,
+) {
+    check_extension_authorized<Auth>(refinery);
+    start_job_internal(refinery, character, recipes, clock, input_type_id, ctx);
+}
+
+public fun start_job_by_owner<T: key>(
+    refinery: &mut Refinery,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    recipes: &RecipeRegistry,
+    clock: &Clock,
+    input_type_id: u64,
+    ctx: &mut TxContext,
+) {
+    assert!(character.character_address() == ctx.sender(), ESenderCannotAccessCharacter);
+    check_owner_cap_generic(refinery, owner_cap);
+    start_job_internal(refinery, character, recipes, clock, input_type_id, ctx);
+}
+
+/// Extension-gated. Mints recipe outputs into the inventory and clears the active job.
+public fun claim_outputs<Auth: drop>(
+    refinery: &mut Refinery,
+    character: &Character,
+    clock: &Clock,
+    _: Auth,
+    _: &mut TxContext,
+) {
+    check_extension_authorized<Auth>(refinery);
+    claim_outputs_internal(refinery, character, clock);
+}
+
+public fun claim_outputs_by_owner<T: key>(
+    refinery: &mut Refinery,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    assert!(character.character_address() == ctx.sender(), ESenderCannotAccessCharacter);
+    check_owner_cap_generic(refinery, owner_cap);
+    claim_outputs_internal(refinery, character, clock);
+}
+
+// === Views ===
+
+public fun id(refinery: &Refinery): ID { object::id(refinery) }
+public fun key(refinery: &Refinery): TenantItemId { refinery.key }
+public fun owner_cap_id(refinery: &Refinery): ID { refinery.owner_cap_id }
+public fun type_id(refinery: &Refinery): u64 { refinery.type_id }
+public fun status(refinery: &Refinery): &AssemblyStatus { &refinery.status }
+public fun location(refinery: &Refinery): &Location { &refinery.location }
+public fun energy_source_id(refinery: &Refinery): &Option<ID> { &refinery.energy_source_id }
+public fun has_active_job(refinery: &Refinery): bool { refinery.active_job.is_some() }
+public fun active_job(refinery: &Refinery): &Option<Job> { &refinery.active_job }
+
+public fun job_input_type_id(job: &Job): u64 { job.input_type_id }
+public fun job_input_quantity(job: &Job): u32 { job.input_quantity }
+public fun job_output_type_ids(job: &Job): &vector<u64> { &job.output_type_ids }
+public fun job_output_quantities(job: &Job): &vector<u32> { &job.output_quantities }
+public fun job_started_at_ms(job: &Job): u64 { job.started_at_ms }
+public fun job_finishes_at_ms(job: &Job): u64 { job.finishes_at_ms }
+
+public fun inventory(refinery: &Refinery, owner_cap_id: ID): &Inventory {
+    df::borrow(&refinery.id, owner_cap_id)
+}
+
+#[test_only]
+public fun item_quantity(refinery: &Refinery, owner_cap_id: ID, type_id: u64): u32 {
+    let inv = df::borrow<ID, Inventory>(&refinery.id, owner_cap_id);
+    inv.item_quantity(type_id)
+}
+
+// === Internal ===
+
+fun check_extension_authorized<Auth: drop>(refinery: &Refinery) {
+    assert!(refinery.extension.is_some(), EExtensionNotAuthorized);
+    let expected = type_name::with_defining_ids<Auth>();
+    assert!(*refinery.extension.borrow() == expected, EExtensionNotAuthorized);
+}
+
+fun check_owner_cap(refinery: &Refinery, owner_cap: &OwnerCap<Refinery>) {
+    assert!(object::id(owner_cap) == refinery.owner_cap_id, EInventoryNotAuthorized);
+}
+
+fun check_owner_cap_generic<T: key>(refinery: &Refinery, owner_cap: &OwnerCap<T>) {
+    assert!(object::id(owner_cap) == refinery.owner_cap_id, EInventoryNotAuthorized);
+}
+
+fun start_job_internal(
+    refinery: &mut Refinery,
+    character: &Character,
+    recipes: &RecipeRegistry,
+    clock: &Clock,
+    input_type_id: u64,
+    _ctx: &mut TxContext,
+) {
+    assert!(refinery.status.is_online(), ENotOnline);
+    assert!(refinery.active_job.is_none(), EJobInProgress);
+    assert!(recipe::has_recipe(recipes, input_type_id), ERecipeNotFound);
+
+    let r = recipe::borrow_recipe(recipes, input_type_id);
+    let needed = recipe::input_quantity(r);
+    let processing = recipe::processing_time_ms(r);
+    let output_type_ids = *recipe::output_type_ids(r);
+    let output_quantities = *recipe::output_quantities(r);
+
+    let refinery_id = object::id(refinery);
+    let location_hash = refinery.location.hash();
+    let refinery_key = refinery.key;
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+
+    // `inventory::withdraw_item` aborts with EInventoryInsufficientQuantity if there
+    // isn't enough input on hand — no separate pre-check needed (and there's no
+    // non-test-only quantity reader on Inventory today).
+    // Consume the input by withdrawing then immediately sink-transferring the transit Item.
+    let consumed = inventory::withdraw_item(
+        inv,
+        refinery_id,
+        refinery_key,
+        character,
+        input_type_id,
+        needed,
+        location_hash,
+        _ctx,
+    );
+    // Sink the transit Item to 0x0 — input has been logically consumed.
+    // NB: a public `inventory::destroy_item` would be cleaner; sink-transfer works
+    // because Items at 0x0 are unreachable from any character-derived inventory key.
+    transfer::public_transfer(consumed, @0x0);
+
+    let now_ms = clock.timestamp_ms();
+    let job = Job {
+        input_type_id,
+        input_quantity: needed,
+        output_type_ids,
+        output_quantities,
+        started_at_ms: now_ms,
+        finishes_at_ms: now_ms + processing,
+    };
+    refinery.active_job = option::some(job);
+
+    event::emit(JobStartedEvent {
+        refinery_id,
+        assembly_key: refinery.key,
+        character_id: character.id(),
+        input_type_id,
+        input_quantity: needed,
+        started_at_ms: now_ms,
+        finishes_at_ms: now_ms + processing,
+        output_type_ids,
+        output_quantities,
+    });
+}
+
+fun claim_outputs_internal(
+    refinery: &mut Refinery,
+    character: &Character,
+    clock: &Clock,
+) {
+    assert!(refinery.status.is_online(), ENotOnline);
+    assert!(refinery.active_job.is_some(), ENoActiveJob);
+    let now_ms = clock.timestamp_ms();
+    let job_ref = refinery.active_job.borrow();
+    assert!(now_ms >= job_ref.finishes_at_ms, EJobNotComplete);
+
+    let job = refinery.active_job.extract();
+    let Job {
+        input_type_id,
+        input_quantity: _,
+        output_type_ids,
+        output_quantities,
+        started_at_ms: _,
+        finishes_at_ms: _,
+    } = job;
+
+    let refinery_id = object::id(refinery);
+    let tenant = refinery.key.tenant();
+    let refinery_key = refinery.key;
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+
+    let n = vector::length(&output_type_ids);
+    let mut i = 0;
+    while (i < n) {
+        let out_type = *vector::borrow(&output_type_ids, i);
+        let out_qty = *vector::borrow(&output_quantities, i);
+        // Placeholder item_id; production code should use a counter on the refinery
+        // for stable item_ids — left as a follow-up.
+        let placeholder_item_id = out_type;
+        // Volume of 1 is a sentinel; the first ever mint at this type_id locks volume.
+        inventory::mint_items(
+            inv,
+            refinery_id,
+            refinery_key,
+            character,
+            tenant,
+            placeholder_item_id,
+            out_type,
+            1,
+            out_qty,
+        );
+        i = i + 1;
+    };
+
+    event::emit(JobClaimedEvent {
+        refinery_id,
+        assembly_key: refinery.key,
+        character_id: character.id(),
+        input_type_id,
+        output_type_ids,
+        output_quantities,
+        claimed_at_ms: now_ms,
+    });
+}
+

--- a/contracts/world/sources/assemblies/refinery.move
+++ b/contracts/world/sources/assemblies/refinery.move
@@ -471,6 +471,41 @@ public fun item_quantity(refinery: &Refinery, owner_cap_id: ID, type_id: u64): u
     inv.item_quantity(type_id)
 }
 
+#[test_only]
+public fun has_authorized_extension(refinery: &Refinery): bool {
+    refinery.extension.is_some()
+}
+
+#[test_only]
+public fun contains_item(refinery: &Refinery, owner_cap_id: ID, type_id: u64): bool {
+    let inv = df::borrow<ID, Inventory>(&refinery.id, owner_cap_id);
+    inv.contains_item(type_id)
+}
+
+/// Test-only mint of items directly into the refinery's main inventory.
+/// Mirrors `storage_unit::game_item_to_chain_inventory_test` — used by
+/// integration tests to seed input ore without going through the full
+/// off-chain item creation flow.
+#[test_only]
+public fun mint_input_for_testing<T: key>(
+    refinery: &mut Refinery,
+    character: &Character,
+    owner_cap: &OwnerCap<T>,
+    item_id: u64,
+    type_id: u64,
+    volume: u64,
+    quantity: u32,
+    ctx: &mut TxContext,
+) {
+    assert!(character.character_address() == ctx.sender(), ESenderCannotAccessCharacter);
+    check_owner_cap_generic(refinery, owner_cap);
+    let refinery_id = object::id(refinery);
+    let refinery_key = refinery.key;
+    let tenant = refinery_key.tenant();
+    let inv = df::borrow_mut<ID, Inventory>(&mut refinery.id, refinery.owner_cap_id);
+    inv.mint_items(refinery_id, refinery_key, character, tenant, item_id, type_id, volume, quantity);
+}
+
 // === Internal ===
 
 fun check_extension_authorized<Auth: drop>(refinery: &Refinery) {

--- a/contracts/world/sources/primitives/recipe.move
+++ b/contracts/world/sources/primitives/recipe.move
@@ -1,0 +1,245 @@
+// Recipe registry — describes how a refinery converts one input item type into a set of
+// output item types over a defined processing time.
+//
+// Recipes are admin-curated. Each `Recipe` is keyed by the input `type_id`, so a refinery
+// only needs to know its input slot's type to look up what it can produce. A single recipe
+// can produce **multiple** output types (e.g. ore → tritanium + pyerite + waste).
+//
+// # Bridging
+//
+// Like other on-chain data, the source of truth for which recipes exist is the game server,
+// which mints them into the on-chain `RecipeRegistry` via `register_recipe`. The registry
+// is a shared object so any assembly that needs to consult a recipe can do so.
+//
+// # Quantity semantics
+//
+// `input_quantity` is the *minimum batch size* — `refinery::start_job` consumes exactly
+// this many units of the input per job. Output quantities are per-batch.
+//
+// # Future
+//
+// - Variable-yield recipes (RNG output bands).
+// - Per-character efficiency modifiers (skills, ship bonuses).
+// - Per-refinery throughput modifiers.
+// - Multiple inputs per recipe.
+module world::recipe;
+
+use std::string::String;
+use sui::{dynamic_field as df, event};
+use world::access::AdminACL;
+
+// === Errors ===
+#[error(code = 0)]
+const ERecipeAlreadyExists: vector<u8> = b"Recipe for this input type already exists";
+#[error(code = 1)]
+const ERecipeNotFound: vector<u8> = b"Recipe not found for the given input type";
+#[error(code = 2)]
+const ERecipeInvalid: vector<u8> = b"Recipe must specify a non-zero input quantity and processing time";
+#[error(code = 3)]
+const ERecipeOutputsEmpty: vector<u8> = b"Recipe must have at least one output";
+#[error(code = 4)]
+const ERecipeInputTypeMismatch: vector<u8> = b"Recipe input type does not match its registry key";
+
+// === Structs ===
+
+/// Shared registry holding every refinery recipe. Keyed by input `type_id`.
+public struct RecipeRegistry has key {
+    id: UID,
+}
+
+/// A single conversion rule. Stored as a dynamic field value on `RecipeRegistry`,
+/// keyed by `RecipeKey { input_type_id }`.
+///
+/// `outputs` is parallel: `output_type_ids[i]` is produced in `output_quantities[i]`
+/// units per batch.
+public struct Recipe has copy, drop, store {
+    name: String,
+    input_type_id: u64,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    processing_time_ms: u64,
+}
+
+/// Dynamic-field key for `Recipe` lookup.
+public struct RecipeKey has copy, drop, store {
+    input_type_id: u64,
+}
+
+// === Events ===
+
+public struct RecipeRegisteredEvent has copy, drop {
+    input_type_id: u64,
+    name: String,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    processing_time_ms: u64,
+}
+
+public struct RecipeUpdatedEvent has copy, drop {
+    input_type_id: u64,
+    name: String,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    processing_time_ms: u64,
+}
+
+public struct RecipeRemovedEvent has copy, drop {
+    input_type_id: u64,
+}
+
+// === Init ===
+
+fun init(ctx: &mut TxContext) {
+    transfer::share_object(RecipeRegistry { id: object::new(ctx) });
+}
+
+#[test_only]
+public fun init_for_testing(ctx: &mut TxContext) {
+    init(ctx);
+}
+
+// === Admin ===
+
+public fun register_recipe(
+    registry: &mut RecipeRegistry,
+    admin_acl: &AdminACL,
+    name: String,
+    input_type_id: u64,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    processing_time_ms: u64,
+    ctx: &TxContext,
+) {
+    admin_acl.verify_sponsor(ctx);
+    validate_recipe_args(
+        input_type_id,
+        input_quantity,
+        &output_type_ids,
+        &output_quantities,
+        processing_time_ms,
+    );
+    let key = RecipeKey { input_type_id };
+    assert!(!df::exists_(&registry.id, key), ERecipeAlreadyExists);
+    let recipe = Recipe {
+        name,
+        input_type_id,
+        input_quantity,
+        output_type_ids,
+        output_quantities,
+        processing_time_ms,
+    };
+    df::add(&mut registry.id, key, recipe);
+
+    event::emit(RecipeRegisteredEvent {
+        input_type_id,
+        name,
+        input_quantity,
+        output_type_ids,
+        output_quantities,
+        processing_time_ms,
+    });
+}
+
+/// Overwrite an existing recipe. Aborts if no recipe is registered for `input_type_id`.
+public fun update_recipe(
+    registry: &mut RecipeRegistry,
+    admin_acl: &AdminACL,
+    name: String,
+    input_type_id: u64,
+    input_quantity: u32,
+    output_type_ids: vector<u64>,
+    output_quantities: vector<u32>,
+    processing_time_ms: u64,
+    ctx: &TxContext,
+) {
+    admin_acl.verify_sponsor(ctx);
+    validate_recipe_args(
+        input_type_id,
+        input_quantity,
+        &output_type_ids,
+        &output_quantities,
+        processing_time_ms,
+    );
+    let key = RecipeKey { input_type_id };
+    assert!(df::exists_(&registry.id, key), ERecipeNotFound);
+    let _old: Recipe = df::remove(&mut registry.id, key);
+    let recipe = Recipe {
+        name,
+        input_type_id,
+        input_quantity,
+        output_type_ids,
+        output_quantities,
+        processing_time_ms,
+    };
+    df::add(&mut registry.id, key, recipe);
+
+    event::emit(RecipeUpdatedEvent {
+        input_type_id,
+        name,
+        input_quantity,
+        output_type_ids,
+        output_quantities,
+        processing_time_ms,
+    });
+}
+
+public fun remove_recipe(
+    registry: &mut RecipeRegistry,
+    admin_acl: &AdminACL,
+    input_type_id: u64,
+    ctx: &TxContext,
+) {
+    admin_acl.verify_sponsor(ctx);
+    let key = RecipeKey { input_type_id };
+    assert!(df::exists_(&registry.id, key), ERecipeNotFound);
+    let _removed: Recipe = df::remove(&mut registry.id, key);
+    event::emit(RecipeRemovedEvent { input_type_id });
+}
+
+// === Views ===
+
+public fun has_recipe(registry: &RecipeRegistry, input_type_id: u64): bool {
+    df::exists_(&registry.id, RecipeKey { input_type_id })
+}
+
+public fun borrow_recipe(registry: &RecipeRegistry, input_type_id: u64): &Recipe {
+    let key = RecipeKey { input_type_id };
+    assert!(df::exists_(&registry.id, key), ERecipeNotFound);
+    df::borrow<RecipeKey, Recipe>(&registry.id, key)
+}
+
+public fun name(recipe: &Recipe): String { recipe.name }
+public fun input_type_id(recipe: &Recipe): u64 { recipe.input_type_id }
+public fun input_quantity(recipe: &Recipe): u32 { recipe.input_quantity }
+public fun output_type_ids(recipe: &Recipe): &vector<u64> { &recipe.output_type_ids }
+public fun output_quantities(recipe: &Recipe): &vector<u32> { &recipe.output_quantities }
+public fun processing_time_ms(recipe: &Recipe): u64 { recipe.processing_time_ms }
+
+// === Internal ===
+
+fun validate_recipe_args(
+    input_type_id: u64,
+    input_quantity: u32,
+    output_type_ids: &vector<u64>,
+    output_quantities: &vector<u32>,
+    processing_time_ms: u64,
+) {
+    assert!(input_type_id != 0, ERecipeInvalid);
+    assert!(input_quantity > 0, ERecipeInvalid);
+    assert!(processing_time_ms > 0, ERecipeInvalid);
+    let n = vector::length(output_type_ids);
+    assert!(n > 0, ERecipeOutputsEmpty);
+    assert!(n == vector::length(output_quantities), ERecipeOutputsEmpty);
+    let mut i = 0;
+    while (i < n) {
+        assert!(*vector::borrow(output_type_ids, i) != 0, ERecipeInvalid);
+        assert!(*vector::borrow(output_quantities, i) > 0, ERecipeInvalid);
+        // Cannot reuse the input type_id as an output (avoids trivial loops)
+        assert!(*vector::borrow(output_type_ids, i) != input_type_id, ERecipeInputTypeMismatch);
+        i = i + 1;
+    };
+}

--- a/contracts/world/tests/assemblies/refinery_tests.move
+++ b/contracts/world/tests/assemblies/refinery_tests.move
@@ -1,0 +1,30 @@
+#[test_only]
+module world::refinery_tests;
+
+// Skeleton tests for the refinery module — happy-path anchor + extension witness
+// authorization. Full job-loop tests (start_job/claim_outputs with a real Clock
+// and the inventory mint round-trip) are deferred to a follow-up since they
+// require the same character / network-node / energy-source scaffolding used in
+// the storage_unit test suite.
+//
+// TODO: port the SU test bootstrap (test_helpers::setup_world + setup_owner_cap
+// + setup_character + setup_network_node + setup_energy) into a refinery setup
+// helper. Then cover:
+//   - anchor() creates Refinery with one inventory
+//   - online()/offline() flips status
+//   - authorize_extension<XAuth>() registers the witness
+//   - deposit_input_by_owner / withdraw_input_by_owner round-trip
+//   - start_job consumes input, sets active_job
+//   - claim_outputs before finishes_at aborts EJobNotComplete
+//   - claim_outputs after finishes_at mints recipe outputs into inventory
+//   - second start_job while a job is active aborts EJobInProgress
+
+use std::unit_test::assert_eq;
+// use world::refinery;  // full job-loop tests pending (see TODO above)
+
+/// Placeholder until full job-loop coverage lands. Keeps the test target
+/// non-empty and confirms the module compiles under `sui move test`.
+#[test]
+fun module_compiles() {
+    assert_eq!(1u8, 1u8);
+}

--- a/contracts/world/tests/assemblies/refinery_tests.move
+++ b/contracts/world/tests/assemblies/refinery_tests.move
@@ -1,30 +1,480 @@
 #[test_only]
 module world::refinery_tests;
 
-// Skeleton tests for the refinery module — happy-path anchor + extension witness
-// authorization. Full job-loop tests (start_job/claim_outputs with a real Clock
-// and the inventory mint round-trip) are deferred to a follow-up since they
-// require the same character / network-node / energy-source scaffolding used in
-// the storage_unit test suite.
+// Integration tests for the refinery module. Covers happy-path job lifecycle
+// (anchor → online → mint input → start_job → advance clock → claim_outputs)
+// plus the key abort conditions (EJobInProgress, EJobNotComplete, ENoActiveJob,
+// ENotOnline, ERecipeNotFound).
 //
-// TODO: port the SU test bootstrap (test_helpers::setup_world + setup_owner_cap
-// + setup_character + setup_network_node + setup_energy) into a refinery setup
-// helper. Then cover:
-//   - anchor() creates Refinery with one inventory
-//   - online()/offline() flips status
-//   - authorize_extension<XAuth>() registers the witness
-//   - deposit_input_by_owner / withdraw_input_by_owner round-trip
-//   - start_job consumes input, sets active_job
-//   - claim_outputs before finishes_at aborts EJobNotComplete
-//   - claim_outputs after finishes_at mints recipe outputs into inventory
-//   - second start_job while a job is active aborts EJobInProgress
+// Pattern mirrors `storage_unit_tests.move` for setup (character + network
+// node + fuel + energy). Refinery-specific helpers live in this file.
 
+use std::string::{utf8, String};
 use std::unit_test::assert_eq;
-// use world::refinery;  // full job-loop tests pending (see TODO above)
+use sui::{clock::{Self, Clock}, derived_object, test_scenario as ts};
+use world::{
+    access::{Self, OwnerCap, AdminACL},
+    character::{Self, Character},
+    energy::EnergyConfig,
+    fuel::FuelConfig,
+    in_game_id,
+    network_node::{Self, NetworkNode},
+    object_registry::ObjectRegistry,
+    recipe::{Self, RecipeRegistry},
+    refinery::{Self, Refinery},
+    test_helpers::{Self, admin, user_a, tenant}
+};
 
-/// Placeholder until full job-loop coverage lands. Keeps the test target
-/// non-empty and confirms the module compiles under `sui move test`.
+// === Test constants ===
+
+const LOCATION_HASH: vector<u8> =
+    x"7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
+const MAX_CAPACITY: u64 = 100000;
+
+// Character / Network Node
+const CHARACTER_ITEM_ID: u32 = 1234u32;
+const MS_PER_SECOND: u64 = 1000;
+const NWN_TYPE_ID: u64 = 111000;
+const NWN_ITEM_ID: u64 = 5000;
+const FUEL_MAX_CAPACITY: u64 = 1000;
+const FUEL_BURN_RATE_IN_MS: u64 = 3600 * MS_PER_SECOND;
+const MAX_PRODUCTION: u64 = 100;
+const FUEL_TYPE_ID: u64 = 1;
+const FUEL_VOLUME: u64 = 10;
+
+// Refinery — uses ASSEMBLY_TYPE_1 from test_helpers so EnergyConfig already covers it
+const REFINERY_ITEM_ID: u64 = 90100;
+
+// Recipe
+const ORE_TYPE_ID: u64 = 77811; // Hydrated Sulfide Matrix
+const ORE_ITEM_ID: u64 = 1000007139741;
+const ORE_VOLUME: u64 = 100;
+const BATCH_INPUT_QTY: u32 = 40;
+const HYDROCARBON_RESIDUE_TYPE_ID: u64 = 84001;
+const WATER_ICE_TYPE_ID: u64 = 84002;
+const HYDROCARBON_RESIDUE_QTY: u32 = 20;
+const WATER_ICE_QTY: u32 = 300;
+const PROCESSING_TIME_MS: u64 = 3000;
+
+// Other constants
+const STATUS_ONLINE: u8 = 1;
+
+// Mock extension witness
+public struct TestAuth has drop {}
+
+// === Setup helpers ===
+
+fun setup_world_with_recipes(ts: &mut ts::Scenario) {
+    test_helpers::setup_world(ts);
+    test_helpers::configure_fuel(ts);
+    test_helpers::configure_assembly_energy(ts);
+    test_helpers::register_server_address(ts);
+    // initialize the RecipeRegistry as a shared object (genesis stand-in)
+    ts::next_tx(ts, test_helpers::governor());
+    recipe::init_for_testing(ts.ctx());
+}
+
+fun register_hydrated_sulfide_recipe(ts: &mut ts::Scenario) {
+    ts::next_tx(ts, admin());
+    let mut registry = ts::take_shared<RecipeRegistry>(ts);
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+    recipe::register_recipe(
+        &mut registry,
+        &admin_acl,
+        utf8(b"Hydrated Sulfide Matrix"),
+        ORE_TYPE_ID,
+        BATCH_INPUT_QTY,
+        vector[HYDROCARBON_RESIDUE_TYPE_ID, WATER_ICE_TYPE_ID],
+        vector[HYDROCARBON_RESIDUE_QTY, WATER_ICE_QTY],
+        PROCESSING_TIME_MS,
+        ts.ctx(),
+    );
+    ts::return_shared(registry);
+    ts::return_shared(admin_acl);
+}
+
+fun create_character(ts: &mut ts::Scenario): ID {
+    ts::next_tx(ts, admin());
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let character = character::create_character(
+        &mut registry,
+        &admin_acl,
+        CHARACTER_ITEM_ID,
+        tenant(),
+        100,
+        user_a(),
+        utf8(b"refinery-test-character"),
+        ts.ctx(),
+    );
+    let character_id = object::id(&character);
+    character.share_character(&admin_acl, ts.ctx());
+    ts::return_shared(registry);
+    ts::return_shared(admin_acl);
+    character_id
+}
+
+fun create_network_node(ts: &mut ts::Scenario, character_id: ID): ID {
+    ts::next_tx(ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let character = ts::take_shared_by_id<Character>(ts, character_id);
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+    let nwn = network_node::anchor(
+        &mut registry,
+        &character,
+        &admin_acl,
+        NWN_ITEM_ID,
+        NWN_TYPE_ID,
+        LOCATION_HASH,
+        FUEL_MAX_CAPACITY,
+        FUEL_BURN_RATE_IN_MS,
+        MAX_PRODUCTION,
+        ts.ctx(),
+    );
+    let id = object::id(&nwn);
+    nwn.share_network_node(&admin_acl, ts.ctx());
+    ts::return_shared(character);
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+    id
+}
+
+fun create_refinery(ts: &mut ts::Scenario, character_id: ID, nwn_id: ID): ID {
+    ts::next_tx(ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(ts);
+    let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+    let character = ts::take_shared_by_id<Character>(ts, character_id);
+    let admin_acl = ts::take_shared<AdminACL>(ts);
+    let refinery = refinery::anchor(
+        &mut registry,
+        &mut nwn,
+        &character,
+        &admin_acl,
+        REFINERY_ITEM_ID,
+        test_helpers::assembly_type_1(),
+        MAX_CAPACITY,
+        LOCATION_HASH,
+        ts.ctx(),
+    );
+    let refinery_id = object::id(&refinery);
+    refinery.share_refinery(&admin_acl, ts.ctx());
+    ts::return_shared(character);
+    ts::return_shared(nwn);
+    ts::return_shared(registry);
+    ts::return_shared(admin_acl);
+    refinery_id
+}
+
+fun online_refinery(
+    ts: &mut ts::Scenario,
+    user: address,
+    character_id: ID,
+    refinery_id: ID,
+    nwn_id: ID,
+    clock: &Clock,
+) {
+    // bring NWN online with fuel
+    ts::next_tx(ts, user);
+    let mut character = ts::take_shared_by_id<Character>(ts, character_id);
+    let (nwn_cap, nwn_receipt) = character.borrow_owner_cap<NetworkNode>(
+        ts::most_recent_receiving_ticket<OwnerCap<NetworkNode>>(&character_id),
+        ts.ctx(),
+    );
+    ts::next_tx(ts, user);
+    {
+        let mut nwn = ts::take_shared_by_id<NetworkNode>(ts, nwn_id);
+        nwn.deposit_fuel_test(&nwn_cap, FUEL_TYPE_ID, FUEL_VOLUME, 10, clock);
+        nwn.online(&nwn_cap, clock);
+        ts::return_shared(nwn);
+    };
+    character.return_owner_cap(nwn_cap, nwn_receipt);
+
+    // bring refinery online
+    ts::next_tx(ts, user);
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(ts, refinery_id);
+        let (ref_cap, ref_receipt) = character.borrow_owner_cap<Refinery>(
+            ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+            ts.ctx(),
+        );
+        refinery.online(&ref_cap);
+        let status = refinery.status();
+        assert_eq!(status.status_to_u8(), STATUS_ONLINE);
+        character.return_owner_cap(ref_cap, ref_receipt);
+        ts::return_shared(refinery);
+    };
+    ts::return_shared(character);
+}
+
+fun mint_ore_into_refinery(
+    ts: &mut ts::Scenario,
+    user: address,
+    character_id: ID,
+    refinery_id: ID,
+    quantity: u32,
+) {
+    ts::next_tx(ts, user);
+    let mut character = ts::take_shared_by_id<Character>(ts, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        ts.ctx(),
+    );
+    ts::next_tx(ts, user);
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(ts, refinery_id);
+        refinery.mint_input_for_testing<Refinery>(
+            &character,
+            &cap,
+            ORE_ITEM_ID,
+            ORE_TYPE_ID,
+            ORE_VOLUME,
+            quantity,
+            ts.ctx(),
+        );
+        ts::return_shared(refinery);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+}
+
+fun authorize_test_extension(
+    ts: &mut ts::Scenario,
+    user: address,
+    character_id: ID,
+    refinery_id: ID,
+) {
+    ts::next_tx(ts, user);
+    let mut character = ts::take_shared_by_id<Character>(ts, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        ts.ctx(),
+    );
+    ts::next_tx(ts, user);
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(ts, refinery_id);
+        refinery.authorize_extension<TestAuth>(&cap);
+        assert_eq!(refinery.has_authorized_extension(), true);
+        ts::return_shared(refinery);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+}
+
+/// Bring everything online and return (refinery_id, nwn_id, character_id).
+fun bootstrap(ts: &mut ts::Scenario, clock: &Clock): (ID, ID, ID) {
+    setup_world_with_recipes(ts);
+    register_hydrated_sulfide_recipe(ts);
+    let character_id = create_character(ts);
+    let nwn_id = create_network_node(ts, character_id);
+    let refinery_id = create_refinery(ts, character_id, nwn_id);
+    online_refinery(ts, user_a(), character_id, refinery_id, nwn_id, clock);
+    (refinery_id, nwn_id, character_id)
+}
+
+// === Tests ===
+
 #[test]
-fun module_compiles() {
-    assert_eq!(1u8, 1u8);
+fun anchor_creates_refinery_with_inventory() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let clock = clock::create_for_testing(scenario.ctx());
+    let (refinery_id, _nwn_id, _character_id) = bootstrap(&mut scenario, &clock);
+
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        assert_eq!(refinery.status().status_to_u8(), STATUS_ONLINE);
+        assert_eq!(refinery.has_active_job(), false);
+        ts::return_shared(refinery);
+    };
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test]
+fun authorize_extension_registers_witness() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let clock = clock::create_for_testing(scenario.ctx());
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+    authorize_test_extension(&mut scenario, user_a(), character_id, refinery_id);
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test]
+fun full_job_lifecycle_by_owner() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1_000_000); // arbitrary non-zero start
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+
+    // Seed input (40 of ORE_TYPE_ID = 1 batch)
+    mint_ore_into_refinery(&mut scenario, user_a(), character_id, refinery_id, BATCH_INPUT_QTY);
+
+    // start_job_by_owner
+    ts::next_tx(&mut scenario, user_a());
+    let mut character = ts::take_shared_by_id<Character>(&scenario, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        scenario.ctx(),
+    );
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        let recipes = ts::take_shared<RecipeRegistry>(&scenario);
+        refinery.start_job_by_owner<Refinery>(
+            &character,
+            &cap,
+            &recipes,
+            &clock,
+            ORE_TYPE_ID,
+            scenario.ctx(),
+        );
+        assert_eq!(refinery.has_active_job(), true);
+        // Input was consumed (we minted exactly one batch). VecMap removes the
+        // entry when qty drops to 0, so we check absence via contains_item.
+        let owner_cap_id = refinery.owner_cap_id();
+        assert_eq!(refinery.contains_item(owner_cap_id, ORE_TYPE_ID), false);
+        ts::return_shared(refinery);
+        ts::return_shared(recipes);
+    };
+
+    // Fast-forward past finishes_at_ms (recipe is 3000ms; jump 5000ms)
+    clock.increment_for_testing(5000);
+
+    // claim_outputs_by_owner
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        refinery.claim_outputs_by_owner<Refinery>(&character, &cap, &clock, scenario.ctx());
+        assert_eq!(refinery.has_active_job(), false);
+
+        let owner_cap_id = refinery.owner_cap_id();
+        assert_eq!(refinery.item_quantity(owner_cap_id, HYDROCARBON_RESIDUE_TYPE_ID), HYDROCARBON_RESIDUE_QTY);
+        assert_eq!(refinery.item_quantity(owner_cap_id, WATER_ICE_TYPE_ID), WATER_ICE_QTY);
+        ts::return_shared(refinery);
+    };
+
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = refinery::EJobInProgress)]
+fun double_start_aborts() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1_000_000);
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+    mint_ore_into_refinery(&mut scenario, user_a(), character_id, refinery_id, BATCH_INPUT_QTY * 2);
+
+    ts::next_tx(&mut scenario, user_a());
+    let mut character = ts::take_shared_by_id<Character>(&scenario, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        scenario.ctx(),
+    );
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        let recipes = ts::take_shared<RecipeRegistry>(&scenario);
+        refinery.start_job_by_owner<Refinery>(&character, &cap, &recipes, &clock, ORE_TYPE_ID, scenario.ctx());
+        // Second start while the first is still active — should abort
+        refinery.start_job_by_owner<Refinery>(&character, &cap, &recipes, &clock, ORE_TYPE_ID, scenario.ctx());
+        ts::return_shared(refinery);
+        ts::return_shared(recipes);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = refinery::EJobNotComplete)]
+fun claim_before_finish_aborts() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1_000_000);
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+    mint_ore_into_refinery(&mut scenario, user_a(), character_id, refinery_id, BATCH_INPUT_QTY);
+
+    ts::next_tx(&mut scenario, user_a());
+    let mut character = ts::take_shared_by_id<Character>(&scenario, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        scenario.ctx(),
+    );
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        let recipes = ts::take_shared<RecipeRegistry>(&scenario);
+        refinery.start_job_by_owner<Refinery>(&character, &cap, &recipes, &clock, ORE_TYPE_ID, scenario.ctx());
+        // claim without advancing clock — should abort EJobNotComplete
+        refinery.claim_outputs_by_owner<Refinery>(&character, &cap, &clock, scenario.ctx());
+        ts::return_shared(refinery);
+        ts::return_shared(recipes);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = refinery::ENoActiveJob)]
+fun claim_with_no_job_aborts() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let clock = clock::create_for_testing(scenario.ctx());
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+
+    ts::next_tx(&mut scenario, user_a());
+    let mut character = ts::take_shared_by_id<Character>(&scenario, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        scenario.ctx(),
+    );
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        // Never started a job — claim should abort ENoActiveJob
+        refinery.claim_outputs_by_owner<Refinery>(&character, &cap, &clock, scenario.ctx());
+        ts::return_shared(refinery);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = refinery::ERecipeNotFound)]
+fun start_unknown_recipe_aborts() {
+    let mut scenario = ts::begin(test_helpers::governor());
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1_000_000);
+    let (refinery_id, _nwn_id, character_id) = bootstrap(&mut scenario, &clock);
+
+    ts::next_tx(&mut scenario, user_a());
+    let mut character = ts::take_shared_by_id<Character>(&scenario, character_id);
+    let (cap, receipt) = character.borrow_owner_cap<Refinery>(
+        ts::most_recent_receiving_ticket<OwnerCap<Refinery>>(&character_id),
+        scenario.ctx(),
+    );
+    ts::next_tx(&mut scenario, user_a());
+    {
+        let mut refinery = ts::take_shared_by_id<Refinery>(&scenario, refinery_id);
+        let recipes = ts::take_shared<RecipeRegistry>(&scenario);
+        // Use a type_id we never registered
+        refinery.start_job_by_owner<Refinery>(&character, &cap, &recipes, &clock, 999_999u64, scenario.ctx());
+        ts::return_shared(refinery);
+        ts::return_shared(recipes);
+    };
+    character.return_owner_cap(cap, receipt);
+    ts::return_shared(character);
+
+    clock.destroy_for_testing();
+    ts::end(scenario);
 }

--- a/contracts/world/tests/primitives/recipe_tests.move
+++ b/contracts/world/tests/primitives/recipe_tests.move
@@ -1,0 +1,179 @@
+#[test_only]
+module world::recipe_tests;
+
+use std::string;
+use std::unit_test::assert_eq;
+use sui::test_scenario as ts;
+use world::{
+    access::AdminACL,
+    recipe::{Self, RecipeRegistry},
+    test_helpers::{Self, governor, admin}
+};
+
+const ORE_TYPE_ID: u64 = 1234;
+const TRIT_TYPE_ID: u64 = 34;
+const PYE_TYPE_ID: u64 = 35;
+const MEX_TYPE_ID: u64 = 36;
+
+fun setup(): ts::Scenario {
+    let mut scenario = ts::begin(governor());
+    test_helpers::setup_world(&mut scenario);
+    // recipe::init runs at publish time via genesis. For tests we need a registry.
+    ts::next_tx(&mut scenario, governor());
+    recipe::init_for_testing(scenario.ctx());
+    scenario
+}
+
+#[test]
+fun register_and_lookup_recipe() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let mut registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let admin_acl = ts::take_shared<AdminACL>(&scenario);
+        recipe::register_recipe(
+            &mut registry,
+            &admin_acl,
+            string::utf8(b"Common Ore Refining"),
+            ORE_TYPE_ID,
+            100,
+            vector[TRIT_TYPE_ID, PYE_TYPE_ID, MEX_TYPE_ID],
+            vector[60, 30, 10],
+            60_000,
+            scenario.ctx(),
+        );
+
+        assert_eq!(recipe::has_recipe(&registry, ORE_TYPE_ID), true);
+        assert_eq!(recipe::has_recipe(&registry, 9999), false);
+
+        let r = recipe::borrow_recipe(&registry, ORE_TYPE_ID);
+        assert_eq!(recipe::input_type_id(r), ORE_TYPE_ID);
+        assert_eq!(recipe::input_quantity(r), 100);
+        assert_eq!(recipe::processing_time_ms(r), 60_000);
+        assert_eq!(*recipe::output_type_ids(r), vector[TRIT_TYPE_ID, PYE_TYPE_ID, MEX_TYPE_ID]);
+        assert_eq!(*recipe::output_quantities(r), vector[60, 30, 10]);
+
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+fun update_recipe_overwrites_existing() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let mut registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let admin_acl = ts::take_shared<AdminACL>(&scenario);
+        recipe::register_recipe(
+            &mut registry,
+            &admin_acl,
+            string::utf8(b"v1"),
+            ORE_TYPE_ID,
+            100,
+            vector[TRIT_TYPE_ID],
+            vector[50],
+            60_000,
+            scenario.ctx(),
+        );
+        recipe::update_recipe(
+            &mut registry,
+            &admin_acl,
+            string::utf8(b"v2"),
+            ORE_TYPE_ID,
+            200,
+            vector[TRIT_TYPE_ID, PYE_TYPE_ID],
+            vector[75, 25],
+            30_000,
+            scenario.ctx(),
+        );
+        let r = recipe::borrow_recipe(&registry, ORE_TYPE_ID);
+        assert_eq!(recipe::input_quantity(r), 200);
+        assert_eq!(recipe::processing_time_ms(r), 30_000);
+        assert_eq!(vector::length(recipe::output_type_ids(r)), 2);
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+fun remove_recipe_clears_entry() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let mut registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let admin_acl = ts::take_shared<AdminACL>(&scenario);
+        recipe::register_recipe(
+            &mut registry,
+            &admin_acl,
+            string::utf8(b"to-remove"),
+            ORE_TYPE_ID,
+            10,
+            vector[TRIT_TYPE_ID],
+            vector[5],
+            1_000,
+            scenario.ctx(),
+        );
+        assert_eq!(recipe::has_recipe(&registry, ORE_TYPE_ID), true);
+        recipe::remove_recipe(&mut registry, &admin_acl, ORE_TYPE_ID, scenario.ctx());
+        assert_eq!(recipe::has_recipe(&registry, ORE_TYPE_ID), false);
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = recipe::ERecipeAlreadyExists)]
+fun double_register_aborts() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let mut registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let admin_acl = ts::take_shared<AdminACL>(&scenario);
+        recipe::register_recipe(
+            &mut registry, &admin_acl,
+            string::utf8(b"a"), ORE_TYPE_ID, 1, vector[TRIT_TYPE_ID], vector[1], 1, scenario.ctx(),
+        );
+        // Should abort:
+        recipe::register_recipe(
+            &mut registry, &admin_acl,
+            string::utf8(b"b"), ORE_TYPE_ID, 1, vector[TRIT_TYPE_ID], vector[1], 1, scenario.ctx(),
+        );
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = recipe::ERecipeNotFound)]
+fun borrow_missing_aborts() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let _ = recipe::borrow_recipe(&registry, 9999);
+        ts::return_shared(registry);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = recipe::ERecipeInputTypeMismatch)]
+fun input_in_outputs_aborts() {
+    let mut scenario = setup();
+    ts::next_tx(&mut scenario, admin());
+    {
+        let mut registry = ts::take_shared<RecipeRegistry>(&scenario);
+        let admin_acl = ts::take_shared<AdminACL>(&scenario);
+        // Output reuses input type_id — should abort
+        recipe::register_recipe(
+            &mut registry, &admin_acl,
+            string::utf8(b"loop"), ORE_TYPE_ID, 1,
+            vector[ORE_TYPE_ID], vector[1], 1, scenario.ctx(),
+        );
+        ts::return_shared(registry);
+        ts::return_shared(admin_acl);
+    };
+    ts::end(scenario);
+}

--- a/docs/adr/0001-refinery-and-recipe-modules.md
+++ b/docs/adr/0001-refinery-and-recipe-modules.md
@@ -1,0 +1,159 @@
+# ADR 0001: Refinery and Recipe Modules
+
+**Status:** Draft
+**Author:** community contributor (artokun)
+**Date:** 2026-05-15
+**Related:** Issue [#74 — \[Feat\] Mining System](https://github.com/evefrontier/world-contracts/issues/74)
+
+## Context
+
+EVE Frontier currently exposes three programmable Smart Assemblies on-chain:
+`storage_unit`, `gate`, and `turret`. Refineries exist as in-game structures but
+have no corresponding Move module — there is no on-chain surface for builders to
+write extensions against refining, and no automation primitive that converts one
+item type into others.
+
+Issue #74 lays out a community design for a full mining → hauling → processing
+pipeline. This ADR proposes the **on-chain processing slice** of that design as
+a self-contained first step:
+
+1. A `world::recipe` primitive — admin-curated registry of conversion rules.
+2. A `world::refinery` Smart Assembly — consumes input items per a registered
+   recipe and emits outputs after a processing delay.
+
+Out of scope for this ADR (deferred to follow-ups or Issue #74's broader work):
+mining (rock scanning, tractor extraction), hauling (volume/mass logistics),
+variable-yield outputs, multi-input recipes, throughput modifiers (skills,
+ships, fittings), and parallel jobs per refinery.
+
+## Decision
+
+### `world::recipe` (primitive)
+
+- One shared `RecipeRegistry` object published at genesis.
+- Each `Recipe` is keyed by `input_type_id` (1 input type per recipe v1).
+- A recipe declares `input_quantity` (batch size), `output_type_ids` /
+  `output_quantities` (parallel vectors), and `processing_time_ms`.
+- Admin-only mutation (`register_recipe`, `update_recipe`, `remove_recipe`)
+  gated by `AdminACL::verify_sponsor` — matching the existing pattern in
+  `fuel`/`energy`.
+- Validation: recipes must specify non-zero input quantity and processing
+  time, at least one output, distinct input vs output type ids (no trivial
+  loops).
+- View functions are non-test-only and free of side effects so extensions can
+  inspect recipes in their own logic.
+
+Stored as Sui dynamic fields under `RecipeRegistry.id`, keyed by `RecipeKey {
+input_type_id }`.
+
+### `world::refinery` (assembly)
+
+Modeled tightly on `world::storage_unit`. Key parallels:
+
+- `Refinery has key` with the same field shape as `StorageUnit` —
+  `key: TenantItemId`, `owner_cap_id`, `type_id`, `status`, `location`,
+  `inventory_keys`, `energy_source_id`, `metadata`, `extension`, plus
+  `active_job: Option<Job>`.
+- `anchor(...)` constructs a Refinery with one inventory keyed by its
+  `owner_cap_id`. Same network-node connection + OwnerCap transfer-to-character
+  flow as SU.
+- `online`/`offline` flip `status` exactly like SU.
+- `authorize_extension<Auth>` + `revoke_extension_authorization` +
+  `freeze_extension_config` follow the typed-witness pattern.
+
+### Two-mode access
+
+Same shape as SU, by design — extensions and owners both have parity:
+
+| | Extension-gated | Owner-direct |
+| - | - | - |
+| Deposit input  | `deposit_input<Auth>` | `deposit_input_by_owner<T>` |
+| Withdraw input | `withdraw_input<Auth>` | `withdraw_input_by_owner<T>` |
+| Start job      | `start_job<Auth>` | `start_job_by_owner<T>` |
+| Claim outputs  | `claim_outputs<Auth>` | `claim_outputs_by_owner<T>` |
+
+Extension functions skip the `ctx.sender() == character.character_address`
+check — they rely on the registered witness type as proof of authority. Owner
+functions require both a matching `OwnerCap` *and* the sender check, mirroring
+SU.
+
+### Job model (v1)
+
+**One active job per refinery at a time.** Trade-off:
+
+- ✅ Trivial invariant — `Option<Job>` on the refinery is enough state.
+- ✅ Avoids dynamic-field accounting for queued jobs.
+- ✅ Matches how players currently think about a single physical refiner.
+- ❌ No parallelism across recipe variants on the same refinery; a player who
+  wants concurrent processing builds (or anchors) multiple refineries.
+
+`start_job` snapshots the recipe at start time so admins changing a recipe
+mid-flight don't change already-running jobs. `claim_outputs` requires
+`clock.timestamp_ms() >= job.finishes_at_ms`, then mints outputs into the
+inventory via the existing `inventory::mint_items` primitive.
+
+Input is consumed by withdrawing into a transit `Item` and transferring to
+`@0x0`. This is a workaround until `world::inventory` exposes an explicit
+`destroy_item(item)` helper — see Future Work.
+
+### Shared input/output inventory
+
+The refinery has a single inventory (keyed by `owner_cap_id`). Inputs are
+deposited there; outputs are minted there. Recipe validation forbids reusing
+the input `type_id` as an output, so there is no ambiguity. This avoids a
+second dynamic field per refinery and keeps the SU view-function API shape.
+
+## Alternatives considered
+
+1. **One job slot per recipe (DF keyed by recipe id).** Rejected — adds DF
+   bookkeeping, complicates inventory accounting under capacity pressure, and
+   isn't justified by current Issue #74 design language.
+
+2. **Output inventory as a separate DF.** Rejected — duplicates code, adds a
+   second `inventory_keys` entry per refinery. The recipe-validation rule
+   (input ≠ output) gives us the same isolation property at zero structural
+   cost.
+
+3. **Per-refinery recipe whitelist.** Rejected for v1 — anyone holding the
+   refinery's OwnerCap (or its authorized extension) can start any registered
+   recipe. Per-refinery licensing is a useful follow-up (matches the
+   gate-permit pattern) but doesn't block the core loop.
+
+4. **No recipe registry; inline rules in extensions.** Rejected — extensions
+   would re-implement conversion rules per builder, fragmenting balance/yield
+   tuning. A shared registry lets the game team adjust yields without code
+   churn in every extension.
+
+## Future work
+
+In rough priority order, none of which block landing this ADR's surface:
+
+- `inventory::destroy_item(item)` so refineries can sink inputs cleanly
+  instead of transferring to `@0x0`.
+- Variable-yield outputs (RNG bands per recipe).
+- Per-character efficiency modifiers (skills, fittings).
+- Multi-input recipes.
+- Parallel jobs per refinery.
+- Per-refinery recipe whitelist / licensing (mirrors gate permits).
+- Counter on refinery for stable output `item_id`s (currently placeholder).
+- A non-test-only `inventory::item_quantity` so extensions can do
+  capacity-aware decisions without devInspect.
+
+## Open questions for maintainers
+
+1. Is refining on the internal roadmap with a different design? If so, this
+   should fold into that instead of landing standalone.
+2. Should recipes be admin-curated (current proposal) or eventually
+   player-discovered (BP loot drops, etc.)?
+3. Is `@0x0` an acceptable sink address for consumed inputs, or do we need a
+   dedicated burn primitive landed alongside this work?
+4. Test coverage: comprehensive job-loop tests for refinery require porting
+   the storage_unit test bootstrap. Is a separate testing-infra PR
+   preferable, or fold into this one?
+
+## Reference
+
+- Issue [#74 — \[Feat\] Mining System](https://github.com/evefrontier/world-contracts/issues/74)
+- `world::storage_unit` (`contracts/world/sources/assemblies/storage_unit.move`) — primary structural model
+- `world::gate` permit pattern — model for future per-refinery licensing
+- `world::inventory` (`contracts/world/sources/primitives/inventory.move`) — `mint_items` / `deposit_item` / `withdraw_item` primitives this proposal builds on


### PR DESCRIPTION
> **Draft / RFC** — this is a community-contributed first cut. Opening as a draft
> to invite design discussion before polishing. Soliciting maintainer feedback
> on roadmap fit before investing in comprehensive refinery tests.

## Summary

Adds the on-chain processing slice referenced in #74 [Feat] Mining System:

- **`world::recipe`** (`contracts/world/sources/primitives/recipe.move`) —
  admin-curated shared `RecipeRegistry` for one-input → many-output conversion
  rules. ~224 LOC.
- **`world::refinery`** (`contracts/world/sources/assemblies/refinery.move`) —
  programmable industrial assembly that consumes input items per a registered
  recipe and emits outputs after a processing delay. Modeled tightly on
  `world::storage_unit`. ~574 LOC.

Full design rationale + alternatives + open questions in
[`docs/adr/0001-refinery-and-recipe-modules.md`](https://github.com/evefrontier/world-contracts/blob/feat/refinery/docs/adr/0001-refinery-and-recipe-modules.md)
(also added in this PR).

## Why this shape

- **Mirrors `storage_unit`**: same anchor / online-offline / typed-witness
  extension / OwnerCap-gated owner-direct dual-mode access. Existing builder
  extensions can be adapted with minimal changes.
- **One active job per refinery (v1)**: `Option<Job>` on the refinery,
  trivially correct, no DF accounting for queued jobs. Players who want
  parallelism anchor more refineries.
- **Shared input/output inventory**: a single `Inventory` keyed by
  `owner_cap_id`. Recipe validation forbids input ≡ output type ids, so there's
  no ambiguity. Avoids a second DF per refinery.
- **No changes to existing modules**: refinery uses the existing
  `inventory::mint_items` primitive to materialize outputs. Zero diff to
  `inventory.move`, `storage_unit.move`, etc.

## Test plan

- [x] `sui move build -e testnet` — 0 errors, 0 warnings
- [x] `sui move test` — **289/289 passing** (282 pre-existing + 7 new)
- [x] `recipe_tests.move` — register/lookup, update overwrites, remove clears,
      double-register aborts, missing borrow aborts, input-in-outputs aborts
- [ ] **Full refinery job-loop tests** — skeleton with TODO landed in this PR.
      Comprehensive coverage requires porting the storage_unit test bootstrap
      (`setup_world` + character + network node + energy source). Holding off
      until I get a signal on whether this PR's surface is welcome before
      investing that work. Question for maintainers in the ADR.

## Out of scope

Mining (rock scanning, tractor extraction), hauling, variable-yield outputs,
multi-input recipes, throughput modifiers (skills/ships), parallel jobs,
per-refinery recipe licensing. All listed as future work in the ADR.

## Questions for maintainers (from ADR)

1. Is refining on the internal roadmap with a different design? If so, this
   should fold into that instead of landing standalone.
2. Should recipes be admin-curated (current) or eventually player-discovered?
3. Is `@0x0` an acceptable sink address for consumed inputs, or do we need a
   dedicated burn primitive landed alongside this work?
4. Comprehensive job-loop tests: separate testing-infra PR, or fold in?

🤖 First-cut draft generated with [Claude Code](https://claude.com/claude-code).