### PR TITLE
fix(ci): complete pnpm 9→corepack migration for integration image

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,14 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       
+      - name: Setup pnpm
+        # version is read from the "packageManager" field in package.json
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-      
-      - name: Setup pnpm
-        # version is read from the "packageManager" field in package.json
-        uses: pnpm/action-setup@v4
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docker/Dockerfile.integration
+++ b/docker/Dockerfile.integration
@@ -20,7 +20,7 @@ RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends nodejs \
     && corepack enable \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && command -v curl >/dev/null && command -v git >/dev/null && command -v jq >/dev/null && command -v dos2unix >/dev/null && command -v node >/dev/null
+    && command -v curl >/dev/null && command -v git >/dev/null && command -v jq >/dev/null && command -v dos2unix >/dev/null && command -v node >/dev/null && command -v corepack >/dev/null && command -v pnpm >/dev/null
 
 # pnpm version is pinned by the "packageManager" field in package.json (mounted at /app).
 # Let corepack download the pinned pnpm without an interactive prompt.

--- a/docker/Dockerfile.integration
+++ b/docker/Dockerfile.integration
@@ -2,7 +2,6 @@
 # Pin versions for reproducible CI. Override with build-args if needed.
 FROM docker.io/library/ubuntu:24.04
 
-ARG PNPM_VERSION=9
 # Sui version/network: testnet, devnet, mainnet, or a version tag.
 # Must match Move.toml/Move.lock rev (e.g. testnet-v1.66.2) so the CLI can parse the lockfile.
 ARG SUI_VERSION=testnet-v1.66.2
@@ -19,9 +18,13 @@ RUN apt-get -o Acquire::Retries=3 update \
     dos2unix \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends nodejs \
-    && npm install -g "pnpm@${PNPM_VERSION}" \
+    && corepack enable \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && command -v curl >/dev/null && command -v git >/dev/null && command -v jq >/dev/null && command -v dos2unix >/dev/null && command -v node >/dev/null
+
+# pnpm version is pinned by the "packageManager" field in package.json (mounted at /app).
+# Let corepack download the pinned pnpm without an interactive prompt.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 ENV PATH="/root/.local/bin:/root/.suiup/bin:${PATH}"
 RUN curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh \


### PR DESCRIPTION
PR #195 migrated docker/Dockerfile to corepack (pnpm 11.9.0 from the packageManager field) and added a settings-only pnpm-workspace.yaml, but docker/Dockerfile.integration was left pinned to pnpm 9. That image runs the entrypoint, which calls `pnpm install --frozen-lockfile` at runtime. pnpm 9 treats pnpm-workspace.yaml strictly as a workspace definition and requires a `packages` field, so it aborted with "packages field missing or empty" — failing the release image build. pnpm 10/11 tolerate a settings-only workspace file.

- Dockerfile.integration: drop `ARG PNPM_VERSION=9` and the `npm install -g pnpm@9`; bootstrap pnpm via `corepack enable` and set COREPACK_ENABLE_DOWNLOAD_PROMPT=0, matching docker/Dockerfile. pnpm is now resolved from the packageManager field (mounted at /app), keeping a single source of truth across local/Docker/CI.
- pr.yml: reorder Setup pnpm before Setup Node.js and add `cache: 'pnpm'` to match deploy-decoder.yml (setup-node's pnpm cache requires pnpm to be installed first).

Verified: reverting the fix reproduces the exact CI error under pnpm 9; the corepack image runs `pnpm install --frozen-lockfile` cleanly on pnpm 11.9.0; and the pr.yml lint job passes end-to-end via act (install, fmt:check, and pnpm cache save all succeed).