### PR TITLE
feat: add global package registry for dynamic package ID resolution for indexers

### DIFF
--- a/contracts/world/sources/registry/package_registry.move
+++ b/contracts/world/sources/registry/package_registry.move
@@ -1,0 +1,45 @@
+/// Unified registry to track the upgrade lineage of world packages.
+///
+/// Due to the nature of the Move module system on Sui, package upgrades
+/// create a new package ID. While MVR (Move Registry) allows resolving
+/// to the latest package ID, certain off-chain systems—like Indexers—need
+/// to track the entire history of package IDs to properly ingest events
+/// emitted by older versions of the modules.
+///
+/// This registry solves that by maintaining an on-chain `vector<address>`
+/// containing every package ID the system has ever lived at. Authorized
+/// sponsors can append to this array whenever a package upgrade is performed,
+/// ensuring that indexers and other services can dynamically query this single
+/// source of truth to discover all historical and current package IDs.
+module world::package_registry {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use std::vector;
+    use world::access::AdminACL;
+
+    public struct PackageRegistry has key {
+        id: UID,
+        /// Array of all package IDs in the upgrade lineage
+        package_ids: vector<address>
+    }
+
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(PackageRegistry {
+            id: object::new(ctx),
+            package_ids: vector::empty(),
+        });
+    }
+
+    /// Appends a new package ID to the registry upon an upgrade.
+    /// Only an authorized sponsor/admin can execute this.
+    public fun add_package_id(
+        registry: &mut PackageRegistry,
+        admin_acl: &AdminACL,
+        package_id: address,
+        ctx: &TxContext
+    ) {
+        admin_acl.verify_sponsor(ctx);
+        registry.package_ids.push_back(package_id);
+    }
+}

--- a/scripts/configure-world.sh
+++ b/scripts/configure-world.sh
@@ -12,6 +12,9 @@ export SUI_NETWORK="$ENV"
 echo "--- setup-access ---"
 pnpm exec tsx ts-scripts/access/setup-access.ts
 
+echo "--- initialize package registry ---"
+pnpm exec tsx ts-scripts/registry/add-package.ts
+
 echo "--- configure-fuel-energy ---"
 pnpm exec tsx ts-scripts/network-node/configure-fuel-energy.ts
 

--- a/ts-scripts/registry/add-package.ts
+++ b/ts-scripts/registry/add-package.ts
@@ -1,0 +1,77 @@
+import "dotenv/config";
+import { Transaction } from "@mysten/sui/transactions";
+import {
+    getEnvConfig,
+    handleError,
+    hydrateWorldConfig,
+    initializeContext,
+} from "../utils/helper";
+
+async function addPackageToRegistry(
+    registryId: string,
+    adminAcl: string,
+    newPackageId: string,
+    ctx: ReturnType<typeof initializeContext>
+) {
+    const { client, keypair, config } = ctx;
+
+    const tx = new Transaction();
+    tx.moveCall({
+        target: `${config.packageId}::package_registry::add_package_id`,
+        arguments: [
+            tx.object(registryId),
+            tx.object(adminAcl),
+            tx.pure.address(newPackageId),
+        ],
+    });
+
+    const result = await client.signAndExecuteTransaction({
+        transaction: tx,
+        signer: keypair,
+        options: { showEffects: true, showObjectChanges: true },
+    });
+
+    console.log("\nPackage ID added to registry!");
+    console.log("Transaction digest:", result.digest);
+    return result;
+}
+
+async function main() {
+    console.log("============= Add Package to Registry example ==============\n");
+
+    try {
+        const env = getEnvConfig();
+        const ctx = initializeContext(env.network, env.adminExportedKey);
+        const config = await hydrateWorldConfig(ctx);
+        const { client } = ctx;
+
+        const adminAcl = config.adminAcl;
+        
+        const registryId = config.packageRegistry;
+        const newPackageId = process.env.NEW_PACKAGE_ID || config.packageId;
+
+        if (!registryId) throw new Error("Registry ID not found in config");
+
+        await addPackageToRegistry(
+            registryId,
+            adminAcl,
+            newPackageId,
+            ctx
+        );
+        
+        // Let's read it back to prove it worked
+        console.log("\nFetching registry from RPC...");
+        const registryObj = await client.getObject({
+            id: registryId,
+            options: { showBcs: true, showContent: true }
+        });
+        
+        console.log("Registry state:");
+        console.dir(registryObj.data?.content, { depth: null });
+        
+    } catch (error) {
+        handleError(error);
+    }
+}
+
+main();

--- a/ts-scripts/utils/config.ts
+++ b/ts-scripts/utils/config.ts
@@ -6,6 +6,7 @@ export type WorldObjectIds = {
     energyConfig: string;
     fuelConfig: string;
     gateConfig: string;
+    packageRegistry: string;
 };
 
 /** Extracted object IDs written by extract-object-ids script (run once per deploy). */

