### PR TITLE
fix(ci): stabilize per-arch builds (sui config race, suiup install)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,12 +48,22 @@ FROM dependency-stage AS lint-stage
 RUN pnpm run fmt:check
 
 FROM dependency-stage AS build-stage
-# Build all Move contracts in parallel
-RUN find contracts -maxdepth 1 -mindepth 1 -type d | \
+# Build all Move contracts in parallel. The first `sui` invocation creates
+# ~/.sui/{client.yaml,sui.aliases}; running several in parallel (xargs -P 4)
+# makes concurrent first-runs race and corrupt those files ("EOF while parsing
+# a value", "Cannot deserialize aliases file"), which fails the build
+# nondeterministically. Build one package serially first to create the config,
+# then build them all in parallel against the now-existing config.
+RUN set -eu; \
+    first="$(find contracts -maxdepth 1 -mindepth 1 -type d | head -n1)"; \
+    sui move build --path "$first"; \
+    find contracts -maxdepth 1 -mindepth 1 -type d | \
     xargs -P 4 -I {} sui move build --path {}
 
 FROM build-stage AS test-stage
-# Run all tests in parallel
+# Run all tests in parallel. Safe to parallelize: the Sui config was already
+# created in build-stage and is inherited via this FROM, so there is no
+# concurrent first-run config race here.
 RUN find contracts -maxdepth 1 -mindepth 1 -type d | \
     xargs -P 4 -I {} sui move test --path {}
 

--- a/docker/Dockerfile.integration
+++ b/docker/Dockerfile.integration
@@ -27,7 +27,23 @@ RUN apt-get -o Acquire::Retries=3 update \
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 ENV PATH="/root/.local/bin:/root/.suiup/bin:${PATH}"
-RUN curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh \
+
+# Install suiup from a pinned release rather than piping its install.sh. The
+# upstream installer resolves its own latest version by grepping the GitHub API
+# with a sed that assumes pretty-printed JSON; when the API returns compact JSON
+# (which a GitHub Actions build hit -- the API doesn't guarantee formatting) the
+# whole JSON blob becomes the "version" and the download URL breaks ("curl: (3)
+# nested brace in URL"). Pinning the release avoids that call entirely and makes
+# the image reproducible; the arch suffix keeps it correct for amd64 and arm64.
+ARG SUIUP_VERSION=v0.0.13
+RUN case "$(uname -m)" in \
+        x86_64) suiup_arch=x86_64 ;; \
+        aarch64 | arm64) suiup_arch=arm64 ;; \
+        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/MystenLabs/suiup/releases/download/${SUIUP_VERSION}/suiup-Linux-musl-${suiup_arch}.tar.gz" -o /tmp/suiup.tar.gz \
+    && tar -xzf /tmp/suiup.tar.gz -C /usr/local/bin suiup \
+    && rm /tmp/suiup.tar.gz \
     && echo y | suiup install "sui@${SUI_VERSION}" \
     && sui --version
 


### PR DESCRIPTION
Neither failure is caused by the multi-arch build changes. Both live in pre-existing code that work didn't touch: the parallel Move build predates it, and docker/Dockerfile.integration's installer is unchanged. They are long-standing, latent/intermittent issues -- a build-time race that amd64 usually happened to win, and an upstream installer that only breaks when GitHub serves compact JSON -- that the new native per-arch pipeline finally surfaced by actually exercising the arm64 build and rebuilding the integration image.

The two independent, nondeterministic failure points:

- docker/Dockerfile: the parallel `sui move build` (xargs -P 4) let concurrent first-runs of `sui` create ~/.sui/{client.yaml,sui.aliases} at the same time, racing and corrupting them ("EOF while parsing a value", "Cannot deserialize aliases file"). Build one package serially first so the config exists, then build the rest in parallel; test-stage inherits that config via FROM and is safe.

- docker/Dockerfile.integration: `curl install.sh | sh` failed because suiup's installer resolves its own version by grepping the GitHub API with a sed that assumes pretty-printed JSON. When the API returned compact JSON, the entire release blob became the "version" and the download URL broke ("curl: (3) nested brace in URL"). Install a pinned suiup release directly (arch-aware), which also removes the unpinned pipe-to-sh and makes the image reproducible.

Verified with native arm64 builds: the config is created once with no corruption and all contracts build; the integration image installs suiup and `sui --version` reports 1.66.2.