### PR TITLE
fix(scripts): deterministic localnet deploy of core and character

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ prd.md
 
 # contracts
 contracts/**/Pub.*.toml
+# ephemeral publish files (shared pubfile lives under deployments/)
+Pub.*.toml
 
 # Error decoder build artifacts
 tools/error-decoder/*.js

--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ npm run test
 ```
 
 ### Deploy Locally
+
+Deploys the Move packages (`core`, then `character`) to a **running** localnet. Start a
+local node first (e.g. `sui start --with-faucet --force-regenesis`) and fund your active
+address from the faucet.
+
 ```bash
-# Uses SUI_NETWORK from .env (default: localnet)
-pnpm deploy-world
+./scripts/deploy-world.sh localnet
 ```
 
 ### Progress on V1 
 TODO 
 - Docker files update 
 - All README's
-- scripts
 - Workflows 
    - integration test
    - publish to mvr 

--- a/scripts/deploy-world.sh
+++ b/scripts/deploy-world.sh
@@ -18,7 +18,9 @@ start_logging "$ENV" "deploy-world"
 PUBFILE="$REPO_ROOT/$DEPLOY_DIR/Pub.$ENV.toml"
 rm -f "$PUBFILE" "$REPO_ROOT"/contracts/*/Pub."$ENV".toml
 
-[[ "$ENV" == "localnet" ]] && sui client switch --env localnet >/dev/null
+# Pin the active env to the deploy target so publish + chain-identifier never
+# run against a stale selection (which would deploy to the wrong network).
+sui client switch --env "$ENV" >/dev/null
 
 echo "Deploying [${PACKAGES[*]}] to $ENV ..."
 for pkg in "${PACKAGES[@]}"; do

--- a/scripts/deploy-world.sh
+++ b/scripts/deploy-world.sh
@@ -1,24 +1,33 @@
 #!/usr/bin/env bash
-# Deploy world contracts.
+# Deploy the world Move packages (core, then character) to a network.
+# Assumes the target node is already running (for localnet, start it separately).
 # Usage: ./scripts/deploy-world.sh [localnet|testnet|mainnet|devnet]
 source "$(dirname "$0")/lib.sh"
 
+# Packages in dependency order (character depends on core).
+PACKAGES=(core character)
+
 setup
 ENV=$(get_env "${1:-}")
-pnpm clean
-rm -rf contracts/world/Pub.*.toml
-mkdir -p "deployments/$ENV"
+DEPLOY_DIR="deployments/$ENV"
+mkdir -p "$DEPLOY_DIR"
 start_logging "$ENV" "deploy-world"
 