--- a/ts-scripts/utils/extract-object-ids.ts
+++ b/ts-scripts/utils/extract-object-ids.ts
@@ -81,6 +81,13 @@ function extractWorldIds(
             "GateConfig",
             findCreatedObjectId(objectChanges, typeName(packageId, MODULES.GATE, "GateConfig"))
         ),
+        packageRegistry: requireId(
+            "PackageRegistry",
+            findCreatedObjectId(
+                objectChanges,
+                typeName(packageId, "package_registry", "PackageRegistry")
+            )
+        ),
     };
 }
 


### PR DESCRIPTION
I had this idea while upgrading my dApp to handle world upgrades using the move registry per [docs.evefrontier.com](https://docs.evefrontier.com/tools/world-upgrades). While I was able to incorporate the MVR changes into my React app, I didn't see a way to incorporate dynamic world ID resolution into my indexer. This left me still needing to hardcode or at least manually feed package IDs to the indexer. This causes a drift, where it's up to me or at least an automation job to find the new ID, add it to my rust code or indexer environment, and restart/redeploy the indexer.

Furthermore, MVR as I understand it, we only get the latest IDs, and events are emitted against their original IDs, meaning after yet another upgrade we will have gaps.

In an attempt to avoid that monotony for my indexer, I wanted to propose a package registry move object, `::package_registry::PackageRegistry`. Updating this object during world upgrades would keep a ledger of all world IDs for the respective suinet. My indexer would only need to know this object's address for the given suinet.

Full disclaimer: for my use case, I don't actually have any Move code nor do I leverage world-contracts repo in my project at all. It's not that I couldn't, but my app reads from the chain and uses a dashboard. I know some people have world-contracts readily available or even as a component of their app, where it would be trivial to read the Published.toml file. That isn't the case for me.

Perhaps I am looking at things the wrong way, and could use some pointers.

#### Bootstrapping

This would require some bootstrapping from the EF team to make it possible, obviously there have been world upgrades already and this object does not exist.

#### 1. The Initial Deployment (Day 1)

EF-team would need to deploy this manually, including calling `add_package_id` a few times to backfill historical IDs. Then take the Object ID and publish it to something like docs.evefrontier.com. 

#### 2. The Developer Handoff

Developers building indexers, dashboards, or bots will hardcode that single Registry Object ID into their `.env` files (e.g.,  `REGISTRY_ID=0x9342...` ).

From that point forward, devs are insulated from world upgrades. The EVE Frontier team can upgrade the package 50 times, and the developer's indexer will automatically discover all 50 new package IDs by querying that exact same registry object on startup.

#### 3. A Cleaner Handoff (SuiNS)

SuiNS natively supports mapping  `.sui`  names to arbitrary Target Objects today. EF devs could take their Registry ObjectID and bind it to a human-readable name like `registry.evefrontier.sui`. At that point, devs could drop the hardcoded registry ID, resolve `registry.evefrontier.sui` on-chain to find the registry object, and fetch the package lineage automatically.

#### Example usage

For example, I could outfit my rust indexer with the following code to automatically index new world IDs as `PackageRegistry` was updated.

```rust
use reqwest::Client;
use serde_json::{json, Value};
use anyhow::Result;

/// Instead of parsing `EVE_PACKAGE_ID` from a .env file, the indexer queries
/// the shared PackageRegistry object on startup to load all historical package IDs.
async fn fetch_historical_package_ids(rpc_url: &str, registry_id: &str) -> Result<Vec<String>> {
    let client = Client::new();

    // 1. Query the Sui JSON-RPC for the registry object
    let request_body = json!({
        "jsonrpc": "2.0",
        "id": 1,
        "method": "sui_getObject",
        "params": [
            registry_id,
            { "showContent": true }
        ]
    });

    let res: Value = client.post(rpc_url)
        .json(&request_body)
        .send()
        .await?
        .json()
        .await?;

    // 2. Extract the package_ids vector from the parsed Move object content
    let mut package_ids = Vec::new();

    if let Some(fields) = res["result"]["data"]["content"]["fields"].as_object() {
        if let Some(ids_array) = fields.get("package_ids").and_then(|v| v.as_array()) {
            for id_val in ids_array {
                if let Some(id_str) = id_val.as_str() {
                    package_ids.push(id_str.to_string());
                }
            }
        }
    }

    Ok(package_ids)
}

// ... inside the indexer's main() startup sequence ...
// let package_ids = fetch_historical_package_ids(SUI_RPC_URL, "0x93425961db7486...").await?;
// event_poller.start_polling(package_ids);
```

### Testing

I've done preliminary testing using `efctl`, where I was able to make the package registry object and point my indexer at it.