### PR TITLE
fix(deploy): don't fail deploy when PR creation is blocked by policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,4 +140,4 @@ jobs:
             --head "$branch" \
             --title "$title" \
             --body "Automated deployment records for \`${{ inputs.env }}\` from image \`${{ inputs.image_tag }}\` (mode: ${{ inputs.mode }}, version: ${{ inputs.version }}, commit: ${{ github.sha }})." \
-            || echo "PR creation blocked; open one from: https://github.com/${{ github.repository }}/pull/new/${branch}"
+            || echo "PR creation blocked; open one from: https://github.com/${{ github.repository }}/compare/dev...${branch}?expand=1"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,8 +133,11 @@ jobs:
           title="deploy(${{ inputs.env }}): ${{ inputs.image_tag }}"
           git commit -m "$title [skip ci]"
           git push origin "HEAD:${branch}"
+          # PR creation may be blocked by org policy; the records branch is
+          # already pushed, so print a link to open it.
           gh pr create \
             --base dev \
             --head "$branch" \
             --title "$title" \
-            --body "Automated deployment records for \`${{ inputs.env }}\` from image \`${{ inputs.image_tag }}\` (mode: ${{ inputs.mode }}, version: ${{ inputs.version }}, commit: ${{ github.sha }})."
+            --body "Automated deployment records for \`${{ inputs.env }}\` from image \`${{ inputs.image_tag }}\` (mode: ${{ inputs.mode }}, version: ${{ inputs.version }}, commit: ${{ github.sha }})." \
+            || echo "PR creation blocked; open one from: https://github.com/${{ github.repository }}/pull/new/${branch}"


### PR DESCRIPTION
- handle PR creation failure and provide manual link for deployment records

fixes this deploy workflow failure 
https://github.com/evefrontier/world-contracts/actions/runs/28436901692/job/84264921068