### PR TITLE
fix: emit-only V2 inventory events; drop dead V1 structs and update w…

### DIFF
--- a/contracts/world/sources/primitives/inventory.move
+++ b/contracts/world/sources/primitives/inventory.move
@@ -126,30 +126,10 @@ public struct ItemBurnedEvent has copy, drop {
     quantity: u32,
 }
 
-public struct ItemDepositedEvent has copy, drop {
-    assembly_id: ID,
-    assembly_key: TenantItemId,
-    character_id: ID,
-    character_key: TenantItemId,
-    item_id: u64,
-    type_id: u64,
-    quantity: u32,
-}
-
 public struct ItemDepositedEventV2 has copy, drop {
     assembly_id: ID,
     assembly_key: TenantItemId,
     inventory_key: ID,
-    character_id: ID,
-    character_key: TenantItemId,
-    item_id: u64,
-    type_id: u64,
-    quantity: u32,
-}
-
-public struct ItemWithdrawnEvent has copy, drop {
-    assembly_id: ID,
-    assembly_key: TenantItemId,
     character_id: ID,
     character_key: TenantItemId,
     item_id: u64,

--- a/ts-scripts/storage-unit/withdraw-deposit.ts
+++ b/ts-scripts/storage-unit/withdraw-deposit.ts
@@ -74,11 +74,11 @@ async function withdraw(
     console.log("Transaction digest:", result.digest);
 
     const withdrawEvent = result.events?.find((event) =>
-        event.type.endsWith("::inventory::ItemWithdrawnEvent")
+        event.type.endsWith("::inventory::ItemWithdrawnEventV2")
     );
 
     if (!withdrawEvent) {
-        throw new Error("ItemWithdrawnEvent not found in transaction result");
+        throw new Error("ItemWithdrawnEventV2 not found in transaction result");
     }
 
     console.log("withdrawEvent:", withdrawEvent);


### PR DESCRIPTION
…ithdraw script

Commit #155 added ItemDepositedEventV2/ItemWithdrawnEventV2 (with the inventory_key discriminator) and switched event::emit to the V2 structs, but left the original ItemDepositedEvent/ItemWithdrawnEvent structs defined and never emitted. Their now-unused fields triggered W09009 (unused struct field), which the pinned CI toolchain (mysten/sui-tools:testnet-v1.64.0) treats as a hard error, breaking `sui move build` (xargs exit 123) in the Release/Deploy build-and-test job.

The integration test also still matched the pre-V2 event type and failed with "ItemWithdrawnEvent not found in transaction result".

- Remove the dead V1 ItemDepositedEvent and ItemWithdrawnEvent structs
- Point withdraw-deposit.ts at ::inventory::ItemWithdrawnEventV2

Verified against the pinned toolchain:
- docker build --target build-stage / test-stage: builds clean, 289 + 5 Move tests pass, W09009 gone
- act push -j build-and-test (release.yml): job succeeds from scratch
- docker run world-integration test: full 30-step flow passes, incl. the previously-failing withdraw-deposit step