### PR TITLE
feat(ci): build native multi-arch release and snapshot images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,45 +16,131 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Run full test pipeline
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile
           target: test-stage
-      
+
       # TODO: Add integration tests here
       # TODO: Add smoke tests for deployed contracts
 
-  release-image:
-    name: Build and Push Release Image
-    runs-on: ubuntu-latest
+  bake:
+    name: Bake ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     needs: build-and-test
     permissions:
       contents: read
-      packages: write  
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
-      
-      # Setup QEMU for multi-platform builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      # Setup Docker Buildx
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      # Labels only; final tags are assembled in the merge job. Same for every arch.
+      # The tags block is only here so the semver pattern drives
+      # org.opencontainers.image.version to the docker-style "1.2.3" (no leading v),
+      # matching the image tags rather than the git tag.
+      - name: Extract labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest
+
+      # --- Base release image: build natively for this arch, push by digest (no tag). ---
+      - name: Build base image and push by digest
+        id: base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: release-stage
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Disable provenance so outputs.digest is a plain single-platform image
+          # manifest (not an attestation index); keeps the merged index to exactly
+          # the two platforms with no unknown/unknown entries.
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }},push-by-digest=true,push=true
+
+      - name: Export base digest
+        env:
+          BASE_DIGEST: ${{ steps.base.outputs.digest }}
+          ARCH: ${{ matrix.arch }}
+          DIGEST_DIR: /tmp/digests
+        run: ./scripts/export-base-digest.sh
+
+      # --- Snapshot image: native bake, push a fixed per-arch temp tag, capture digest. ---
+      - name: Bake and push snapshot (pre-baked container state)
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          OWNER: ${{ env.REPO_OWNER }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SNAPSHOT_OUT_REF: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }}:snapshot-tmp-${{ matrix.arch }}
+          SNAPSHOT_DIGEST_FILE: /tmp/digests/snapshot/${{ matrix.arch }}
+          METADATA_LABELS: ${{ steps.meta.outputs.labels }}
+        run: ./scripts/bake-snapshot-image.sh
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifests
+    runs-on: ubuntu-latest
+    needs: bake
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -67,22 +153,14 @@ jobs:
             type=sha
             type=raw,value=latest
 
-      - name: Build and push release image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          target: release-stage
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Bake and push snapshot image (pre-baked container state)
+      - name: Create multi-arch manifests from per-arch digests
         env:
-          REGISTRY: ${{ env.REGISTRY }}
-          OWNER: ${{ env.REPO_OWNER }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          METADATA_TAGS: ${{ steps.meta.outputs.tags }}
-          METADATA_LABELS: ${{ steps.meta.outputs.labels }}
-        run: ./scripts/bake-snapshot-image.sh
+          BASE_NAME: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }}
+          FINAL_TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST_DIR: /tmp/digests
+        run: ./scripts/create-multiarch-manifests.sh
+
+      - name: Verify final manifests are multi-arch
+        env:
+          FINAL_TAGS: ${{ steps.meta.outputs.tags }}
+        run: ./scripts/verify-multiarch-manifests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,8 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v5
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,14 @@
 
-FROM mysten/sui-tools:testnet-v1.64.0 AS dependency-stage
+# mysten/sui-tools has no multi-arch manifest: amd64 lives under the plain tag,
+# arm64 under a separate "-arm64" tag. Declare both and let BuildKit pick the one
+# matching the build's TARGETARCH (base-amd64 / base-arm64), so a native arm64
+# build (Apple Silicon) gets a real arm64 base instead of an emulated amd64 one.
+ARG SUI_TOOLS_VERSION=testnet-v1.64.0
+FROM mysten/sui-tools:${SUI_TOOLS_VERSION} AS base-amd64
+FROM mysten/sui-tools:${SUI_TOOLS_VERSION}-arm64 AS base-arm64
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS dependency-stage
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,8 @@ Images are on **GitHub Container Registry**:
 
 Tags line up with releases (e.g. version numbers, `latest`). Check this repo’s **Packages** on GitHub for what’s available.
 
