### PR TITLE
fix: integration test

### DIFF
--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -179,6 +179,9 @@ if [ $# -eq 1 ]; then
   pnpm install --frozen-lockfile
   pnpm deploy-world localnet
   pnpm run configure-world localnet
+
+  echo "[ci] Switching to ADMIN for builder deployment..."
+  sui client switch --address ADMIN >/dev/null
   pnpm deploy-builder-ext localnet
 
   if [ "$1" = "test" ]; then


### PR DESCRIPTION
- Deploy the builder extension as **ADMIN** so the builder `AdminCap` is owned by the admin account
