### PR TITLE
fix: bind jump permits to gate extension (shadow permit vulnerability)

### DIFF
--- a/contracts/world/sources/assemblies/gate.move
+++ b/contracts/world/sources/assemblies/gate.move
@@ -77,6 +77,9 @@ const EJumpPermitExtensionMismatch: vector<u8> =
     b"Jump permit extension does not match gate extension";
 #[error(code = 21)]
 const EGateExtensionMismatch: vector<u8> = b"Gates use different extension types";
+#[error(code = 22)]
+const EJumpPermitStaleExtension: vector<u8> =
+    b"Jump permit was issued under a stale gate extension configuration";
 
 // === Structs ===
 public struct GateConfig has key {
@@ -95,6 +98,8 @@ public struct Gate has key {
     energy_source_id: Option<ID>,
     metadata: Option<Metadata>,
     extension: Option<TypeName>,
+    // Bumped on every `authorize_extension`
+    extension_version: u64,
 }
 
 // Note : Can add more fields later
@@ -109,6 +114,9 @@ public struct JumpPermit has key, store {
     // the extension prevents a permit from outliving the extension that authorized it (e.g. after
     // the owner revokes or swaps the gate's extension).
     extension_type: TypeName,
+    // Order-agnostic hash binding both gates' ids and their `extension_version` at issuance. Even if
+    // the same extension type is later re-authorized, the version bump invalidates this permit.
+    extension_config_hash: vector<u8>,
 }
 
 // === Events ===
@@ -179,6 +187,7 @@ public fun authorize_extension<Auth: drop>(gate: &mut Gate, owner_cap: &OwnerCap
     assert!(!extension_freeze::is_extension_frozen(&gate.id), EExtensionConfigFrozen);
     let previous_extension = gate.extension;
     gate.extension.swap_or_fill(type_name::with_defining_ids<Auth>());
+    gate.extension_version = gate.extension_version + 1;
     event::emit(ExtensionAuthorizedEvent {
         assembly_id: gate_id,
         assembly_key: gate.key,
@@ -648,6 +657,7 @@ public fun anchor(
             ),
         ),
         extension: option::none(),
+        extension_version: 0,
     };
 
     network_node.connect_assembly(gate_id);
@@ -878,6 +888,21 @@ fun compute_route_hash(gate_a_id: ID, gate_b_id: ID): vector<u8> {
     hash::blake2b256(&concatenated)
 }
 
+/// Binds a permit to both gates' ids and their `extension_version`. `validate_jump_permit` checks
+/// both orderings, so the permit stays direction-agnostic while detecting a version bump on either gate.
+fun compute_extension_config_hash(
+    gate_a_id: ID,
+    gate_a_version: u64,
+    gate_b_id: ID,
+    gate_b_version: u64,
+): vector<u8> {
+    let mut bytes = bcs::to_bytes(&gate_a_id);
+    vector::append(&mut bytes, bcs::to_bytes(&gate_a_version));
+    vector::append(&mut bytes, bcs::to_bytes(&gate_b_id));
+    vector::append(&mut bytes, bcs::to_bytes(&gate_b_version));
+    hash::blake2b256(&bytes)
+}
+
 fun jump_internal(source_gate: &Gate, destination_gate: &Gate, character: &Character) {
     let source_gate_id = object::id(source_gate);
     let destination_gate_id = object::id(destination_gate);
@@ -917,6 +942,24 @@ fun validate_jump_permit(
     let dst_ext = option::borrow(&destination_gate.extension);
     assert!(src_ext == dst_ext, EGateExtensionMismatch);
     assert!(jump_permit.extension_type == *src_ext, EJumpPermitExtensionMismatch);
+
+    // Reject permits issued under a previous extension configuration session (revoke -> reauthorize
+    // of the same type bumps `extension_version`, so a stale permit no longer matches).
+    assert!(
+        jump_permit.extension_config_hash == compute_extension_config_hash(
+            source_gate_id,
+            source_gate.extension_version,
+            destination_gate_id,
+            destination_gate.extension_version,
+        )
+        || jump_permit.extension_config_hash == compute_extension_config_hash(
+            destination_gate_id,
+            destination_gate.extension_version,
+            source_gate_id,
+            source_gate.extension_version,
+        ),
+        EJumpPermitStaleExtension,
+    );
 
     // Validate jump permit then invalidate it
     assert!(jump_permit.expires_at_timestamp_ms > clock.timestamp_ms(), EJumpPermitExpired);
@@ -995,12 +1038,19 @@ fun issue_jump_permit_internal<Auth: drop>(
     let jump_permit_id = object::uid_to_inner(&permit_uid);
 
     let extension_type = type_name::with_defining_ids<Auth>();
+    let extension_config_hash = compute_extension_config_hash(
+        source_gate_id,
+        source_gate.extension_version,
+        destination_gate_id,
+        destination_gate.extension_version,
+    );
     let jump_permit = JumpPermit {
         id: permit_uid,
         route_hash,
         character_id,
         expires_at_timestamp_ms,
         extension_type,
+        extension_config_hash,
     };
     transfer::transfer(jump_permit, character.character_address());
 

--- a/contracts/world/sources/assemblies/gate.move
+++ b/contracts/world/sources/assemblies/gate.move
@@ -69,14 +69,14 @@ const EGateTypeMismatch: vector<u8> = b"Gates have different TypeId values";
 #[error(code = 17)]
 const EExtensionConfigFrozen: vector<u8> = b"Extension configuration is frozen";
 #[error(code = 18)]
-const EExtensionNotConfigured: vector<u8> = b"Extension must be configured before freezing";
+const EExtensionNotConfigured: vector<u8> = b"Gate extension must be configured";
 #[error(code = 19)]
 const ENoExtensionToRevoke: vector<u8> = b"No extension authorization to revoke";
 #[error(code = 20)]
 const EJumpPermitExtensionMismatch: vector<u8> =
     b"Jump permit extension does not match gate extension";
 #[error(code = 21)]
-const EGateExtensionMismatch: vector<u8> = b"Linked gates use different extension types";
+const EGateExtensionMismatch: vector<u8> = b"Gates use different extension types";
 
 // === Structs ===
 public struct GateConfig has key {

--- a/contracts/world/sources/assemblies/gate.move
+++ b/contracts/world/sources/assemblies/gate.move
@@ -72,6 +72,11 @@ const EExtensionConfigFrozen: vector<u8> = b"Extension configuration is frozen";
 const EExtensionNotConfigured: vector<u8> = b"Extension must be configured before freezing";
 #[error(code = 19)]
 const ENoExtensionToRevoke: vector<u8> = b"No extension authorization to revoke";
+#[error(code = 20)]
+const EJumpPermitExtensionMismatch: vector<u8> =
+    b"Jump permit extension does not match gate extension";
+#[error(code = 21)]
+const EGateExtensionMismatch: vector<u8> = b"Linked gates use different extension types";
 
 // === Structs ===
 public struct GateConfig has key {
@@ -100,6 +105,10 @@ public struct JumpPermit has key, store {
     // Computed in a direction-agnostic way so the same permit works for A->B and B->A.
     route_hash: vector<u8>,
     expires_at_timestamp_ms: u64,
+    // Extension witness type active on the gates when the permit was issued. Binding the permit to
+    // the extension prevents a permit from outliving the extension that authorized it (e.g. after
+    // the owner revokes or swaps the gate's extension).
+    extension_type: TypeName,
 }
 
 // === Events ===
@@ -368,6 +377,10 @@ public fun delete_jump_permit_with_auth<Auth: drop>(
     _: Auth,
 ) {
     assert_gate_extension_matches<Auth>(source_gate);
+    assert!(
+        jump_permit.extension_type == type_name::with_defining_ids<Auth>(),
+        EJumpPermitExtensionMismatch,
+    );
     let JumpPermit { id, .. } = jump_permit;
     id.delete();
 }
@@ -530,6 +543,11 @@ public fun id(gate: &Gate): ID {
 
 public fun jump_permit_id(permit: &JumpPermit): ID {
     object::id(permit)
+}
+
+/// Returns the extension witness type the permit was issued under.
+public fun jump_permit_extension(permit: &JumpPermit): TypeName {
+    permit.extension_type
 }
 
 public fun status(gate: &Gate): &AssemblyStatus {
@@ -891,6 +909,15 @@ fun validate_jump_permit(
     let source_gate_id = object::id(source_gate);
     let destination_gate_id = object::id(destination_gate);
 
+    // Bind the permit to the extension active on both gates. This prevents a permit issued under one
+    // extension from being used after the gate's extension is revoked or swapped (shadow permits).
+    assert!(option::is_some(&source_gate.extension), EExtensionNotConfigured);
+    assert!(option::is_some(&destination_gate.extension), EExtensionNotConfigured);
+    let src_ext = option::borrow(&source_gate.extension);
+    let dst_ext = option::borrow(&destination_gate.extension);
+    assert!(src_ext == dst_ext, EGateExtensionMismatch);
+    assert!(jump_permit.extension_type == *src_ext, EJumpPermitExtensionMismatch);
+
     // Validate jump permit then invalidate it
     assert!(jump_permit.expires_at_timestamp_ms > clock.timestamp_ms(), EJumpPermitExpired);
     assert!(jump_permit.character_id == object::id(character), EInvalidJumpPermit);
@@ -967,15 +994,16 @@ fun issue_jump_permit_internal<Auth: drop>(
     let permit_uid = object::new(ctx);
     let jump_permit_id = object::uid_to_inner(&permit_uid);
 
+    let extension_type = type_name::with_defining_ids<Auth>();
     let jump_permit = JumpPermit {
         id: permit_uid,
         route_hash,
         character_id,
         expires_at_timestamp_ms,
+        extension_type,
     };
     transfer::transfer(jump_permit, character.character_address());
 
-    let extension_type = type_name::with_defining_ids<Auth>();
     event::emit(JumpPermitIssuedEvent {
         jump_permit_id,
         source_gate_id,

--- a/contracts/world/tests/assemblies/gate_tests.move
+++ b/contracts/world/tests/assemblies/gate_tests.move
@@ -242,6 +242,14 @@ fun link_and_online_gates(
 }
 
 fun authorize_gate_extension(ts: &mut ts::Scenario, character_id: ID, gate_id: ID) {
+    authorize_gate_extension_typed<GateAuth>(ts, character_id, gate_id);
+}
+
+fun authorize_gate_extension_typed<Auth: drop>(
+    ts: &mut ts::Scenario,
+    character_id: ID,
+    gate_id: ID,
+) {
     ts::next_tx(ts, user_a());
     {
         let mut gate_obj = ts::take_shared_by_id<Gate>(ts, gate_id);
@@ -249,7 +257,22 @@ fun authorize_gate_extension(ts: &mut ts::Scenario, character_id: ID, gate_id: I
         let owner_cap_id = gate_obj.owner_cap_id();
         let gate_ticket = ts::receiving_ticket_by_id<OwnerCap<Gate>>(owner_cap_id);
         let (owner_cap, receipt) = character.borrow_owner_cap<Gate>(gate_ticket, ts.ctx());
-        gate_obj.authorize_extension<GateAuth>(&owner_cap);
+        gate_obj.authorize_extension<Auth>(&owner_cap);
+        character.return_owner_cap(owner_cap, receipt);
+        ts::return_shared(character);
+        ts::return_shared(gate_obj);
+    };
+}
+
+fun revoke_gate_extension(ts: &mut ts::Scenario, character_id: ID, gate_id: ID) {
+    ts::next_tx(ts, user_a());
+    {
+        let mut gate_obj = ts::take_shared_by_id<Gate>(ts, gate_id);
+        let mut character = ts::take_shared_by_id<Character>(ts, character_id);
+        let owner_cap_id = gate_obj.owner_cap_id();
+        let gate_ticket = ts::receiving_ticket_by_id<OwnerCap<Gate>>(owner_cap_id);
+        let (owner_cap, receipt) = character.borrow_owner_cap<Gate>(gate_ticket, ts.ctx());
+        gate_obj.revoke_extension_authorization(&owner_cap);
         character.return_owner_cap(owner_cap, receipt);
         ts::return_shared(character);
         ts::return_shared(gate_obj);
@@ -745,6 +768,113 @@ fun test_jump_with_permit_fails_expired_permit() {
     ts::return_shared(gate_a);
     ts::return_shared(gate_b);
     clock.destroy_for_testing();
+    ts::end(ts);
+}
+
+// A permit issued under an extension must not survive that extension being revoked.
+#[test]
+#[expected_failure(abort_code = gate::EExtensionNotConfigured)]
+fun jump_with_permit_fails_after_extension_revoked() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 120);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a permit under GateAuth while the extension is active.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
+    // Owner revokes the gate extension after the permit was minted.
+    revoke_gate_extension(&mut ts, character_id, gate_a_id);
+
+    // The previously valid permit can no longer be used to jump.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
+    ts::end(ts);
+}
+
+// A shadow permit (issued under the old extension) must not work after the extension is swapped.
+#[test]
+#[expected_failure(abort_code = gate::EJumpPermitExtensionMismatch)]
+fun jump_with_permit_fails_after_extension_swapped() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 121);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a permit under GateAuth.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
+    // Owner swaps both gates to a different extension witness.
+    authorize_gate_extension_typed<WrongGateAuth>(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension_typed<WrongGateAuth>(&mut ts, character_id, gate_b_id);
+
+    // The GateAuth permit no longer matches the gate's WrongGateAuth extension.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
     ts::end(ts);
 }
 

--- a/contracts/world/tests/assemblies/gate_tests.move
+++ b/contracts/world/tests/assemblies/gate_tests.move
@@ -878,6 +878,60 @@ fun jump_with_permit_fails_after_extension_swapped() {
     ts::end(ts);
 }
 
+// A permit must not revive after the SAME extension type is revoked and then re-authorized.
+#[test]
+#[expected_failure(abort_code = gate::EJumpPermitStaleExtension)]
+fun jump_with_permit_fails_after_revoke_then_reauthorize_same_auth() {
+    let mut ts = ts::begin(governor());
+    setup(&mut ts);
+
+    let character_id = create_character(&mut ts, user_a(), 122);
+    let nwn_id = create_network_node(&mut ts, character_id);
+    let gate_a_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_1);
+    let gate_b_id = create_gate(&mut ts, character_id, nwn_id, GATE_TYPE_ID_1, GATE_ITEM_ID_2);
+
+    bring_network_node_online(&mut ts, character_id, nwn_id);
+    link_and_online_gates(&mut ts, character_id, nwn_id, gate_a_id, gate_b_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_b_id);
+
+    // Issue a permit under the first GateAuth configuration.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let expires_at_timestamp_ms = clock.timestamp_ms() + 10_000;
+        claim_ticket(&gate_a, &gate_b, &character, expires_at_timestamp_ms, ts.ctx());
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
+    // Owner revokes then re-authorizes the SAME extension witness type on the source gate.
+    revoke_gate_extension(&mut ts, character_id, gate_a_id);
+    authorize_gate_extension(&mut ts, character_id, gate_a_id);
+
+    // The permit was bound to the previous configuration session and must not be reusable.
+    ts::next_tx(&mut ts, user_a());
+    {
+        let clock = clock::create_for_testing(ts.ctx());
+        let gate_a = ts::take_shared_by_id<Gate>(&ts, gate_a_id);
+        let gate_b = ts::take_shared_by_id<Gate>(&ts, gate_b_id);
+        let character = ts::take_shared_by_id<Character>(&ts, character_id);
+        let permit = ts::take_from_sender<JumpPermit>(&ts);
+        gate::test_jump_with_permit(&gate_a, &gate_b, &character, permit, &clock);
+        ts::return_shared(gate_a);
+        ts::return_shared(gate_b);
+        ts::return_shared(character);
+        clock.destroy_for_testing();
+    };
+
+    ts::end(ts);
+}
+
 #[test]
 #[expected_failure(abort_code = gate::EExtensionNotAuthorized)]
 fun delete_jump_permit_with_auth_fails_wrong_auth() {


### PR DESCRIPTION
## Summary

Fixes the shadow-permit vulnerability in `world::gate` where a `JumpPermit` issued under one extension stayed valid after the gate's extension (`Auth` witness) was revoked or swapped. `validate_jump_permit` only checked `route_hash`, expiry, and character, never the extension -- so legacy permits could bypass the active extension's logic.

This is the **fresh-deployment** alternative to #153. Because we are deploying a new contract (no existing on-chain `JumpPermit` objects), we fix `JumpPermit` directly instead of introducing a backward-compatible `JumpPermitV2` + migration path. No new entrypoints, no migration tooling, no client/script changes.