+These images are published as **multi-arch manifests** (`linux/amd64` + `linux/arm64`), so Docker automatically pulls the variant matching your machine. On **Apple Silicon** that means a native `arm64` image — drop any `DOCKER_DEFAULT_PLATFORM=linux/amd64` override or `--platform linux/amd64` flag, which would otherwise force the slower emulated amd64 image.
+
 ## Object IDs on your machine (`extracted-object-ids.json`)
 
 Tests need the **package and object IDs** that exist on this chain. The image ships that list as JSON.

--- a/scripts/bake-snapshot-image.sh
+++ b/scripts/bake-snapshot-image.sh
@@ -5,10 +5,22 @@ set -euo pipefail
 REGISTRY="${REGISTRY:-ghcr.io}"
 OWNER="${OWNER:-${GITHUB_REPOSITORY_OWNER:-}}"
 IMAGE_NAME="${IMAGE_NAME:-world-contracts}"
-TAG="${TAG:-${GITHUB_REF_NAME:-local}}"
 
 BAKER_IMAGE="${BAKER_IMAGE:-${IMAGE_NAME}-snapshot:baker}"
-OUT_IMAGE="${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}"
+
+# The single, fixed per-arch temp ref this bake pushes to. CI sets this to a
+# tag like ghcr.io/<owner>/world-contracts:snapshot-tmp-<arch>; the tag is
+# reused (self-overwriting) each release so it never accumulates. The multi-arch
+# manifest is assembled downstream from the pushed image's digest, not this tag.
+SNAPSHOT_OUT_REF="${SNAPSHOT_OUT_REF:-${REGISTRY}/${OWNER}/${IMAGE_NAME}:snapshot-tmp-local}"
+
+# Optional: file to write the pushed image digest (sha256:...) to, so CI can
+# upload it as an artifact and stitch the multi-arch manifest by digest.
+SNAPSHOT_DIGEST_FILE="${SNAPSHOT_DIGEST_FILE:-}"
+
+# Optional: newline-separated key=value labels (docker/metadata-action output)
+# baked onto the committed image.
+METADATA_LABELS="${METADATA_LABELS:-}"
 
 if [ -z "$OWNER" ]; then
     echo "ERROR: OWNER is empty. Set OWNER or GITHUB_REPOSITORY_OWNER." >&2
@@ -20,16 +32,10 @@ if [ -z "$IMAGE_NAME" ]; then
     exit 1
 fi
 
-if [ -z "$TAG" ]; then
-    echo "ERROR: TAG is empty. Set TAG or GITHUB_REF_NAME." >&2
+if [ -z "$SNAPSHOT_OUT_REF" ]; then
+    echo "ERROR: SNAPSHOT_OUT_REF is empty. Set SNAPSHOT_OUT_REF to the per-arch temp ref." >&2
     exit 1
 fi
