### PR TITLE
ci: pull prebuilt integration image instead of rebuilding per PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,21 +66,23 @@ jobs:
     # can iterate freely; mark the PR ready for review to run it.
     if: github.event.pull_request.draft == false
     needs: [sdk, contracts]
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}/world-integration:latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build integration image
-        uses: docker/build-push-action@v6
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: ./docker/Dockerfile.integration
-          tags: world-integration:latest
-          load: true
-          cache-from: type=gha,scope=integration
-          cache-to: type=gha,mode=max,scope=integration
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull integration image
+        run: docker pull "$IMAGE"
 
       - name: Run integration tests
         run: |
@@ -88,4 +90,4 @@ jobs:
             -v "${{ github.workspace }}:/app" \
             -w /app \
             -e CI=true \
-            world-integration:latest test
+            "$IMAGE" test

--- a/.github/workflows/publish-integration-image.yml
+++ b/.github/workflows/publish-integration-image.yml
@@ -1,0 +1,52 @@
+name: Publish Integration Image
+
+# Builds the integration toolchain image (Sui + Node + pnpm + genesis assets)
+# and pushes it to GHCR. 
+#
+# Triggers:
+#   - manual dispatch (ad-hoc refresh, e.g. after a Sui version bump)
+#   - push to dev touching docker/** (keeps the image from going stale)
+on:
+  workflow_dispatch:
+  push:
+    branches: [dev]
+    paths:
+      - 'docker/Dockerfile.integration'
+      - 'docker/entrypoint-integration.sh'
+      - 'docker/entrypoint-snapshot-image.sh'
+      - 'docker/fullnode.yaml'
+      - 'docker/genesis/**'
+      - '.github/workflows/publish-integration-image.yml'
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/world-integration
+
+jobs:
+  publish:
+    name: Build & push integration image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.integration
+          tags: ${{ env.IMAGE }}:latest
+          push: true
+          cache-from: type=gha,scope=integration
+          cache-to: type=gha,mode=max,scope=integration

--- a/.github/workflows/publish-integration-image.yml
+++ b/.github/workflows/publish-integration-image.yml
@@ -46,7 +46,9 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.integration
-          tags: ${{ env.IMAGE }}:latest
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
           push: true
           cache-from: type=gha,scope=integration
           cache-to: type=gha,mode=max,scope=integration

--- a/.github/workflows/publish-integration-image.yml
+++ b/.github/workflows/publish-integration-image.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.integration
+          platforms: linux/amd64
+          provenance: false
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}


### PR DESCRIPTION
## Problem
PR integration job rebuilds the Docker image every run — up to ~4 min, while tests only take ~20s. 
(toolchain + genesis only; source is mounted).

eg: https://github.com/evefrontier/world-contracts/actions/runs/28093890472/job/83178424340?pr=186


**Changes**
- New `publish-integration-image.yml` :  builds + pushes image to GHCR.
- `pr.yml` : integration job now pulls the image instead of building it.
