### PR TITLE
perf(ci): drop leftover suiup download cache from snapshot image

### DIFF
--- a/docker/Dockerfile.integration
+++ b/docker/Dockerfile.integration
@@ -45,7 +45,8 @@ RUN case "$(uname -m)" in \
     && tar -xzf /tmp/suiup.tar.gz -C /usr/local/bin suiup \
     && rm /tmp/suiup.tar.gz \
     && echo y | suiup install "sui@${SUI_VERSION}" \
-    && sui --version
+    && sui --version \
+    && rm -rf /root/.cache/suiup
 
 WORKDIR /app
 ENV SUI_CONFIG_DIR=/root/.sui


### PR DESCRIPTION
`suiup install sui@...` leaves the downloaded release archive at ~/.cache/suiup/releases/*.tgz (~740 MB) after extracting it. Because that tarball is already gzipped it barely re-compresses, so it dominated the pushed layer and every pull.

Remove ~/.cache/suiup in the same RUN. The cache is only used during install; the runtime entrypoint (`sui start ...`) and the bake never touch it.

Effect: the snapshot image's compressed pull drops from ~1086 MB to ~345 MB (~68%), and it's no longer one oversized serial layer.

Verified on a native arm64 build: the suiup install layer shrank from 1.16 GB to 381 MB, the cache is gone, and the image still runs end to end (genesis -> localnet -> faucet -> `sui client gas` all succeed).