-
-# Optional: pass through docker/metadata-action outputs (multiline strings).
-# - METADATA_TAGS: newline-separated image refs (e.g. ghcr.io/org/img:1.2.3)
-# - METADATA_LABELS: newline-separated key=value labels
-METADATA_TAGS="${METADATA_TAGS:-}"
-METADATA_LABELS="${METADATA_LABELS:-}"
 
 cleanup() {
     if [ -n "${CID:-}" ]; then
@@ -38,7 +44,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# 1) Build the baker image (should run chain + deploy + exit 0)
+# 1) Build the baker image (should run chain + deploy + exit 0).
+#    Native to the runner arch: on an arm64 runner suiup fetches the arm64 sui
+#    binary, so the committed snapshot is a genuine arm64 image.
 docker build -f docker/Dockerfile.integration -t "$BAKER_IMAGE" .
 
 # 2) Run bake container (mount workspace so pnpm install / deploy scripts can run)
@@ -75,14 +83,30 @@ fi
 
 IMAGE_ID="$(docker commit "${commit_args[@]}" "$CID")"
 
-# 5) Tag + push
-if [ -n "$METADATA_TAGS" ]; then
-    while IFS= read -r ref; do
-        [ -z "$ref" ] && continue
-        docker tag "$IMAGE_ID" "${ref}-snapshot"
-        docker push "${ref}-snapshot"
-    done <<<"$METADATA_TAGS"
-else
-    docker tag "$IMAGE_ID" "${OUT_IMAGE}-snapshot"
-    docker push "${OUT_IMAGE}-snapshot"
+# 5) Tag + push the single fixed temp ref, then record the pushed digest so the
+#    merge job can build the multi-arch manifest by digest (race-safe, no cleanup).
+docker tag "$IMAGE_ID" "$SNAPSHOT_OUT_REF"
+push_output="$(docker push "$SNAPSHOT_OUT_REF")"
+printf '%s\n' "$push_output"
+
+digest="$(printf '%s\n' "$push_output" | grep -oE 'sha256:[0-9a-f]{64}' | head -n1 || true)"
+
+if [ -z "$digest" ]; then
+    # Fallback: read the digest back from the local image's RepoDigests.
+    repo="${SNAPSHOT_OUT_REF%:*}"
+    digest="$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$SNAPSHOT_OUT_REF" \
+        | grep -oE "${repo}@sha256:[0-9a-f]{64}" | grep -oE 'sha256:[0-9a-f]{64}' | head -n1 || true)"
+fi
+
+if [ -z "$digest" ]; then
+    echo "ERROR: could not determine pushed image digest for $SNAPSHOT_OUT_REF" >&2
+    exit 1
+fi
+
+echo "Pushed ${SNAPSHOT_OUT_REF} (${digest})"
+
+if [ -n "$SNAPSHOT_DIGEST_FILE" ]; then
+    mkdir -p "$(dirname "$SNAPSHOT_DIGEST_FILE")"
+    printf '%s\n' "$digest" >"$SNAPSHOT_DIGEST_FILE"
+    echo "Wrote digest to ${SNAPSHOT_DIGEST_FILE}"
 fi

--- a/scripts/create-multiarch-manifests.sh
+++ b/scripts/create-multiarch-manifests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Assemble multi-arch manifests for the base and snapshot images from the
+# per-arch image digests produced by the bake matrix. Each final base tag gets
+# a manifest, and the snapshot image reuses each tag with a "-snapshot" suffix.
+# Referencing images by digest (not by the temp tags) keeps this race-safe.
+#
+# Inputs (env):
+#   BASE_NAME    Fully-qualified image name without tag
+#                (e.g. ghcr.io/evefrontier/world-contracts). Required.
+#   FINAL_TAGS   Newline-separated list of fully-qualified final tags for the
+#                base image (docker/metadata-action output). Required.
+#   DIGEST_DIR   Directory holding the per-arch digest files, laid out as
+#                base/<arch> and snapshot/<arch>. Default: /tmp/digests.
+
+set -euo pipefail
+
+BASE_NAME="${BASE_NAME:?BASE_NAME is required}"
+FINAL_TAGS="${FINAL_TAGS:?FINAL_TAGS is required}"
+DIGEST_DIR="${DIGEST_DIR:-/tmp/digests}"
+
+base_amd64="$(cat "${DIGEST_DIR}/base/amd64")"
+base_arm64="$(cat "${DIGEST_DIR}/base/arm64")"
+snap_amd64="$(cat "${DIGEST_DIR}/snapshot/amd64")"
+snap_arm64="$(cat "${DIGEST_DIR}/snapshot/arm64")"
+
+for d in "$base_amd64" "$base_arm64" "$snap_amd64" "$snap_arm64"; do
+    case "$d" in
+        sha256:*) : ;;
+        *) echo "ERROR: missing or malformed digest: '$d'" >&2; exit 1 ;;
+    esac
+done
+
+while IFS= read -r tag; do
+    [ -z "$tag" ] && continue
+
+    echo "== base manifest: ${tag}"
+    docker buildx imagetools create -t "${tag}" \
+        "${BASE_NAME}@${base_amd64}" "${BASE_NAME}@${base_arm64}"
+
+    echo "== snapshot manifest: ${tag}-snapshot"
+    docker buildx imagetools create -t "${tag}-snapshot" \
+        "${BASE_NAME}@${snap_amd64}" "${BASE_NAME}@${snap_arm64}"
+done <<< "${FINAL_TAGS}"