-echo "--- pnpm i ---"
-pnpm i
+# Single shared pubfile so local deps resolve each other's published ids.
+# Lives under deployments/ (gitignored); ephemeral per node session.
+PUBFILE="$REPO_ROOT/$DEPLOY_DIR/Pub.$ENV.toml"
+rm -f "$PUBFILE" "$REPO_ROOT"/contracts/*/Pub."$ENV".toml
 
-# echo "--- sui client publish ---"
-# publish world "deployments/$ENV/world_package.json" "$ENV"
+[[ "$ENV" == "localnet" ]] && sui client switch --env localnet >/dev/null
 
-# echo "--- extract-object-ids ---"
-# export SUI_NETWORK="$ENV"
-# pnpm exec tsx ts-scripts/utils/extract-object-ids.ts
+echo "Deploying [${PACKAGES[*]}] to $ENV ..."
+for pkg in "${PACKAGES[@]}"; do
+    publish "$pkg" "$ENV" "$PUBFILE" "$DEPLOY_DIR/$pkg.publish.json"
+done
 
-# echo "Deployed world to $ENV. Output: deployments/$ENV/"
-# echo "Log: deployments/$ENV/deploy.log"
+CHAIN_ID=$(sui client chain-identifier)
+pnpm exec tsx ts-scripts/build-manifest.ts "$DEPLOY_DIR" "$CHAIN_ID" "${PACKAGES[@]}"
+
+echo "Deployed world to $ENV."
+echo "  Manifest: $DEPLOY_DIR/world.json"
+echo "  Log:      $DEPLOY_DIR/deploy.log"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -8,7 +8,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 setup() {
     cd "$REPO_ROOT"
-    [ -f .env ] && set -a && source .env && set +a
+    if [ -f .env ]; then
+        set -a
+        source .env
+        set +a
+    fi
 }
 
 get_env() {
@@ -32,52 +36,44 @@ start_logging() {
     exec 1> >(tee -a "$LOG") 2>&1
 }
 
-# publish() {
-#     local pkg=$1
-#     local out_file=$2
-#     local env=$3
-#     local localnet_pubfile=${4:-}
-#     local tmp tmp_err
-#     tmp=$(mktemp)
-#     tmp_err=$(mktemp)
-#     trap 'rm -f -- "$tmp" "$tmp_err"' RETURN
+# Publish one package to the current network and save the raw --json output.
+# Args: pkg env pubfile out_file
+#   pkg      package dir name under contracts/ (e.g. core)
+#   env      target env (localnet uses ephemeral test-publish; others use publish)
+#   pubfile  absolute path to a SHARED pubfile; all packages read/write the same
+#            file so local deps (character -> core) resolve their published ids
+#   out_file path to write the raw publish JSON to
+publish() {
+    local pkg=$1 env=$2 pubfile=$3 out_file=$4
+    local tmp tmp_err
+    tmp=$(mktemp)
+    tmp_err=$(mktemp)
+    trap 'rm -f -- "$tmp" "$tmp_err"' RETURN
 
-#     sui client switch --env "$env"
+    # JSON goes to stdout; build progress goes to stderr. Do not merge them.
+    if [[ "$env" == "localnet" ]]; then
+        (cd "contracts/$pkg" && sui client test-publish --build-env testnet --pubfile-path "$pubfile" --json) > "$tmp" 2> "$tmp_err" || true
+    else
+        (cd "contracts/$pkg" && sui client publish --json) > "$tmp" 2> "$tmp_err" || true
+    fi
 
-#     # JSON goes to stdout; build progress often goes to stderr. Do not merge (2>&1) or extract-json breaks.
-#     if [[ "$env" == "localnet" ]]; then
-#         if [[ -n "$localnet_pubfile" ]]; then
-#             # Path is relative to contracts/$pkg (same as test-publish cwd); check from there.
-#             if ! (cd "contracts/$pkg" && [[ -f "$localnet_pubfile" && -r "$localnet_pubfile" ]]); then
-#                 echo "Error: localnet pubfile not found or not readable: $localnet_pubfile (from contracts/$pkg)" >&2
-#                 exit 1
-#             fi
-#             (cd "contracts/$pkg" && sui client test-publish --build-env testnet --pubfile-path "$localnet_pubfile" --json) > "$tmp" 2> "$tmp_err" || true
-#         else
-#             (cd "contracts/$pkg" && sui client test-publish --build-env testnet --json) > "$tmp" 2> "$tmp_err" || true
-#         fi
-#     else
-#         (cd "contracts/$pkg" && sui client publish --json) > "$tmp" 2> "$tmp_err" || true
-#     fi
+    {
+        echo ""
+        echo "--- Publish $pkg output ---"
+        cat "$tmp"
+        if [[ -s "$tmp_err" ]]; then
+            echo "--- Publish $pkg stderr ---"
+            cat "$tmp_err"
+        fi
+    } >> "${LOG:-deployments/$env/deploy.log}"
 
-#     pnpm exec tsx ts-scripts/utils/extract-json.ts "$tmp" > "$out_file" || true
+    # On dependency/build errors sui prints a plain message to stdout, not JSON.
+    if [[ "$(head -c1 "$tmp")" != "{" ]]; then
+        echo "ERROR: publish '$pkg' failed:" >&2
+        cat "$tmp" "$tmp_err" >&2
+        exit 1
+    fi
 
-#     log="${LOG:-deployments/$env/deploy.log}"
-#     {
-#         echo ""
-#         echo "--- Publish output ---"
-#         cat "$tmp"
-#         if [[ -s "$tmp_err" ]]; then
-#             echo ""
-#             echo "--- Publish stderr ---"
-#             cat "$tmp_err"
-#         fi
-#     } >> "$log"
-
-#     if [[ ! -s "$out_file" ]]; then
-#         echo "" >&2
-#         echo "=== Publish failed. Raw output ===" >&2
-#         cat "$tmp" "$tmp_err" >&2
-#         exit 1
-#     fi
-# }
+    cp "$tmp" "$out_file"
+    echo "Published $pkg -> $out_file"
+}

--- a/ts-scripts/build-manifest.ts
+++ b/ts-scripts/build-manifest.ts
@@ -20,7 +20,7 @@ interface CreatedChange {
   type: "created";
   objectId: string;
   objectType: string;
-  owner: { Shared?: { initial_shared_version: number } } | unknown;
+  owner: { Shared?: { initial_shared_version: number | string } } | unknown;
 }
 
 type ObjectChange = PublishedChange | CreatedChange | { type: string };
@@ -38,7 +38,7 @@ interface PackageEntry {
 
 interface SharedObjectEntry {
   id: string;
-  initialSharedVersion: number;
+  initialSharedVersion: string;
   type: string;
 }
 
@@ -54,10 +54,11 @@ function isCreated(c: ObjectChange): c is CreatedChange {
   return c.type === "created";
 }
 
-function sharedVersion(owner: CreatedChange["owner"]): number | undefined {
+function sharedVersion(owner: CreatedChange["owner"]): string | undefined {
   if (typeof owner === "object" && owner !== null && "Shared" in owner) {
-    return (owner as { Shared: { initial_shared_version: number } }).Shared
-      .initial_shared_version;
+    const v = (owner as { Shared?: { initial_shared_version?: number | string } })
+      .Shared?.initial_shared_version;
+    return v === undefined ? undefined : String(v);
   }
   return undefined;
 }
@@ -89,13 +90,14 @@ function main(): void {
     const upgradeCap = changes.find(
       (c): c is CreatedChange => isCreated(c) && c.objectType === UPGRADE_CAP_TYPE
     );
+    if (!upgradeCap) throw new Error(`no UpgradeCap created in ${pkg}.publish.json`);
 
     manifest.packages[pkg] = {
       // Fresh publish: original id, published-at and package id are identical.
       // Upgrades (real envs) will need to read published-at from Published.toml.
       originalId: published.packageId,
       publishedAt: published.packageId,
-      upgradeCap: upgradeCap?.objectId ?? "",
+      upgradeCap: upgradeCap.objectId,
       version: Number(published.version),
     };
 

--- a/ts-scripts/build-manifest.ts
+++ b/ts-scripts/build-manifest.ts
@@ -1,0 +1,120 @@
+/**
+ * Build a deployment manifest (world.json) from `sui client publish --json` output.
+ *
+ * Captures what is NOT derivable on-chain: per-package ids/upgrade-caps, and the
+ * shared objects created at publish time (e.g. the core ObjectRegistry, whose id and
+ * initialSharedVersion every PTB needs). Clients (the SDK, seeding) read this file.
+ *
+ * Usage: tsx ts-scripts/build-manifest.ts <deployDir> <chainId> <pkg...>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface PublishedChange {
+  type: "published";
+  packageId: string;
+  version: string;
+}
+
+interface CreatedChange {
+  type: "created";
+  objectId: string;
+  objectType: string;
+  owner: { Shared?: { initial_shared_version: number } } | unknown;
+}
+
+type ObjectChange = PublishedChange | CreatedChange | { type: string };
+
+interface PublishOutput {
+  objectChanges?: ObjectChange[];
+}
+
+interface PackageEntry {
+  originalId: string;
+  publishedAt: string;
+  upgradeCap: string;
+  version: number;
+}
+
+interface SharedObjectEntry {
+  id: string;
+  initialSharedVersion: number;
+  type: string;
+}
+
+interface Manifest {
+  chainId: string;
+  packages: Record<string, PackageEntry>;
+  sharedObjects: Record<string, SharedObjectEntry>;
+}
+
+const UPGRADE_CAP_TYPE = "0x2::package::UpgradeCap";
+
+function isCreated(c: ObjectChange): c is CreatedChange {
+  return c.type === "created";
+}
+
+function sharedVersion(owner: CreatedChange["owner"]): number | undefined {
+  if (typeof owner === "object" && owner !== null && "Shared" in owner) {
+    return (owner as { Shared: { initial_shared_version: number } }).Shared
+      .initial_shared_version;
+  }
+  return undefined;
+}
+
+/** lower-camel key for a created shared object, from its `module::Struct` suffix. */
+function sharedKey(objectType: string): string {
+  const struct = objectType.split("::").pop() ?? objectType;
+  return struct.charAt(0).toLowerCase() + struct.slice(1);
+}
+
+function main(): void {
+  const [deployDir, chainId, ...packages] = process.argv.slice(2);
+  if (!deployDir || !chainId || packages.length === 0) {
+    console.error("Usage: tsx ts-scripts/build-manifest.ts <deployDir> <chainId> <pkg...>");
+    process.exit(1);
+  }
+
+  const manifest: Manifest = { chainId, packages: {}, sharedObjects: {} };
+
+  for (const pkg of packages) {
+    const out: PublishOutput = JSON.parse(
+      readFileSync(join(deployDir, `${pkg}.publish.json`), "utf8")
+    );
+    const changes = out.objectChanges ?? [];
+
+    const published = changes.find((c): c is PublishedChange => c.type === "published");
+    if (!published) throw new Error(`no published package in ${pkg}.publish.json`);
+
+    const upgradeCap = changes.find(
+      (c): c is CreatedChange => isCreated(c) && c.objectType === UPGRADE_CAP_TYPE
+    );
+
+    manifest.packages[pkg] = {
+      // Fresh publish: original id, published-at and package id are identical.
+      // Upgrades (real envs) will need to read published-at from Published.toml.
+      originalId: published.packageId,
+      publishedAt: published.packageId,
+      upgradeCap: upgradeCap?.objectId ?? "",
+      version: Number(published.version),
+    };
+
+    // Record every shared object created at publish (e.g. the ObjectRegistry).
+    for (const c of changes) {
+      if (!isCreated(c)) continue;
+      const v = sharedVersion(c.owner);
+      if (v === undefined) continue;
+      manifest.sharedObjects[sharedKey(c.objectType)] = {
+        id: c.objectId,
+        initialSharedVersion: v,
+        type: c.objectType,
+      };
+    }
+  }
+
+  const path = join(deployDir, "world.json");
+  writeFileSync(path, JSON.stringify(manifest, null, 2) + "\n");
+  console.log(`Wrote ${path}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
One command that deploys `core` + `character` to a running localnet and writes a single `world.json` manifest, replacing the manual multi-step flow where package and shared-object IDs had to be hand-copied downstream
