### PR TITLE
refactor(docker): Use fixed test accounts for snapshot bake and ship keys in the image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -51,12 +51,13 @@ Builders and service tests need to **act as** the accounts that exist on the bak
 
 > ⚠️ **Test keys only.** These private keys are committed and public on purpose. They exist solely to drive the local snapshot chain. **Never** use these accounts on a real/public network or fund them with real assets.
 
-Four **distinct** accounts (`sponsor` is deliberately different from `governor`, `admin`, and `player`):
+Four **distinct** roles (`sponsor` is deliberately different from `governor`, `admin`, and the players):
 
 - **`governor`** — deployed the contracts; owns the `GovernorCap`.
 - **`admin`** — owns the builder `AdminCap`, is the registered server address, and is an admin in the `AdminACL`.
 - **`sponsor`** — has lots of SUI, both a coin balance and an [address balance](https://docs.sui.io/onchain-finance/asset-custody/address-balances/) (EF-17526); added to the `AdminACL`.
-- **`player`** — already owns a character on the baked chain.
+- **`player`** — player A (`PLAYER_A`); owns a character on the baked chain.
+- **`player_b`** — player B (`PLAYER_B`); second player for multi-user scripts and builder extensions.
 
 Each entry has an `address` and a `privateKey` (Sui bech32 `suiprivkey1…`), ready to import with `sui keytool import` or load directly in the TS SDK. The same keys are committed at [`docker/genesis/accounts.json`](genesis/accounts.json).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,6 +43,23 @@ Small JSON with a `network` name and two groups of IDs:
 
 Your services or tests read these hex IDs when calling the chain (e.g. which package to target, which objects to pass into transactions).
 
+## Accounts and keys on your machine (`accounts.json`)
+
+Builders and service tests need to **act as** the accounts that exist on the baked chain, so the image also ships their private keys and addresses. Like the object IDs, this file is baked into the image and copied onto the host on container start:
+
+`deployments/localnet-snapshot/accounts.json`
+
+> ⚠️ **Test keys only.** These private keys are committed and public on purpose. They exist solely to drive the local snapshot chain. **Never** use these accounts on a real/public network or fund them with real assets.
+
+Four **distinct** accounts (`sponsor` is deliberately different from `governor`, `admin`, and `player`):
+
+- **`governor`** — deployed the contracts; owns the `GovernorCap`.
+- **`admin`** — owns the builder `AdminCap`, is the registered server address, and is an admin in the `AdminACL`.
+- **`sponsor`** — has lots of SUI, both a coin balance and an [address balance](https://docs.sui.io/onchain-finance/asset-custody/address-balances/) (EF-17526); added to the `AdminACL`.
+- **`player`** — already owns a character on the baked chain.
+
+Each entry has an `address` and a `privateKey` (Sui bech32 `suiprivkey1…`), ready to import with `sui keytool import` or load directly in the TS SDK. The same keys are committed at [`docker/genesis/accounts.json`](genesis/accounts.json).
+
 ## Integration image (localnet from scratch)
 
 Build and run the same flow as CI (genesis, deploy, integration tests):

--- a/docker/docker-compose-snapshot-image.yml
+++ b/docker/docker-compose-snapshot-image.yml
@@ -24,9 +24,10 @@ services:
       - 9123:9123
       - 9125:9125
     volumes:
-      # Host folder for object IDs. On first start the container copies the baked JSON from the
-      # image into this mount (see entrypoint-snapshot-image.sh), so the file appears on the host
-      # at ../deployments/localnet-snapshot/extracted-object-ids.json. Needs :rw for that seed step.
+      # Host folder for the baked artifacts. On first start the container copies the baked JSON
+      # files from the image into this mount (see entrypoint-snapshot-image.sh), so they appear on
+      # the host at ../deployments/localnet-snapshot/{extracted-object-ids,accounts}.json. Needs
+      # :rw for that seed step.
       - ../deployments/localnet-snapshot:/data/deployment:rw
     environment:
       POSTGRES_CONNECTION_STRING: "postgres://postgres:postgres@postgres:5432/postgres"

--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -8,10 +8,15 @@ CLIENT_YAML="$SUI_CFG/client.yaml"
 INIT_MARKER="$SUI_CFG/.initialized"
 APP_ENV="/app/.env"
 APP_ENV_EXAMPLE="/app/env.example"
+ACCOUNTS_JSON="${ACCOUNTS_JSON:-/app/docker/genesis/accounts.json}"
 
-# ---------- first-run: create keys ----------
+# ---------- first-run: import the fixed test keys ----------
 if [ ! -f "$INIT_MARKER" ]; then
-  echo "[ci] First run — initialising keys..."
+  echo "[ci] First run — importing fixed test keys from $ACCOUNTS_JSON..."
+  if [ ! -f "$ACCOUNTS_JSON" ]; then
+    echo "[ci] ERROR: accounts file not found at $ACCOUNTS_JSON" >&2
+    exit 1
+  fi
   mkdir -p "$SUI_CFG"
   printf '%s' '[]' > "$KEYSTORE"
   cat > "$CLIENT_YAML" << EOF
@@ -29,13 +34,18 @@ EOF
 
   printf 'y\n' | sui client switch --env localnet 2>/dev/null || true
 
-  echo "[ci] Creating keypairs: ADMIN, PLAYER_A, PLAYER_B..."
-  for alias in ADMIN PLAYER_A PLAYER_B; do
-    printf '\n' | sui client new-address ed25519 "$alias" \
-      || { echo "[ci] ERROR: failed to create $alias" >&2; exit 1; }
-  done
+  echo "[ci] Importing keypairs from $ACCOUNTS_JSON..."
+  while IFS= read -r key; do
+    alias="$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+    pk="$(jq -r --arg k "$key" '.accounts[$k].privateKey' "$ACCOUNTS_JSON")"
+    if [ -z "$pk" ] || [ "$pk" = "null" ]; then
+      echo "[ci] ERROR: no privateKey for '$key' in $ACCOUNTS_JSON" >&2; exit 1
+    fi
+    sui keytool import "$pk" ed25519 --alias "$alias" \
+      || { echo "[ci] ERROR: failed to import $alias" >&2; exit 1; }
+  done < <(jq -r '.accounts | keys[]' "$ACCOUNTS_JSON")
   touch "$INIT_MARKER"
-  echo "[ci] Keys created."
+  echo "[ci] Keys imported."
 fi
 
 # ---------- start local node ----------
@@ -69,15 +79,50 @@ echo "[ci] RPC ready."
 
 # ---------- fund accounts ----------
 printf 'y\n' | sui client switch --env localnet 2>/dev/null || true
-echo "[ci] Funding accounts from faucet..."
-for alias in ADMIN PLAYER_A PLAYER_B; do
-  sui client switch --address "$alias"
+
+# One faucet grant for the given alias, with retries.
+faucet_once() {
+  local alias="$1"
+  sui client switch --address "$alias" >/dev/null
   for attempt in 1 2 3; do
-    sui client faucet 2>&1 && break
-    [ "$attempt" -eq 3 ] && { echo "[ci] Faucet failed for $alias" >&2; exit 1; }
+    sui client faucet 2>&1 && return 0
+    [ "$attempt" -eq 3 ] && { echo "[ci] Faucet failed for $alias" >&2; return 1; }
     sleep 2
   done
+}
+
+FAUCET_GRANTS="${FAUCET_GRANTS:-5}"
+SPONSOR_FAUCET_GRANTS="${SPONSOR_FAUCET_GRANTS:-50}"
+echo "[ci] Funding GOVERNOR, ADMIN, PLAYER from faucet ($FAUCET_GRANTS grants each)..."
+for alias in GOVERNOR ADMIN PLAYER; do
+  for _ in $(seq 1 "$FAUCET_GRANTS"); do
+    faucet_once "$alias" || exit 1
+    sleep 1
+  done
 done
+
+echo "[ci] Funding SPONSOR from faucet ($SPONSOR_FAUCET_GRANTS grants)..."
+for _ in $(seq 1 "$SPONSOR_FAUCET_GRANTS"); do
+  faucet_once SPONSOR || exit 1
+  sleep 1
+done
+
+sui client switch --address SPONSOR >/dev/null
+SPONSOR_ADDRESS="$(sui client active-address)"
+# Pick one gas coin to deposit whole into the address balance.
+SPONSOR_COIN="$(sui client gas --json 2>/dev/null | jq -r '.[0].gasCoinId // .[0].id // empty')"
+if [ -n "$SPONSOR_COIN" ]; then
+  echo "[ci] Depositing coin $SPONSOR_COIN into SPONSOR address balance..."
+  sui client call \
+    --package 0x2 --module coin --function send_funds \
+    --type-args 0x2::sui::SUI \
+    --args "$SPONSOR_COIN" "$SPONSOR_ADDRESS" \
+    --gas-budget 100000000 \
+    || echo "[ci] WARN: send_funds failed; sponsor still has its coin balance" >&2
+else
+  echo "[ci] WARN: no sponsor coin found; skipping address-balance deposit" >&2
+fi
+
 sui client switch --address ADMIN
 
 # ---------- export keys and generate /app/.env ----------
@@ -90,15 +135,17 @@ require_val() {
   fi
 }
 
+GOVERNOR_ADDRESS=$(get_address GOVERNOR)
 ADMIN_ADDRESS=$(get_address ADMIN)
-PLAYER_A_ADDRESS=$(get_address PLAYER_A)
-PLAYER_B_ADDRESS=$(get_address PLAYER_B)
+SPONSOR_ADDRESS=$(get_address SPONSOR)
+PLAYER_ADDRESS=$(get_address PLAYER)
+GOVERNOR_PRIVATE_KEY=$(get_key GOVERNOR)
 ADMIN_PRIVATE_KEY=$(get_key ADMIN)
-PLAYER_A_PRIVATE_KEY=$(get_key PLAYER_A)
-PLAYER_B_PRIVATE_KEY=$(get_key PLAYER_B)
+SPONSOR_PRIVATE_KEY=$(get_key SPONSOR)
+PLAYER_PRIVATE_KEY=$(get_key PLAYER)
 
-for var in ADMIN_ADDRESS PLAYER_A_ADDRESS PLAYER_B_ADDRESS \
-           ADMIN_PRIVATE_KEY PLAYER_A_PRIVATE_KEY PLAYER_B_PRIVATE_KEY; do
+for var in GOVERNOR_ADDRESS ADMIN_ADDRESS SPONSOR_ADDRESS PLAYER_ADDRESS \
+           GOVERNOR_PRIVATE_KEY ADMIN_PRIVATE_KEY SPONSOR_PRIVATE_KEY PLAYER_PRIVATE_KEY; do
   require_val "$var" "${!var}"
 done
 
@@ -107,11 +154,11 @@ if [ -f "$APP_ENV_EXAMPLE" ]; then
   sed -e 's/\r$//' "$APP_ENV_EXAMPLE" | \
   sed -e "s|^SUI_NETWORK=.*|SUI_NETWORK=localnet|" \
       -e "s|^ADMIN_ADDRESS=.*|ADMIN_ADDRESS=$ADMIN_ADDRESS|" \
-      -e "s|^SPONSOR_ADDRESSES=.*|SPONSOR_ADDRESSES=$ADMIN_ADDRESS|" \
+      -e "s|^SPONSOR_ADDRESSES=.*|SPONSOR_ADDRESSES=$ADMIN_ADDRESS,$SPONSOR_ADDRESS|" \
+      -e "s|^GOVERNOR_PRIVATE_KEY=.*|GOVERNOR_PRIVATE_KEY=$GOVERNOR_PRIVATE_KEY|" \
       -e "s|^ADMIN_PRIVATE_KEY=.*|ADMIN_PRIVATE_KEY=$ADMIN_PRIVATE_KEY|" \
-      -e "s|^GOVERNOR_PRIVATE_KEY=.*|GOVERNOR_PRIVATE_KEY=$ADMIN_PRIVATE_KEY|" \
-      -e "s|^PLAYER_A_PRIVATE_KEY=.*|PLAYER_A_PRIVATE_KEY=$PLAYER_A_PRIVATE_KEY|" \
-      -e "s|^PLAYER_B_PRIVATE_KEY=.*|PLAYER_B_PRIVATE_KEY=$PLAYER_B_PRIVATE_KEY|" \
+      -e "s|^PLAYER_A_PRIVATE_KEY=.*|PLAYER_A_PRIVATE_KEY=$PLAYER_PRIVATE_KEY|" \
+      -e "s|^PLAYER_B_PRIVATE_KEY=.*|PLAYER_B_PRIVATE_KEY=$ADMIN_PRIVATE_KEY|" \
   > "$APP_ENV"
   echo "[ci] .env written."
 else
@@ -123,6 +170,9 @@ if [ $# -eq 1 ]; then
 
   cd /app
   export CI="${CI:-true}"
+
+  echo "[ci] Switching to GOVERNOR for deployment..."
+  sui client switch --address GOVERNOR >/dev/null
 
   pnpm install --frozen-lockfile
   pnpm deploy-world localnet
@@ -136,6 +186,12 @@ if [ $# -eq 1 ]; then
     DELAY_SECONDS="${DELAY_SECONDS:-3}" ./scripts/run-integration-test.sh
   elif [ "$1" = "snapshot" ]; then
     echo "[ci] Building snapshot image..."
+
+    # create-character reads SUI_NETWORK from .env (localnet) and assigns a
+    # character to PLAYER_A = the player key.
+    echo "[ci] Seeding a character for the player..."
+    DELAY_SECONDS="${DELAY_SECONDS:-3}" pnpm create-character \
+      || { echo "[ci] ERROR: failed to seed player character" >&2; exit 1; }
 
     echo "[ci] Shutting down node..."
     if kill -0 "$NODE_PID" 2>/dev/null; then
@@ -167,10 +223,13 @@ if [ $# -eq 1 ]; then
     mv /entrypoint-snapshot-image.sh /entrypoint.sh
     chmod a+x /entrypoint.sh
 
-    # Unmounted copy used at runtime to seed an empty host bind mount at /data/deployment.
+    # Unmounted copies used at runtime to seed an empty host bind mount at /data/deployment.
     echo "[ci] Copying extracted object ids to /opt/world-contracts/extracted-object-ids.json..."
     mkdir -p /opt/world-contracts
     cp deployments/localnet/extracted-object-ids.json /opt/world-contracts/extracted-object-ids.json
+
+    echo "[ci] Copying accounts to /opt/world-contracts/accounts.json..."
+    cp "$ACCOUNTS_JSON" /opt/world-contracts/accounts.json
   fi
 else
   echo "[ci] Localnet ready. Running command..."

--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -93,8 +93,8 @@ faucet_once() {
 
 FAUCET_GRANTS="${FAUCET_GRANTS:-5}"
 SPONSOR_FAUCET_GRANTS="${SPONSOR_FAUCET_GRANTS:-50}"
-echo "[ci] Funding GOVERNOR, ADMIN, PLAYER from faucet ($FAUCET_GRANTS grants each)..."
-for alias in GOVERNOR ADMIN PLAYER; do
+echo "[ci] Funding GOVERNOR, ADMIN, PLAYER, PLAYER_B from faucet ($FAUCET_GRANTS grants each)..."
+for alias in GOVERNOR ADMIN PLAYER PLAYER_B; do
   for _ in $(seq 1 "$FAUCET_GRANTS"); do
     faucet_once "$alias" || exit 1
     sleep 1
@@ -139,13 +139,15 @@ GOVERNOR_ADDRESS=$(get_address GOVERNOR)
 ADMIN_ADDRESS=$(get_address ADMIN)
 SPONSOR_ADDRESS=$(get_address SPONSOR)
 PLAYER_ADDRESS=$(get_address PLAYER)
+PLAYER_B_ADDRESS=$(get_address PLAYER_B)
 GOVERNOR_PRIVATE_KEY=$(get_key GOVERNOR)
 ADMIN_PRIVATE_KEY=$(get_key ADMIN)
 SPONSOR_PRIVATE_KEY=$(get_key SPONSOR)
 PLAYER_PRIVATE_KEY=$(get_key PLAYER)
+PLAYER_B_PRIVATE_KEY=$(get_key PLAYER_B)
 
-for var in GOVERNOR_ADDRESS ADMIN_ADDRESS SPONSOR_ADDRESS PLAYER_ADDRESS \
-           GOVERNOR_PRIVATE_KEY ADMIN_PRIVATE_KEY SPONSOR_PRIVATE_KEY PLAYER_PRIVATE_KEY; do
+for var in GOVERNOR_ADDRESS ADMIN_ADDRESS SPONSOR_ADDRESS PLAYER_ADDRESS PLAYER_B_ADDRESS \
+           GOVERNOR_PRIVATE_KEY ADMIN_PRIVATE_KEY SPONSOR_PRIVATE_KEY PLAYER_PRIVATE_KEY PLAYER_B_PRIVATE_KEY; do
   require_val "$var" "${!var}"
 done
 
@@ -158,7 +160,7 @@ if [ -f "$APP_ENV_EXAMPLE" ]; then
       -e "s|^GOVERNOR_PRIVATE_KEY=.*|GOVERNOR_PRIVATE_KEY=$GOVERNOR_PRIVATE_KEY|" \
       -e "s|^ADMIN_PRIVATE_KEY=.*|ADMIN_PRIVATE_KEY=$ADMIN_PRIVATE_KEY|" \
       -e "s|^PLAYER_A_PRIVATE_KEY=.*|PLAYER_A_PRIVATE_KEY=$PLAYER_PRIVATE_KEY|" \
-      -e "s|^PLAYER_B_PRIVATE_KEY=.*|PLAYER_B_PRIVATE_KEY=$ADMIN_PRIVATE_KEY|" \
+      -e "s|^PLAYER_B_PRIVATE_KEY=.*|PLAYER_B_PRIVATE_KEY=$PLAYER_B_PRIVATE_KEY|" \
   > "$APP_ENV"
   echo "[ci] .env written."
 else
@@ -187,9 +189,8 @@ if [ $# -eq 1 ]; then
   elif [ "$1" = "snapshot" ]; then
     echo "[ci] Building snapshot image..."
 
-    # create-character reads SUI_NETWORK from .env (localnet) and assigns a
-    # character to PLAYER_A = the player key.
-    echo "[ci] Seeding a character for the player..."
+    # create-character reads PLAYER_A/PLAYER_B from .env and seeds both characters.
+    echo "[ci] Seeding characters for PLAYER and PLAYER_B..."
     DELAY_SECONDS="${DELAY_SECONDS:-3}" pnpm create-character \
       || { echo "[ci] ERROR: failed to seed player character" >&2; exit 1; }
 

--- a/docker/entrypoint-snapshot-image.sh
+++ b/docker/entrypoint-snapshot-image.sh
@@ -12,13 +12,20 @@ echo "starting sui with indexer and graphql"
 echo "========================"
 
 # If /data/deployment is an empty host bind mount, it hides the baked layer; copy from a path that
-# is never mounted so the same file appears on the host and in-container.
+# is never mounted so the same files appear on the host and in-container.
+mkdir -p /data/deployment
+
 SEED=/opt/world-contracts/extracted-object-ids.json
 if [ -f "$SEED" ]; then
-    mkdir -p /data/deployment
-
     cp -f "$SEED" /data/deployment/extracted-object-ids.json
     echo "Seeded /data/deployment/extracted-object-ids.json from image (synced to host mount)."
+fi
+
+# The well-known test keypairs + addresses for the baked accounts (EF-17566).
+ACCOUNTS_SEED=/opt/world-contracts/accounts.json
+if [ -f "$ACCOUNTS_SEED" ]; then
+    cp -f "$ACCOUNTS_SEED" /data/deployment/accounts.json
+    echo "Seeded /data/deployment/accounts.json from image (synced to host mount)."
 fi
 
 exec sui start --network.config /data/sui-localnet --with-faucet --with-indexer="$POSTGRES_CONNECTION_STRING" --with-graphql=0.0.0.0:9125

--- a/docker/genesis/accounts.json
+++ b/docker/genesis/accounts.json
@@ -17,9 +17,14 @@
       "privateKey": "suiprivkey1qpvmq2zh83uezwr8hl6ft7gahrp7ugr92car8pwv8awccjzhs9r3k257k3h"
     },
     "player": {
-      "role": "Player that already owns a character on the baked chain.",
+      "role": "Player A (PLAYER_A) that owns a character on the baked chain.",
       "address": "0x9a9f6b4def31aeb6b58e8694def775dab5b3cd493ef03dc8e6d65db50ef2e72e",
       "privateKey": "suiprivkey1qre8d4j577wc54kxly57yx62mhacxsj5uw6lc9ymkse9yvv8n8ezqtgrmaz"
+    },
+    "player_b": {
+      "role": "Player B (PLAYER_B) for second-player integration and builder extension scripts.",
+      "address": "0xaedf8c880a42b8e6dd99e9303c146f45e242acc4c5ddb4c04420669fa9411969",
+      "privateKey": "suiprivkey1qp6htvlvnle9hwzqxp0kwdvdmkelr9lk923fyg79mjaczkssd7wlqwqen2a"
     }
   }
 }

--- a/docker/genesis/accounts.json
+++ b/docker/genesis/accounts.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "TEST-ONLY well-known keys baked into the world-contracts snapshot image. These private keys are PUBLIC and committed on purpose so downstream builders/services can act on the pre-deployed contracts. NEVER use these accounts on a real/public network or fund them with real assets",
+  "accounts": {
+    "governor": {
+      "role": "Deploys the contracts and owns the GovernorCap.",
+      "address": "0xcb77ca2dc01819602e2f89774d7ac2574c7913562f9c1576e51e6f2ba61925bd",
+      "privateKey": "suiprivkey1qpppu2z48dr7xzzax47wpe2z5xd7uka5v823kydmu8jrh799q7f5uk09amz"
+    },
+    "admin": {
+      "role": "Owns the builder AdminCap, registered as server address, and is an admin in the AdminACL.",
+      "address": "0x2cec7e1911f1d95838d68d64124faaf01b4d492942f11bf7e4c6a37df9fffa6d",
+      "privateKey": "suiprivkey1qz20s9zeyhyj9zh0r7800t3q7aj7rel8h27v958z0ddsxdgehtqlw2mmk89"
+    },
+    "sponsor": {
+      "role": "Sponsor with lots of SUI (coin balance + address balance)",
+      "address": "0x4cbd72cbc2b80721bcd08fbcc7e1ee8fb2ae070b800855d2f6f9a264b81f81b9",
+      "privateKey": "suiprivkey1qpvmq2zh83uezwr8hl6ft7gahrp7ugr92car8pwv8awccjzhs9r3k257k3h"
+    },
+    "player": {
+      "role": "Player that already owns a character on the baked chain.",
+      "address": "0x9a9f6b4def31aeb6b58e8694def775dab5b3cd493ef03dc8e6d65db50ef2e72e",
+      "privateKey": "suiprivkey1qre8d4j577wc54kxly57yx62mhacxsj5uw6lc9ymkse9yvv8n8ezqtgrmaz"
+    }
+  }
+}


### PR DESCRIPTION
## Why 
- Downstream services need stable, known identities on the baked localnet chain.
- Add address balance funds to the sponsor to suport address balancing for the gas pool

## Changes 
- Add `docker/genesis/accounts.json` with four fixed test-only accounts (governor, admin, sponsor, player) - Rework `entrypoint-integration.sh` to import keys from that file and fund them.
- Fix snapshot bake for distinct admin vs sponsor.
- Export `accounts.json` in the snapshot image and copy it to the host mount on start .