--- a/scripts/export-base-digest.sh
+++ b/scripts/export-base-digest.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Persist the base image's per-arch digest to the shared digest directory so the
+# merge job can assemble the multi-arch manifest. Written to
+# <DIGEST_DIR>/base/<ARCH>.
+#
+# Inputs (env):
+#   BASE_DIGEST  The sha256:... digest emitted by the base image build. Required.
+#   ARCH         Architecture key (amd64 / arm64). Required.
+#   DIGEST_DIR   Root directory for digest files. Default: /tmp/digests.
+
+set -euo pipefail
+
+BASE_DIGEST="${BASE_DIGEST:?BASE_DIGEST is required}"
+ARCH="${ARCH:?ARCH is required}"
+DIGEST_DIR="${DIGEST_DIR:-/tmp/digests}"
+
+case "$BASE_DIGEST" in
+    sha256:*) : ;;
+    *) echo "ERROR: BASE_DIGEST is not a sha256 digest: '$BASE_DIGEST'" >&2; exit 1 ;;
+esac
+
+mkdir -p "${DIGEST_DIR}/base"
+printf '%s\n' "$BASE_DIGEST" > "${DIGEST_DIR}/base/${ARCH}"
+echo "Wrote base digest for ${ARCH}: ${BASE_DIGEST}"

--- a/scripts/verify-multiarch-manifests.sh
+++ b/scripts/verify-multiarch-manifests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Assert that every final manifest (base and each "-snapshot" counterpart) is a
+# multi-arch index containing all required platforms. Pure inspection — no image
+# is pulled-and-run, so it can't be tripped up by emulation.
+#
+# Inputs (env):
+#   FINAL_TAGS  Newline-separated list of fully-qualified base tags. Each is
+#               checked, along with its "-snapshot" counterpart. Required.
+#   PLATFORMS   Space-separated platforms that must be present.
+#               Default: "linux/amd64 linux/arm64".
+
+set -euo pipefail
+
+FINAL_TAGS="${FINAL_TAGS:?FINAL_TAGS is required}"
+PLATFORMS="${PLATFORMS:-linux/amd64 linux/arm64}"
+
+read -ra required_platforms <<< "${PLATFORMS}"
+
+fail=0
+
+check() {
+    local ref="$1"
+    local out
+    echo "== inspecting ${ref}"
+    out="$(docker buildx imagetools inspect "${ref}")"
+    echo "${out}"
+    for plat in "${required_platforms[@]}"; do
+        if ! grep -q "${plat}" <<< "${out}"; then
+            echo "ERROR: ${ref} is missing platform ${plat}" >&2
+            fail=1
+        fi
+    done
+}
+
+while IFS= read -r tag; do
+    [ -z "$tag" ] && continue
+    check "${tag}"
+    check "${tag}-snapshot"
+done <<< "${FINAL_TAGS}"
+
+exit "${fail}"


### PR DESCRIPTION
ARM Macs pulling the GHCR snapshot image got an amd64 build that ran under emulation and hung at 100% CPU without ever opening the service ports. Two root causes:

- The base image (docker/Dockerfile) hardcoded the amd64-only mysten/sui-tools tag, so its linux/arm64 build was never a genuine arm64 image. sui-tools ships arm64 under a separate "-arm64" tag with no combined multi-arch manifest.
- The snapshot image is produced via `docker commit` on a running container, which can only capture the runner's architecture (amd64).

Build both images natively per architecture and stitch them into multi-arch manifests:

- docker/Dockerfile: select the base per TARGETARCH (base-amd64 / base-arm64) so a native arm64 build uses the arm64 sui-tools base.
- release.yml: run a bake matrix on ubuntu-latest (amd64) and ubuntu-24.04-arm (arm64). Each leg pushes the base image by digest (no tag) and bakes the snapshot to a fixed per-arch temp tag, exporting both digests as artifacts. A merge job assembles the final base and -snapshot manifests from those digests (race-safe, no registry cleanup) and verifies both platforms are present.
- scripts/: bake-snapshot-image.sh now pushes one per-arch ref and emits its digest; add export-base-digest.sh, create-multiarch-manifests.sh, and verify-multiarch-manifests.sh.
- docker/README.md: note images are published multi-arch; Apple Silicon users should drop any linux/amd64 platform override.

Verified natively on Apple Silicon that `docker buildx build --platform linux/arm64 --target release-stage` produces a real arm64 image with a working sui toolchain. The arm64 CI bake and manifest assembly only exercise on a tagged release run.