### PR TITLE
fix(ci): unblock esbuild build script and pin pnpm via packageManager

### DIFF
--- a/.github/workflows/deploy-decoder.yml
+++ b/.github/workflows/deploy-decoder.yml
@@ -24,10 +24,9 @@ jobs:
       - uses: actions/checkout@v5
       
       - name: Setup pnpm
+        # version is read from the "packageManager" field in package.json
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,10 +21,9 @@ jobs:
           node-version: '24'
       
       - name: Setup pnpm
+        # version is read from the "packageManager" field in package.json
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,20 +7,25 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js and pnpm
+# Install Node.js, then enable pnpm via corepack
+# (pnpm version is pinned by the "packageManager" field in package.json)
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g pnpm \
+    && corepack enable \
     && rm -rf /var/lib/apt/lists/*
 
+# Let corepack download the pinned pnpm without an interactive prompt
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 # Verify installations
-RUN sui --version && node --version && pnpm --version && jq --version
+RUN sui --version && node --version && jq --version
 
 WORKDIR /app
 
 # Copy package files and install dependencies with pnpm
-COPY package*.json pnpm-lock.yaml ./
-RUN pnpm install --no-frozen-lockfile
+# (pnpm version is resolved from the "packageManager" field in package.json)
+COPY package*.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm --version && pnpm install --no-frozen-lockfile
 
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "description": "contracts for eve frontier",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "build": "find contracts -maxdepth 1 -mindepth 1 -type d | xargs -P 4 -I {} sui move build --path {}",
     "test": "find contracts -maxdepth 1 -mindepth 1 -type d | xargs -P 4 -I {} sui move test --path {}",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
The Docker build failed with ERR_PNPM_IGNORED_BUILDS because pnpm 10+
blocks dependency build scripts by default. esbuild (pulled in
transitively via tsx) has an install script that was ignored, causing
`pnpm install` to exit non-zero. CI also failed once a pnpm version was
pinned, because pnpm/action-setup hardcoded a conflicting version.

- Add pnpm-workspace.yaml with `allowBuilds: esbuild: true` to approve
  the build script non-interactively (the package.json "pnpm" field is
  no longer read by pnpm 11).
- Pin the pnpm version via the "packageManager" field in package.json as
  the single source of truth, and bootstrap it in Docker with corepack
  instead of an unpinned `npm install -g pnpm`.
- Copy pnpm-workspace.yaml into the image so the approval is present at
  install time.
- Drop the hardcoded `version: 9` from pnpm/action-setup@v4 in pr.yml and
  deploy-decoder.yml so CI resolves pnpm from the packageManager field,
  removing the "Multiple versions of pnpm specified" conflict.

The packageManager field now drives the pnpm version across local dev,
Docker (corepack), and CI (action-setup).

Resolves https://fenriscreations.atlassian.net/browse/EF-16267.