### PR TITLE
chore: update Published.toml and Move.lock for testnet_stillness

### DIFF
--- a/contracts/assets/Published.toml
+++ b/contracts/assets/Published.toml
@@ -12,12 +12,12 @@ upgrade-capability = "0x20d2782bafff72df38e854cc813879f4513ee7a5dc14225c2a2889b1
 
 [published.testnet_stillness]
 chain-id = "4c78adac"
-published-at = "0x2a66a89b5a735738ffa4423ac024d23571326163f324f9051557617319e59d60"
-original-id = "0x2a66a89b5a735738ffa4423ac024d23571326163f324f9051557617319e59d60"
+published-at = "0xac361aa5ceb726bd974f885c9dea9e55dc9bc98fa1f5731c5965a810707bf0b8"
+original-id = "0xac361aa5ceb726bd974f885c9dea9e55dc9bc98fa1f5731c5965a810707bf0b8"
 version = 1
-toolchain-version = "1.67.1"
+toolchain-version = "1.74.0"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x7be14e8d115f6b4031a015c8ff3a2fbfd9b0086b7bc1a79d089abcf5eac42a82"
+upgrade-capability = "0x4fd9d93aca5383580f4142e40b22a10c89de22aeb6a9556580dfea2d7ad768c4"
 
 [published.testnet_utopia]
 chain-id = "4c78adac"

--- a/contracts/extension_examples/Move.lock
+++ b/contracts/extension_examples/Move.lock
@@ -27,3 +27,27 @@ source = { local = "../world" }
 use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet_stillness.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "b124567746b3a78a7e294ac2de265f693401ec9d" }
+use_environment = "testnet_stillness"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet_stillness.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "b124567746b3a78a7e294ac2de265f693401ec9d" }
+use_environment = "testnet_stillness"
+manifest_digest = "38D8855849DF7CA0FAD3B9510DD9EC3755149F5B283E45CA6547194ADFF90D73"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet_stillness.extension_examples]
+source = { root = true }
+use_environment = "testnet_stillness"
+manifest_digest = "322B638CF4A392ED1066EBFAB27290B5F66C03C1713AC921AC3252ED6F77B315"
+deps = { std = "MoveStdlib", sui = "Sui", world = "world" }
+
+[pinned.testnet_stillness.world]
+source = { local = "../world" }
+use_environment = "testnet_stillness"
+manifest_digest = "16363423CD37589C5B9A56E3F9E984FED988276E0134635135B45CB4480A9484"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/contracts/world/Published.toml
+++ b/contracts/world/Published.toml
@@ -22,12 +22,12 @@ upgrade-capability = "0x17b0dd46c4babd4527bc046c71cfa771c1443604b68e978578e045d8
 
 [published.testnet_stillness]
 chain-id = "4c78adac"
-published-at = "0xd2fd1224f881e7a705dbc211888af11655c315f2ee0f03fe680fc3176e6e4780"
-original-id = "0x28b497559d65ab320d9da4613bf2498d5946b2c0ae3597ccfda3072ce127448c"
-version = 2
-toolchain-version = "1.69.1"
+published-at = "0x8b8a46ed766fa1358ce7c5c51f6a164b13d627a63e45343f69ed0ba0446c1aa1"
+original-id = "0x8b8a46ed766fa1358ce7c5c51f6a164b13d627a63e45343f69ed0ba0446c1aa1"
+version = 1
+toolchain-version = "1.74.0"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x678a2aa04da281218a692f082f0f7b2c6eb5d0baf51698d9733b660e036f0610"
+upgrade-capability = "0xe8e70deca7715bd8393164930f380046a29fc1017e7708486feea3dcaae5f6cf"
 
 [published.testnet_utopia]
 chain-id = "4c78adac"


### PR DESCRIPTION
update Published.toml and Move.lock for testnet_stillness for cycle 6