### PR TITLE
fix(deploy): make testnet deploy/upgrade work end-to-end in ci

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG SUI_VERSION=testnet-v1.69.1
+ARG SUI_VERSION=testnet-v1.74.0
 ARG PNPM_VERSION=9
 FROM mysten/sui-tools:${SUI_VERSION} AS dependency-stage
 

--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -33,6 +33,15 @@ export_artifacts() {
     cp "deployments/$TARGET_ENV/world.json" "$dir/world.json"
 }
 
+# drop any committed [published.<env>] entry so the
+# fresh publish doesn't hit "package already published". upgrade keeps it.
+if [[ "$MODE" == "deploy" ]]; then
+    for pkg in $PACKAGES; do
+        run pnpm exec tsx ts-scripts/clear-published.ts \
+            "contracts/$pkg/Published.toml" "$TARGET_ENV"
+    done
+fi
+
 # Publish/upgrade on the target network, then refresh the manifest + SDK preset.
 run ./scripts/deploy-world.sh "$TARGET_ENV" "$MODE"
 

--- a/scripts/mvr.sh
+++ b/scripts/mvr.sh
@@ -92,6 +92,11 @@ cmd_set_network() {
     [[ -z "$app_cap" ]] && { echo "ERROR: no appCap for $pkg/$env — run set-appcap (from bootstrap register)" >&2; exit 1; }
 
     ensure_client_env mainnet "$(get_rpc live)"
+
+    sui client ptb \
+        --move-call "$MVR_CORE_MAINNET::move_registry::unset_network" \
+            "@$MVR_REGISTRY" "@$app_cap" "\"$MVR_TESTNET_CHAIN_ID\"" \
+        || echo "unset_network: no existing mapping for $pkg (first deploy)"
     sui client ptb \
         --move-call 0x1::option::some "<0x2::object::ID>" "@$pi_id" --assign pinfo \
         --move-call 0x1::option::some "<address>" "@$pkg_addr" --assign pid \

--- a/sdk/world-sdk/scripts/configure-admins.ts
+++ b/sdk/world-sdk/scripts/configure-admins.ts
@@ -10,7 +10,14 @@ import type { Env } from '../src/config/types.js'
 import { addAdmins, addSponsors } from '../src/packages/core.js'
 
 const DEPLOY_ENV = process.env.ENV ?? 'localnet'
-const SDK_ENV = (DEPLOY_ENV === 'localnet' ? 'local' : DEPLOY_ENV) as Env
+const SDK_ENV = DEPLOY_ENV === 'localnet' ? 'local' : DEPLOY_ENV
+const VALID_ENVS: readonly Env[] = ['local', 'dev', 'uat', 'test', 'live']
+if (!VALID_ENVS.includes(SDK_ENV as Env)) {
+  throw new Error(
+    `unknown ENV "${DEPLOY_ENV}" (want localnet|${VALID_ENVS.join('|')})`,
+  )
+}
+const env = SDK_ENV as Env
 const MANIFEST = fileURLToPath(
   new URL(`../../../deployments/${DEPLOY_ENV}/world.json`, import.meta.url),
 )
@@ -38,9 +45,7 @@ const keypair = Ed25519Keypair.fromSecretKey(privateKey)
 
 const config = loadWorldConfig(MANIFEST)
 const rpcUrl =
-  SDK_ENV === 'local'
-    ? undefined
-    : getJsonRpcFullnodeUrl(envProfile(SDK_ENV).network)
+  env === 'local' ? undefined : getJsonRpcFullnodeUrl(envProfile(env).network)
 const client = createWorldClient({ config, rpcUrl })
 
 const tx = new Transaction()

--- a/sdk/world-sdk/scripts/configure-admins.ts
+++ b/sdk/world-sdk/scripts/configure-admins.ts
@@ -1,14 +1,18 @@
 import { fileURLToPath } from 'node:url'
+import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc'
 import 'dotenv/config'
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519'
 import { Transaction } from '@mysten/sui/transactions'
 import { createWorldClient } from '../src/client.js'
+import { envProfile } from '../src/config/env.js'
 import { loadWorldConfig } from '../src/config/load.js'
+import type { Env } from '../src/config/types.js'
 import { addAdmins, addSponsors } from '../src/packages/core.js'
 
-const ENV = process.env.ENV ?? 'localnet'
+const DEPLOY_ENV = process.env.ENV ?? 'localnet'
+const SDK_ENV = (DEPLOY_ENV === 'localnet' ? 'local' : DEPLOY_ENV) as Env
 const MANIFEST = fileURLToPath(
-  new URL(`../../../deployments/${ENV}/world.json`, import.meta.url),
+  new URL(`../../../deployments/${DEPLOY_ENV}/world.json`, import.meta.url),
 )
 
 // Comma-separated list of addresses, e.g. 0x..,0x..
@@ -33,7 +37,11 @@ if (!privateKey) {
 const keypair = Ed25519Keypair.fromSecretKey(privateKey)
 
 const config = loadWorldConfig(MANIFEST)
-const client = createWorldClient({ config })
+const rpcUrl =
+  SDK_ENV === 'local'
+    ? undefined
+    : getJsonRpcFullnodeUrl(envProfile(SDK_ENV).network)
+const client = createWorldClient({ config, rpcUrl })
 
 const tx = new Transaction()
 if (admins.length > 0) addAdmins(tx, config, admins)

--- a/ts-scripts/clear-published.ts
+++ b/ts-scripts/clear-published.ts
@@ -1,0 +1,25 @@
+/**
+ * Remove the [published.<env>] table from a package's Published.toml so a fresh
+ * `deploy` can record a new lineage. No-op if the file or entry is absent.
+ *
+ * Usage: tsx ts-scripts/clear-published.ts <Published.toml> <env>
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { parse as parseToml, stringify as stringifyToml } from '@iarna/toml'
+
+const [file, env] = process.argv.slice(2)
+if (!file || !env) {
+  console.error('Usage: clear-published.ts <Published.toml> <env>')
+  process.exit(1)
+}
+if (!existsSync(file)) process.exit(0)
+
+const toml = parseToml(readFileSync(file, 'utf8')) as {
+  published?: Record<string, unknown>
+}
+if (!toml.published?.[env]) process.exit(0)
+
+delete toml.published[env]
+if (Object.keys(toml.published).length === 0) delete toml.published
+writeFileSync(file, stringifyToml(toml))
+console.log(`Cleared [published.${env}] from ${file}`)


### PR DESCRIPTION
- bump CI sui to testnet-v1.74.0 (proto 126)
- clear [published.<env>] before fresh deploy 
- set_network: unset then set, so re-deploy repoints MVR
- configure:admins: use target-network RPC, not localnet