### PR TITLE
feat: allow gameplay servers to reveal the location of a Rift onchain when players begin mining

### DIFF
--- a/contracts/world/sources/primitives/location.move
+++ b/contracts/world/sources/primitives/location.move
@@ -283,6 +283,28 @@ public(package) fun reveal_location(
 
 // === Package Functions ===
 
+/// Records plaintext coordinates for an object without requiring an owner cap.
+/// Used by object types (e.g. Rifts) that have no OwnerCap.
+public(package) fun record_revealed_coordinates(
+    registry: &mut LocationRegistry,
+    object_id: ID,
+    solarsystem: u64,
+    x: String,
+    y: String,
+    z: String,
+) {
+    let data = Coordinates {
+        solarsystem,
+        x,
+        y,
+        z,
+    };
+    if (registry.locations.contains(object_id)) {
+        registry.locations.remove(object_id);
+    };
+    registry.locations.add(object_id, data);
+}
+
 public(package) fun attach(location_hash: vector<u8>): Location {
     assert!(location_hash.length() == 32, EInvalidHashLength);
     Location {

--- a/contracts/world/sources/primitives/location.move
+++ b/contracts/world/sources/primitives/location.move
@@ -285,6 +285,8 @@ public(package) fun reveal_location(
 
 /// Records plaintext coordinates for an object without requiring an owner cap.
 /// Used by object types (e.g. Rifts) that have no OwnerCap.
+/// Note: this function performs no authorization checks; callers must
+/// enforce ACLs (e.g. `AdminACL::verify_sponsor`).
 public(package) fun record_revealed_coordinates(
     registry: &mut LocationRegistry,
     object_id: ID,

--- a/contracts/world/sources/rift/rift.move
+++ b/contracts/world/sources/rift/rift.move
@@ -1,9 +1,9 @@
-/// Server-only spatial objects that hold a hashed location until mining begins.
+/// Server-controlled spatial objects that initially store only a hashed location.
 ///
-/// Rifts are created and mutated solely by EVE gameplay servers (authorized sponsors).
+/// Rifts are created and managed solely by gameplay servers (authorized sponsors).
 /// Players have no OwnerCap and therefore no on-chain path to create or modify them.
-/// When a player starts mining, the server broadcasts the plaintext location on-chain
-/// to enable PvP interference.
+/// Authorized sponsors may broadcast the plaintext location on-chain (e.g. when mining begins)
+/// to enable PvP interference; the mining lifecycle itself is enforced off-chain.
 module world::rift;
 
 use std::string::String;

--- a/contracts/world/sources/rift/rift.move
+++ b/contracts/world/sources/rift/rift.move
@@ -1,0 +1,140 @@
+/// Server-only spatial objects that hold a hashed location until mining begins.
+///
+/// Rifts are created and mutated solely by EVE gameplay servers (authorized sponsors).
+/// Players have no OwnerCap and therefore no on-chain path to create or modify them.
+/// When a player starts mining, the server broadcasts the plaintext location on-chain
+/// to enable PvP interference.
+module world::rift;
+
+use std::string::String;
+use sui::{derived_object, event};
+use world::{
+    access::AdminACL,
+    in_game_id::{Self, TenantItemId},
+    location::{Self, Location, LocationRegistry},
+    object_registry::ObjectRegistry,
+};
+
+// === Errors ===
+#[error(code = 0)]
+const ERiftAlreadyExists: vector<u8> = b"Rift with this ItemId already exists";
+#[error(code = 1)]
+const ERiftItemIdEmpty: vector<u8> = b"Rift ItemId is empty";
+
+// === Structs ===
+public struct Rift has key {
+    id: UID,
+    key: TenantItemId,
+    location: Location,
+}
+
+// === Events ===
+public struct RiftSpawnedEvent has copy, drop {
+    rift_id: ID,
+    rift_key: TenantItemId,
+    location_hash: vector<u8>,
+}
+
+public struct RiftLocationBroadcastEvent has copy, drop {
+    rift_id: ID,
+    rift_key: TenantItemId,
+    location_hash: vector<u8>,
+    solarsystem: u64,
+    x: String,
+    y: String,
+    z: String,
+}
+
+// === View Functions ===
+public fun id(rift: &Rift): ID {
+    object::id(rift)
+}
+
+public fun key(rift: &Rift): TenantItemId {
+    rift.key
+}
+
+public fun location_hash(rift: &Rift): vector<u8> {
+    location::hash(&rift.location)
+}
+
+// === Admin Functions ===
+public fun spawn(
+    registry: &mut ObjectRegistry,
+    admin_acl: &AdminACL,
+    item_id: u64,
+    tenant: String,
+    location_hash: vector<u8>,
+    ctx: &mut TxContext,
+): Rift {
+    admin_acl.verify_sponsor(ctx);
+    assert!(item_id != 0, ERiftItemIdEmpty);
+
+    let rift_key = in_game_id::create_key(item_id, tenant);
+    assert!(!registry.object_exists(rift_key), ERiftAlreadyExists);
+
+    let rift_uid = derived_object::claim(registry.borrow_registry_id(), rift_key);
+    let rift_id = object::uid_to_inner(&rift_uid);
+
+    let rift = Rift {
+        id: rift_uid,
+        key: rift_key,
+        location: location::attach(location_hash),
+    };
+
+    event::emit(RiftSpawnedEvent {
+        rift_id,
+        rift_key,
+        location_hash: rift.location.hash(),
+    });
+
+    rift
+}
+
+public fun share_rift(rift: Rift, admin_acl: &AdminACL, ctx: &TxContext) {
+    admin_acl.verify_sponsor(ctx);
+    transfer::share_object(rift);
+}
+
+public fun broadcast_location(
+    rift: &Rift,
+    location_registry: &mut LocationRegistry,
+    admin_acl: &AdminACL,
+    solarsystem: u64,
+    x: String,
+    y: String,
+    z: String,
+    ctx: &TxContext,
+) {
+    admin_acl.verify_sponsor(ctx);
+
+    let rift_id = object::id(rift);
+    let location_hash = location::hash(&rift.location);
+
+    location::record_revealed_coordinates(
+        location_registry,
+        rift_id,
+        solarsystem,
+        x,
+        y,
+        z,
+    );
+
+    event::emit(RiftLocationBroadcastEvent {
+        rift_id,
+        rift_key: rift.key,
+        location_hash,
+        solarsystem,
+        x,
+        y,
+        z,
+    });
+}
+
+public fun despawn(rift: Rift, admin_acl: &AdminACL, ctx: &TxContext) {
+    admin_acl.verify_sponsor(ctx);
+
+    let Rift { id, location, .. } = rift;
+    location.remove();
+    id.delete();
+}

--- a/contracts/world/sources/rift/rift.move
+++ b/contracts/world/sources/rift/rift.move
@@ -12,7 +12,7 @@ use world::{
     access::AdminACL,
     in_game_id::{Self, TenantItemId},
     location::{Self, Location, LocationRegistry},
-    object_registry::ObjectRegistry,
+    object_registry::ObjectRegistry
 };
 
 // === Errors ===

--- a/contracts/world/tests/rift/rift_tests.move
+++ b/contracts/world/tests/rift/rift_tests.move
@@ -8,7 +8,7 @@ use world::{
     location::{Self, LocationRegistry},
     object_registry::ObjectRegistry,
     rift::{Self, Rift},
-    test_helpers::{Self, governor, admin, tenant},
+    test_helpers::{Self, governor, admin, tenant}
 };
 
 const LOCATION_HASH: vector<u8> =

--- a/contracts/world/tests/rift/rift_tests.move
+++ b/contracts/world/tests/rift/rift_tests.move
@@ -1,0 +1,237 @@
+#[test_only]
+module world::rift_tests;
+
+use std::{string::utf8, unit_test::assert_eq};
+use sui::test_scenario as ts;
+use world::{
+    access::{Self, AdminACL},
+    location::{Self, LocationRegistry},
+    object_registry::ObjectRegistry,
+    rift::{Self, Rift},
+    test_helpers::{Self, governor, admin, tenant},
+};
+
+const LOCATION_HASH: vector<u8> =
+    x"7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b7a8f3b2e9c4d1a6f5e8b2d9c3f7a1e5b";
+const INVALID_HASH: vector<u8> = x"deadbeef";
+const RIFT_ITEM_ID: u64 = 9001;
+
+fun setup(ts: &mut ts::Scenario) {
+    test_helpers::setup_world(ts);
+}
+
+fun spawn_and_share_rift(ts: &mut ts::Scenario, item_id: u64): ID {
+    ts::next_tx(ts, admin());
+    let rift_id = {
+        let mut registry = ts::take_shared<ObjectRegistry>(ts);
+        let admin_acl = ts::take_shared<AdminACL>(ts);
+        let rift = rift::spawn(
+            &mut registry,
+            &admin_acl,
+            item_id,
+            tenant(),
+            LOCATION_HASH,
+            ts.ctx(),
+        );
+        let rift_id = object::id(&rift);
+        rift::share_rift(rift, &admin_acl, ts.ctx());
+        ts::return_shared(admin_acl);
+        ts::return_shared(registry);
+        rift_id
+    };
+    rift_id
+}
+
+#[test]
+fun test_spawn_and_share_rift() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let rift_id = spawn_and_share_rift(&mut ts, RIFT_ITEM_ID);
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let registry = ts::take_shared<ObjectRegistry>(&ts);
+        assert!(registry.object_exists(test_helpers::in_game_id(RIFT_ITEM_ID)), 0);
+        ts::return_shared(registry);
+    };
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let rift = ts::take_shared_by_id<Rift>(&ts, rift_id);
+        assert_eq!(rift::id(&rift), rift_id);
+        assert_eq!(rift::location_hash(&rift), LOCATION_HASH);
+        ts::return_shared(rift);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+fun test_broadcast_location() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let rift_id = spawn_and_share_rift(&mut ts, RIFT_ITEM_ID);
+
+    let solarsystem: u64 = 42;
+    let x = utf8(b"100");
+    let y = utf8(b"200");
+    let z = utf8(b"300");
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let rift = ts::take_shared_by_id<Rift>(&ts, rift_id);
+        let mut location_registry = ts::take_shared<LocationRegistry>(&ts);
+        let admin_acl = ts::take_shared<AdminACL>(&ts);
+        rift::broadcast_location(
+            &rift,
+            &mut location_registry,
+            &admin_acl,
+            solarsystem,
+            x,
+            y,
+            z,
+            ts.ctx(),
+        );
+        ts::return_shared(admin_acl);
+        ts::return_shared(location_registry);
+        ts::return_shared(rift);
+    };
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let location_registry = ts::take_shared<LocationRegistry>(&ts);
+        let coords = location::get_location(&location_registry, rift_id);
+        assert!(option::is_some(&coords), 0);
+        let coords_ref = option::borrow(&coords);
+        assert_eq!(location::solarsystem(coords_ref), solarsystem);
+        assert_eq!(location::x(coords_ref), x);
+        assert_eq!(location::y(coords_ref), y);
+        assert_eq!(location::z(coords_ref), z);
+        ts::return_shared(location_registry);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+fun test_despawn_rift() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let rift_id = spawn_and_share_rift(&mut ts, RIFT_ITEM_ID);
+
+    ts::next_tx(&mut ts, admin());
+    {
+        let rift = ts::take_shared_by_id<Rift>(&ts, rift_id);
+        let admin_acl = ts::take_shared<AdminACL>(&ts);
+        rift::despawn(rift, &admin_acl, ts.ctx());
+        ts::return_shared(admin_acl);
+    };
+
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = rift::ERiftAlreadyExists)]
+fun test_spawn_duplicate_item_id() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    spawn_and_share_rift(&mut ts, RIFT_ITEM_ID);
+
+    ts::next_tx(&mut ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+    let admin_acl = ts::take_shared<AdminACL>(&ts);
+    let rift = rift::spawn(
+        &mut registry,
+        &admin_acl,
+        RIFT_ITEM_ID,
+        tenant(),
+        LOCATION_HASH,
+        ts.ctx(),
+    );
+    rift::share_rift(rift, &admin_acl, ts.ctx());
+
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = location::EInvalidHashLength)]
+fun test_spawn_invalid_hash_length() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    ts::next_tx(&mut ts, admin());
+    let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+    let admin_acl = ts::take_shared<AdminACL>(&ts);
+    let rift = rift::spawn(
+        &mut registry,
+        &admin_acl,
+        RIFT_ITEM_ID,
+        tenant(),
+        INVALID_HASH,
+        ts.ctx(),
+    );
+    rift::share_rift(rift, &admin_acl, ts.ctx());
+
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = access::EUnauthorizedSponsor)]
+fun test_spawn_unauthorized_sponsor() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    ts::next_tx(&mut ts, @0xF);
+    let mut registry = ts::take_shared<ObjectRegistry>(&ts);
+    let admin_acl = ts::take_shared<AdminACL>(&ts);
+    let rift = rift::spawn(
+        &mut registry,
+        &admin_acl,
+        RIFT_ITEM_ID,
+        tenant(),
+        LOCATION_HASH,
+        ts.ctx(),
+    );
+    rift::share_rift(rift, &admin_acl, ts.ctx());
+
+    ts::return_shared(admin_acl);
+    ts::return_shared(registry);
+    ts::end(ts);
+}
+
+#[test]
+#[expected_failure(abort_code = access::EUnauthorizedSponsor)]
+fun test_broadcast_location_unauthorized_sponsor() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let rift_id = spawn_and_share_rift(&mut ts, RIFT_ITEM_ID);
+
+    ts::next_tx(&mut ts, @0xF);
+    let rift = ts::take_shared_by_id<Rift>(&ts, rift_id);
+    let mut location_registry = ts::take_shared<LocationRegistry>(&ts);
+    let admin_acl = ts::take_shared<AdminACL>(&ts);
+    rift::broadcast_location(
+        &rift,
+        &mut location_registry,
+        &admin_acl,
+        42,
+        utf8(b"100"),
+        utf8(b"200"),
+        utf8(b"300"),
+        ts.ctx(),
+    );
+
+    ts::return_shared(admin_acl);
+    ts::return_shared(location_registry);
+    ts::return_shared(rift);
+    ts::end(ts);
+}


### PR DESCRIPTION
First pass implementing the feature described here: https://www.figma.com/make/2mbGjlxsVuOqw1OHpBhczA/Crude-Onchain?fullscreen=1&t=QxVN3SgaJP3Xz3ps-1&code-node-id=0-9

## Overview:
Put Rifts onchain and broadcast their location when any player starts mining them.

## Goal:
- The idea is to promote PvP combat. Most players are able to mine and extract Crude successfully without encountering resistance because the universe is very sparsely populated. By broadcasting location we hope that it will encourage other players to interfere in the mining process and spark combat.
- This also gives us a chance to lay the groundwork for putting Rifts and Crude mining **fully** onchain in the near future.