### PR TITLE
Add v1 freight receipt for exact Item cross-entity delivery.

### DIFF
--- a/contracts/freight/.gitignore
+++ b/contracts/freight/.gitignore
@@ -1,0 +1,5 @@
+build/*
+traces/*
+.trace
+.coverage*
+Pub.*.toml

--- a/contracts/freight/Move.toml
+++ b/contracts/freight/Move.toml
@@ -1,0 +1,20 @@
+[package]
+name = "freight"
+edition = "2024"         # edition = "legacy" to use legacy (pre-2024) Move
+# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
+[dependencies]
+core = { local = "../core" }
+inventory = { local = "../inventory" }
+
+# Per-env deploy targets. dev/test/uat are independent deployments on the same
+# testnet chain (distinguished by name);
+[environments]
+dev = "4c78adac"
+test = "4c78adac"
+uat = "4c78adac"
+# live = "35834a8a"  # mainnet — deferred (R2)
+
+# Read more about the package management system options:
+# https://docs.sui.io/guides/developer/packages/move-package-management

--- a/contracts/freight/sources/freight.move
+++ b/contracts/freight/sources/freight.move
@@ -1,0 +1,228 @@
+/// Additive freight receipt for cross-entity inventory delivery.
+///
+/// v1 inventory withdraws create transferable `Item`s with no `parent_id`. This
+/// package binds one exact withdrawn `Item` to a source, destination, tenant,
+/// and carrier so a later deposit can prove the haul was authorized — without
+/// changing `core` or `inventory`.
+///
+/// Typical action composition:
+/// - pickup: proximity (injected) → caller → inventory withdraw → freight pickup
+/// - dropoff: proximity (injected) → caller → freight dropoff → inventory deposit
+///
+/// Current entity proximity is hash equality only (`location_service` TODO for
+/// signed proofs). This receipt is the freight-layer authorization; it does not
+/// claim cryptographic anti-teleport locality by itself.
+module freight::freight;
+
+use core::{entity::Entity, request::Request, requirement::{Self, Requirement}};
+use inventory::item::Item;
+use std::{internal::Permit, string::String};
+use sui::{bcs, event};
+
+// === Errors ===
+
+#[error(code = 0)]
+const EWrongEntity: vector<u8> = b"Request does not target this entity";
+#[error(code = 1)]
+const ENotAuthorized: vector<u8> = b"No caller recorded; action must carry a caller requirement";
+#[error(code = 2)]
+const EWrongDestination: vector<u8> = b"Freight receipt destination does not match this entity";
+#[error(code = 3)]
+const EWrongCarrier: vector<u8> = b"Freight receipt carrier does not match the authorized caller";
+#[error(code = 4)]
+const ETenantMismatch: vector<u8> = b"Freight cannot cross tenants";
+#[error(code = 5)]
+const EItemMismatch: vector<u8> = b"Item object id does not match the freight receipt";
+#[error(code = 6)]
+const ETypeMismatch: vector<u8> = b"Item type does not match the freight receipt";
+#[error(code = 7)]
+const EQuantityMismatch: vector<u8> = b"Item quantity does not match the freight receipt";
+
+// === Structs ===
+
+/// Pickup requirement config: the owner-approved destination entity id.
+public struct Pickup has drop {
+    destination: ID,
+}
+
+/// Dropoff requirement marker: validate and consume a `FreightReceipt`.
+public struct Dropoff() has drop;
+
+/// Consumable authorization for one exact Item haul from source to destination.
+/// Transferable so the carrier can hold it between pickup and dropoff txs.
+public struct FreightReceipt has key, store {
+    id: UID,
+    source: ID,
+    destination: ID,
+    carrier: ID,
+    source_tenant: String,
+    item_id: ID,
+    type_id: u64,
+    quantity: u64,
+}
+
+// === Events ===
+
+public struct FreightPickedUp has copy, drop {
+    receipt_id: ID,
+    source: ID,
+    destination: ID,
+    carrier: ID,
+    item_id: ID,
+    type_id: u64,
+    quantity: u64,
+}
+
+public struct FreightDelivered has copy, drop {
+    receipt_id: ID,
+    source: ID,
+    destination: ID,
+    carrier: ID,
+    item_id: ID,
+    type_id: u64,
+    quantity: u64,
+}
+
+// === Public Functions ===
+
+/// Build a pickup requirement that authorizes delivery to `destination`.
+public fun pickup_requirement(destination: ID): Requirement {
+    requirement::from_config(option::none(), Pickup { destination })
+}
+
+/// Build a dropoff requirement that consumes a matching `FreightReceipt`.
+public fun dropoff_requirement(): Requirement {
+    requirement::from_config(option::none(), Dropoff())
+}
+
+/// Issue a receipt binding `item` to this source entity and the destination
+/// configured on the pickup requirement. Requires a prior caller requirement so
+/// `request.authorized_id()` records the carrier.
+///
+/// Call after `inventory::withdraw` in the same request so the withdrawn Item is
+/// the one bound into the receipt.
+public fun pickup(
+    entity: &Entity,
+    request: &mut Request,
+    item: &Item,
+    ctx: &mut TxContext,
+): FreightReceipt {
+    let (requirement, frame) = request.take_next(pickup_permit());
+    let destination = peel_destination(&requirement);
+    frame.destroy_empty_frame();
+
+    assert!(request.entity_id() == option::some(entity.id()), EWrongEntity);
+    let carrier = request.authorized_id().destroy_or!(abort ENotAuthorized);
+
+    let item_id = object::id(item);
+    let type_id = item.type_id();
+    let quantity = item.quantity();
+    let source = entity.id();
+    let receipt = FreightReceipt {
+        id: object::new(ctx),
+        source,
+        destination,
+        carrier,
+        source_tenant: entity.key().tenant(),
+        item_id,
+        type_id,
+        quantity,
+    };
+    let receipt_id = object::id(&receipt);
+    event::emit(FreightPickedUp {
+        receipt_id,
+        source,
+        destination,
+        carrier,
+        item_id,
+        type_id,
+        quantity,
+    });
+    receipt
+}
+
+/// Validate `receipt` against this destination entity, the authorized carrier,
+/// and the exact `item`, then consume the receipt. Call before
+/// `inventory::deposit` in the same request.
+public fun dropoff(entity: &Entity, request: &mut Request, item: &Item, receipt: FreightReceipt) {
+    let (_requirement, frame) = request.take_next(dropoff_permit());
+    frame.destroy_empty_frame();
+
+    assert!(request.entity_id() == option::some(entity.id()), EWrongEntity);
+    assert!(entity.id() == receipt.destination, EWrongDestination);
+
+    let carrier = request.authorized_id().destroy_or!(abort ENotAuthorized);
+    assert!(carrier == receipt.carrier, EWrongCarrier);
+    assert!(entity.key().tenant() == receipt.source_tenant, ETenantMismatch);
+    assert!(object::id(item) == receipt.item_id, EItemMismatch);
+    assert!(item.type_id() == receipt.type_id, ETypeMismatch);
+    assert!(item.quantity() == receipt.quantity, EQuantityMismatch);
+
+    let FreightReceipt {
+        id,
+        source,
+        destination,
+        carrier: receipt_carrier,
+        source_tenant: _,
+        item_id,
+        type_id,
+        quantity,
+    } = receipt;
+    let receipt_id = id.to_inner();
+    event::emit(FreightDelivered {
+        receipt_id,
+        source,
+        destination,
+        carrier: receipt_carrier,
+        item_id,
+        type_id,
+        quantity,
+    });
+    id.delete();
+}
+
+// === View Functions ===
+
+public fun source(receipt: &FreightReceipt): ID {
+    receipt.source
+}
+
+public fun destination(receipt: &FreightReceipt): ID {
+    receipt.destination
+}
+
+public fun carrier(receipt: &FreightReceipt): ID {
+    receipt.carrier
+}
+
+public fun source_tenant(receipt: &FreightReceipt): String {
+    receipt.source_tenant
+}
+
+public fun item_id(receipt: &FreightReceipt): ID {
+    receipt.item_id
+}
+
+public fun type_id(receipt: &FreightReceipt): u64 {
+    receipt.type_id
+}
+
+public fun quantity(receipt: &FreightReceipt): u64 {
+    receipt.quantity
+}
+
+// === Private Functions ===
+
+/// Decode the destination id from a pickup requirement's BCS config.
+fun peel_destination(requirement: &Requirement): ID {
+    let mut b = bcs::new(requirement.data());
+    object::id_from_address(b.peel_address())
+}
+
+fun pickup_permit(): Permit<Pickup> {
+    internal::permit<Pickup>()
+}
+
+fun dropoff_permit(): Permit<Dropoff> {
+    internal::permit<Dropoff>()
+}

--- a/contracts/freight/tests/freight_tests.move
+++ b/contracts/freight/tests/freight_tests.move
@@ -1,0 +1,551 @@
+#[test_only]
+module freight::freight_tests;
+
+use core::{
+    access_cap::{Self, AccessCap},
+    action,
+    admin_service::{Self, AdminACL},
+    entity::{Self, Entity},
+    location_service,
+    object_registry::ObjectRegistry,
+    test_helpers::{claim, setup, take_acl, take_registry}
+};
+use freight::freight::{Self, FreightDelivered, FreightPickedUp, FreightReceipt};
+use inventory::{inventory, item::Item};
+use std::string::{Self, String};
+use sui::{event, test_scenario as ts};
+
+const ADMIN: address = @0xA;
+const OWNER_A: address = @0xB;
+const OWNER_B: address = @0xC;
+const CARRIER: address = @0xD;
+const OTHER: address = @0xE;
+
+const FUEL: u64 = 88834;
+const VOL: u64 = 2;
+const QTY: u64 = 10;
+
+fun unit_name(): String { string::utf8(b"SU-01") }
+
+/// Claim, install inventory, mint a transferable owner cap, and share.
+fun build_storage_unit(
+    scenario: &mut ts::Scenario,
+    registry: &mut ObjectRegistry,
+    acl: &AdminACL,
+    in_game_id: u64,
+    owner: address,
+): Entity {
+    let mut e = claim(registry, acl, in_game_id, scenario.ctx());
+    let mut req = inventory::install(&mut e, unit_name(), 1000, 100, scenario.ctx());
+    admin_service::verify_admin(&mut req, acl, scenario.ctx());
+    e.complete_request(req);
+
+    let mut req = e.mint_access(owner, true, scenario.ctx());
+    admin_service::verify_admin(&mut req, acl, scenario.ctx());
+    e.complete_request(req);
+    e
+}
+
+/// Create a carrier "character" entity and mint a soulbound cap to CARRIER.
+fun create_carrier(scenario: &mut ts::Scenario, registry: &mut ObjectRegistry, acl: &AdminACL): ID {
+    let mut character = claim(registry, acl, 99, scenario.ctx());
+    let mut req = character.mint_access(CARRIER, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, acl, scenario.ctx());
+    character.complete_request(req);
+    let character_id = character.id();
+    character.share();
+    character_id
+}
+
+fun owner_enable(
+    scenario: &mut ts::Scenario,
+    owner: address,
+    e_id: ID,
+    name: vector<u8>,
+    act: action::Action,
+) {
+    ts::next_tx(scenario, owner);
+    let mut e = ts::take_shared_by_id<Entity>(scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(scenario);
+    let mut req = e.enable_action(string::utf8(name), act, scenario.ctx());
+    access_cap::verify(&mut req, &cap);
+    e.complete_request(req);
+    ts::return_to_sender(scenario, cap);
+    ts::return_shared(e);
+}
+
+/// Source: bridge_in + freight_pickup. Destination: freight_dropoff.
+fun configure_freight_actions(
+    scenario: &mut ts::Scenario,
+    source_id: ID,
+    dest_id: ID,
+    owner_a: address,
+    owner_b: address,
+) {
+    let name = unit_name();
+    let any = option::none();
+
+    owner_enable(
+        scenario,
+        owner_a,
+        source_id,
+        b"bridge_in",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            inventory::bridge_in_requirement(name, false, any, any, any),
+        ]),
+    );
+    owner_enable(
+        scenario,
+        owner_a,
+        source_id,
+        b"freight_pickup",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            inventory::withdraw_requirement(name, false, option::some(FUEL), any, any),
+            freight::pickup_requirement(dest_id),
+        ]),
+    );
+    owner_enable(
+        scenario,
+        owner_b,
+        dest_id,
+        b"freight_dropoff",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            freight::dropoff_requirement(),
+            inventory::deposit_requirement(name, false, option::some(FUEL), any, any),
+        ]),
+    );
+}
+
+fun stock_main(scenario: &mut ts::Scenario, owner: address, e_id: ID, qty: u64) {
+    ts::next_tx(scenario, owner);
+    let mut e = ts::take_shared_by_id<Entity>(scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(scenario);
+    let mut req = e.interact(string::utf8(b"bridge_in"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, &cap);
+    inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL, qty, VOL, scenario.ctx());
+    e.complete_request(req);
+    ts::return_to_sender(scenario, cap);
+    ts::return_shared(e);
+}
+
+fun main_balance(e: &Entity, type_id: u64): u64 {
+    inventory::balance_of(e, unit_name(), e.id(), type_id)
+}
+
+/// Pickup at source: withdraw + issue receipt. Leaves the entity shared.
+fun run_pickup(
+    scenario: &mut ts::Scenario,
+    source_id: ID,
+    carrier_cap: &AccessCap,
+): (Item, FreightReceipt) {
+    let mut e = ts::take_shared_by_id<Entity>(scenario, source_id);
+    let mut req = e.interact(string::utf8(b"freight_pickup"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, carrier_cap);
+    let item = inventory::withdraw(&mut e, &mut req, FUEL, QTY, scenario.ctx());
+    let receipt = freight::pickup(&e, &mut req, &item, scenario.ctx());
+    e.complete_request(req);
+    ts::return_shared(e);
+    (item, receipt)
+}
+
+/// Dropoff at destination: validate receipt then deposit. Leaves the entity shared.
+fun run_dropoff(
+    scenario: &mut ts::Scenario,
+    dest_id: ID,
+    carrier_cap: &AccessCap,
+    item: Item,
+    receipt: FreightReceipt,
+) {
+    let mut e = ts::take_shared_by_id<Entity>(scenario, dest_id);
+    let mut req = e.interact(string::utf8(b"freight_dropoff"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, carrier_cap);
+    freight::dropoff(&e, &mut req, &item, receipt);
+    inventory::deposit(&mut e, &mut req, item, scenario.ctx());
+    e.complete_request(req);
+    ts::return_shared(e);
+}
+
+/// Shared fixture: two SUs, carrier character, freight actions, source stocked.
+fun setup_freight(scenario: &mut ts::Scenario): (ID, ID, ID) {
+    setup(scenario);
+
+    ts::next_tx(scenario, ADMIN);
+    let mut registry = take_registry(scenario);
+    let acl = take_acl(scenario);
+
+    let source = build_storage_unit(scenario, &mut registry, &acl, 1, OWNER_A);
+    let dest = build_storage_unit(scenario, &mut registry, &acl, 2, OWNER_B);
+    let source_id = source.id();
+    let dest_id = dest.id();
+    let carrier_id = create_carrier(scenario, &mut registry, &acl);
+    source.share();
+    dest.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    configure_freight_actions(scenario, source_id, dest_id, OWNER_A, OWNER_B);
+    stock_main(scenario, OWNER_A, source_id, 100);
+    (source_id, dest_id, carrier_id)
+}
+
+#[test]
+fun pickup_then_dropoff_delivers_across_entities() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, carrier_id) = setup_freight(&mut scenario);
+
+    // Tx 1: pickup — withdraw + bind receipt to the carrier.
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    assert!(access_cap::entity(&carrier_cap) == carrier_id);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+
+    assert!(freight::source(&receipt) == source_id);
+    assert!(freight::destination(&receipt) == dest_id);
+    assert!(freight::carrier(&receipt) == carrier_id);
+    assert!(freight::item_id(&receipt) == object::id(&item));
+    assert!(freight::type_id(&receipt) == FUEL);
+    assert!(freight::quantity(&receipt) == QTY);
+
+    let picked = event::events_by_type<FreightPickedUp>();
+    assert!(picked.length() == 1);
+
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    // Tx 2: dropoff — consume receipt and deposit the exact Item.
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let item = ts::take_from_sender<Item>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+
+    let mut dest = ts::take_shared_by_id<Entity>(&scenario, dest_id);
+    let mut req = dest.interact(string::utf8(b"freight_dropoff"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, &carrier_cap);
+    freight::dropoff(&dest, &mut req, &item, receipt);
+    inventory::deposit(&mut dest, &mut req, item, scenario.ctx());
+    dest.complete_request(req);
+
+    let delivered = event::events_by_type<FreightDelivered>();
+    assert!(delivered.length() == 1);
+    assert!(main_balance(&dest, FUEL) == QTY);
+    ts::return_shared(dest);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    // Tx 3: assert source depleted (cannot re-take dest in the prior tx after return).
+    ts::next_tx(&mut scenario, CARRIER);
+    let source = ts::take_shared_by_id<Entity>(&scenario, source_id);
+    assert!(main_balance(&source, FUEL) == 90);
+    assert!(!ts::has_most_recent_for_sender<FreightReceipt>(&scenario));
+    ts::return_shared(source);
+
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = freight::EWrongDestination)]
+fun dropoff_rejects_wrong_destination() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    // Enable dropoff on the SOURCE so we can attempt delivery to the wrong entity.
+    owner_enable(
+        &mut scenario,
+        OWNER_A,
+        source_id,
+        b"freight_dropoff",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            freight::dropoff_requirement(),
+            inventory::deposit_requirement(
+                unit_name(),
+                false,
+                option::some(FUEL),
+                option::none(),
+                option::none(),
+            ),
+        ]),
+    );
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+    assert!(freight::destination(&receipt) == dest_id);
+
+    // Advance so the source entity is available again after pickup's return_shared.
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let item = ts::take_from_sender<Item>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    run_dropoff(&mut scenario, source_id, &carrier_cap, item, receipt);
+    ts::return_to_sender(&scenario, carrier_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = freight::EWrongCarrier)]
+fun dropoff_rejects_different_carrier() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    ts::next_tx(&mut scenario, ADMIN);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let mut other_character = claim(&mut registry, &acl, 98, scenario.ctx());
+    let mut req = other_character.mint_access(OTHER, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    other_character.complete_request(req);
+    other_character.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+    transfer::public_transfer(item, OTHER);
+    transfer::public_transfer(receipt, OTHER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    ts::next_tx(&mut scenario, OTHER);
+    let other_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let item = ts::take_from_sender<Item>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    run_dropoff(&mut scenario, dest_id, &other_cap, item, receipt);
+    ts::return_to_sender(&scenario, other_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = freight::EItemMismatch)]
+fun dropoff_rejects_substituted_same_type_item() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    owner_enable(
+        &mut scenario,
+        OWNER_A,
+        source_id,
+        b"withdraw",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            inventory::withdraw_requirement(
+                unit_name(),
+                false,
+                option::some(FUEL),
+                option::none(),
+                option::none(),
+            ),
+        ]),
+    );
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    // Fresh tx: withdraw a substitute Item of the same type/qty, then try dropoff.
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    let legit = ts::take_from_sender<Item>(&scenario);
+
+    let mut e = ts::take_shared_by_id<Entity>(&scenario, source_id);
+    let mut req = e.interact(string::utf8(b"withdraw"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, &carrier_cap);
+    let substitute = inventory::withdraw(&mut e, &mut req, FUEL, QTY, scenario.ctx());
+    e.complete_request(req);
+    ts::return_shared(e);
+
+    // Keep the legitimate haul parked; try to deliver a different object id.
+    transfer::public_transfer(legit, CARRIER);
+    transfer::public_transfer(substitute, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    // take_from_sender returns an arbitrary matching owned object; pick the
+    // substitute by comparing against the receipt-bound item id.
+    let first = ts::take_from_sender<Item>(&scenario);
+    let second = ts::take_from_sender<Item>(&scenario);
+    let (substitute, legit) = if (object::id(&first) == freight::item_id(&receipt)) {
+        (second, first)
+    } else {
+        (first, second)
+    };
+    transfer::public_transfer(legit, CARRIER);
+    run_dropoff(&mut scenario, dest_id, &carrier_cap, substitute, receipt);
+    ts::return_to_sender(&scenario, carrier_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = freight::ETenantMismatch)]
+fun dropoff_rejects_cross_tenant_destination() {
+    let mut scenario = ts::begin(ADMIN);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, ADMIN);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+
+    let source = build_storage_unit(&mut scenario, &mut registry, &acl, 1, OWNER_A);
+    let (mut dest, mut claim_req) = entity::new(
+        &mut registry,
+        2,
+        string::utf8(b"other-tenant"),
+        vector[],
+    );
+    admin_service::verify_admin(&mut claim_req, &acl, scenario.ctx());
+    dest.complete_request(claim_req);
+    let mut install_req = inventory::install(&mut dest, unit_name(), 1000, 100, scenario.ctx());
+    admin_service::verify_admin(&mut install_req, &acl, scenario.ctx());
+    dest.complete_request(install_req);
+    let mut mint_req = dest.mint_access(OWNER_B, true, scenario.ctx());
+    admin_service::verify_admin(&mut mint_req, &acl, scenario.ctx());
+    dest.complete_request(mint_req);
+
+    let source_id = source.id();
+    let dest_id = dest.id();
+    let _carrier_id = create_carrier(&mut scenario, &mut registry, &acl);
+    source.share();
+    dest.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    configure_freight_actions(&mut scenario, source_id, dest_id, OWNER_A, OWNER_B);
+    stock_main(&mut scenario, OWNER_A, source_id, 100);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let item = ts::take_from_sender<Item>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    run_dropoff(&mut scenario, dest_id, &carrier_cap, item, receipt);
+    ts::return_to_sender(&scenario, carrier_cap);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = freight::ENotAuthorized)]
+fun pickup_without_caller_requirement_aborts() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    owner_enable(
+        &mut scenario,
+        OWNER_A,
+        source_id,
+        b"freight_pickup_no_caller",
+        action::new(vector[
+            inventory::withdraw_requirement(
+                unit_name(),
+                false,
+                option::some(FUEL),
+                option::none(),
+                option::none(),
+            ),
+            freight::pickup_requirement(dest_id),
+        ]),
+    );
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let mut e = ts::take_shared_by_id<Entity>(&scenario, source_id);
+    let mut req = e.interact(string::utf8(b"freight_pickup_no_caller"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    let item = inventory::withdraw(&mut e, &mut req, FUEL, QTY, scenario.ctx());
+    let receipt = freight::pickup(&e, &mut req, &item, scenario.ctx());
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    e.complete_request(req);
+    ts::return_shared(e);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = inventory::EQuantityAboveMax)]
+fun inventory_quantity_bounds_still_enforced() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    owner_enable(
+        &mut scenario,
+        OWNER_A,
+        source_id,
+        b"freight_pickup_bounded",
+        action::new(vector[
+            access_cap::caller_requirement(),
+            inventory::withdraw_requirement(
+                unit_name(),
+                false,
+                option::some(FUEL),
+                option::none(),
+                option::some(5),
+            ),
+            freight::pickup_requirement(dest_id),
+        ]),
+    );
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let mut e = ts::take_shared_by_id<Entity>(&scenario, source_id);
+    let mut req = e.interact(string::utf8(b"freight_pickup_bounded"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, &carrier_cap);
+    let item = inventory::withdraw(&mut e, &mut req, FUEL, QTY, scenario.ctx());
+    let receipt = freight::pickup(&e, &mut req, &item, scenario.ctx());
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    e.complete_request(req);
+    ts::return_to_sender(&scenario, carrier_cap);
+    ts::return_shared(e);
+    scenario.end();
+}
+
+/// Skipping `freight::dropoff` leaves a non-module-scoped Dropoff requirement next;
+/// `inventory::deposit` reads the module name off `req.next()` before type-checking
+/// and aborts with `ERequirementNotModuleScoped`.
+#[test, expected_failure(abort_code = entity::ERequirementNotModuleScoped)]
+fun dropoff_action_rejects_skipping_receipt_validation() {
+    let mut scenario = ts::begin(ADMIN);
+    let (source_id, dest_id, _carrier_id) = setup_freight(&mut scenario);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let (item, receipt) = run_pickup(&mut scenario, source_id, &carrier_cap);
+    transfer::public_transfer(item, CARRIER);
+    transfer::public_transfer(receipt, CARRIER);
+    ts::return_to_sender(&scenario, carrier_cap);
+
+    ts::next_tx(&mut scenario, CARRIER);
+    let carrier_cap = ts::take_from_sender<AccessCap>(&scenario);
+    let item = ts::take_from_sender<Item>(&scenario);
+    let receipt = ts::take_from_sender<FreightReceipt>(&scenario);
+    // Park the receipt; attempt deposit without consuming it.
+    transfer::public_transfer(receipt, CARRIER);
+
+    let mut e = ts::take_shared_by_id<Entity>(&scenario, dest_id);
+    let mut req = e.interact(string::utf8(b"freight_dropoff"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+    access_cap::verify_caller(&mut req, &carrier_cap);
+    inventory::deposit(&mut e, &mut req, item, scenario.ctx());
+    e.complete_request(req);
+    ts::return_to_sender(&scenario, carrier_cap);
+    ts::return_shared(e);
+    scenario.end();
+}

--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -6,7 +6,7 @@ source "$(dirname "$0")/lib.sh"
 : "${TARGET_ENV:?}" "${MODE:?}" "${NET:?}" "${COMMIT:?}" "${DEPLOYER_KEY:?}" "${VERSION:?}"
 
 # Packages in dependency order, matching deploy-world.sh.
-PACKAGES="core character inventory"
+PACKAGES="core character inventory freight"
 
 # Run a step, or just print it under DRY_RUN=1.
 run() {

--- a/scripts/deploy-world.sh
+++ b/scripts/deploy-world.sh
@@ -5,8 +5,8 @@
 # Usage: ./scripts/deploy-world.sh [localnet|dev|test|uat|live] [deploy|publish|upgrade]
 source "$(dirname "$0")/lib.sh"
 
-# Packages in dependency order (character and inventory depend on core).
-PACKAGES=(core character inventory)
+# Packages in dependency order (character/inventory depend on core; freight on both).
+PACKAGES=(core character inventory freight)
 
 setup
 ENV=$(get_env "${1:-}")

--- a/scripts/reset-published.sh
+++ b/scripts/reset-published.sh
@@ -10,7 +10,7 @@ setup
 ENV=$(get_env "${1:-}")
 shift || true
 PKGS=("$@")
-[ ${#PKGS[@]} -eq 0 ] && PKGS=(core character inventory)
+[ ${#PKGS[@]} -eq 0 ] && PKGS=(core character inventory freight)
 
 if [[ "$ENV" == "localnet" ]]; then
     echo "reset-published: localnet has no committed Published.toml" >&2

--- a/sdk/world-sdk/README.md
+++ b/sdk/world-sdk/README.md
@@ -41,6 +41,74 @@ const config = loadWorldConfig("deployments/localnet/world.json");
 const id = deriveObjectId(config, { id: 7n, tenant: "my-tenant" });
 ```
 
+### Freight delivery (v1)
+
+v1 transit `Item`s have no `parent_id`. Cross-entity hauls use an additive
+`freight` receipt that binds one withdrawn `Item` to a source, destination,
+tenant, and carrier. Typical action composition:
+
+- **pickup:** proximity (injected) → caller → inventory withdraw → freight pickup
+- **dropoff:** proximity (injected) → caller → freight dropoff → inventory deposit
+
+```ts
+import {
+  callerRequirement,
+  completeRequest,
+  dropoff,
+  dropoffRequirement,
+  enableAction,
+  interact,
+  pickup,
+  pickupRequirement,
+  verifyCaller,
+  verifyProximity,
+  withdraw,
+  withdrawRequirement,
+  deposit,
+  depositRequirement,
+} from "@evefrontier/world-sdk";
+
+// Owner configures once (separate txs per entity):
+enableAction(tx, config, source, "freight_pickup", [
+  callerRequirement(tx, config),
+  withdrawRequirement(tx, config, "SU-01", {
+    ephemeral: false,
+    typeId: 88834n,
+  }),
+  pickupRequirement(tx, config, destId),
+], sourceOwnerCap);
+
+enableAction(tx, config, dest, "freight_dropoff", [
+  callerRequirement(tx, config),
+  dropoffRequirement(tx, config),
+  depositRequirement(tx, config, "SU-01", {
+    ephemeral: false,
+    typeId: 88834n,
+  }),
+], destOwnerCap);
+
+// Carrier tx 1 — pickup:
+const pickReq = interact(tx, config, source, "freight_pickup");
+verifyProximity(tx, config, pickReq);
+verifyCaller(tx, config, pickReq, carrierCap);
+const item = withdraw(tx, config, source, pickReq, { typeId: 88834n, quantity: 10n });
+const receipt = pickup(tx, config, source, pickReq, item);
+completeRequest(tx, config, source, pickReq);
+// transfer item + receipt to the carrier (or keep them in the PTB)
+
+// Carrier tx 2 — dropoff:
+const dropReq = interact(tx, config, dest, "freight_dropoff");
+verifyProximity(tx, config, dropReq);
+verifyCaller(tx, config, dropReq, carrierCap);
+dropoff(tx, config, dest, dropReq, item, receipt);
+deposit(tx, config, dest, dropReq, item);
+completeRequest(tx, config, dest, dropReq);
+```
+
+Entity proximity today is hash equality only (`location_service` marks signed
+proof verification as TODO). The receipt authorizes the haul; it is not a
+cryptographic anti-teleport locality proof.
+
 ## Versioning
 
 Manual semver. Each release states which contract release it supports — a

--- a/sdk/world-sdk/src/__integration__/freight.test.ts
+++ b/sdk/world-sdk/src/__integration__/freight.test.ts
@@ -1,0 +1,275 @@
+import { fileURLToPath } from 'node:url'
+import { Transaction } from '@mysten/sui/transactions'
+import { describe, expect, it } from 'vitest'
+import { createWorldClient } from '../client.js'
+import { loadWorldConfig } from '../config/load.js'
+import {
+  callerRequirement,
+  completeRequest,
+  deriveObjectId,
+  enableAction,
+  entityNew,
+  interact,
+  mintAccess,
+  shareEntity,
+  verifyAdmin,
+  verifyCaller,
+  verifyProximity,
+} from '../packages/core.js'
+import {
+  dropoff,
+  dropoffRequirement,
+  pickup,
+  pickupRequirement,
+} from '../packages/freight.js'
+import {
+  bridgeInRequirement,
+  createStorageUnit,
+  deposit,
+  depositRequirement,
+  gameItemToChain,
+  withdraw,
+  withdrawRequirement,
+} from '../packages/inventory.js'
+import {
+  capObjectId,
+  expectSuccess,
+  readBalance,
+  requirePackage,
+  signer,
+} from './helpers.js'
+
+// Two-transaction freight haul: withdraw+receipt at source, dropoff+deposit at
+// destination. Needs a funded localnet admin key and a manifest that includes
+// the freight package (redeploy after adding freight to deploy-world.sh).
+const MANIFEST = fileURLToPath(
+  new URL('../../../../deployments/localnet/world.json', import.meta.url),
+)
+
+const UNIT = 'SU-01'
+const FUEL = 88834n
+const VOL = 2n
+const QTY = 10n
+
+function createdObjectId(
+  result: Awaited<ReturnType<typeof expectSuccess>>,
+  objectTypeSuffix: string,
+): string {
+  const created = result.objectChanges?.find(
+    (c) =>
+      c.type === 'created' &&
+      'objectType' in c &&
+      typeof c.objectType === 'string' &&
+      c.objectType.endsWith(objectTypeSuffix),
+  )
+  const id = (created as { objectId?: string } | undefined)?.objectId
+  if (!id) {
+    throw new Error(`created object ending with ${objectTypeSuffix} not found`)
+  }
+  return id
+}
+
+describe('freight pickup/dropoff (localnet)', () => {
+  const config = loadWorldConfig(MANIFEST)
+  const client = createWorldClient({ config })
+
+  it('delivers an exact withdrawn Item across two storage units', async () => {
+    requirePackage(config, 'freight')
+    const coreId = requirePackage(config, 'core')
+
+    const sourceKey = { id: 6100n, tenant: 'freight-t1' }
+    const destKey = { id: 6101n, tenant: 'freight-t1' }
+    const carrierKey = { id: 6102n, tenant: 'freight-t1' }
+    const sourceId = deriveObjectId(config, sourceKey)
+    const destId = deriveObjectId(config, destKey)
+    // Carrier identity is a bare entity with a soulbound AccessCap (no character
+    // module required for caller authorization).
+    const carrierEntityId = deriveObjectId(config, carrierKey)
+
+    // tx1: create source + dest storage units and a carrier entity.
+    const createTx = new Transaction()
+    createStorageUnit(createTx, config, {
+      inGameId: sourceKey.id,
+      tenant: sourceKey.tenant,
+      name: UNIT,
+      mainCapacity: 1000n,
+      ephemeralCapacity: 100n,
+    })
+    createStorageUnit(createTx, config, {
+      inGameId: destKey.id,
+      tenant: destKey.tenant,
+      name: UNIT,
+      mainCapacity: 1000n,
+      ephemeralCapacity: 100n,
+    })
+    {
+      const [carrier, claimReq] = entityNew(createTx, config, {
+        inGameId: carrierKey.id,
+        tenant: carrierKey.tenant,
+      })
+      verifyAdmin(createTx, config, claimReq)
+      completeRequest(createTx, config, carrier, claimReq)
+      shareEntity(createTx, config, carrier)
+    }
+    await expectSuccess(client, createTx)
+
+    // tx2–4: mint owner/carrier caps separately so object ids are unambiguous.
+    const sourceMint = new Transaction()
+    mintAccess(sourceMint, config, {
+      entity: sourceId,
+      owner: signer,
+      transferable: true,
+    })
+    const sourceCapId = capObjectId(
+      await expectSuccess(client, sourceMint, { showObjectChanges: true }),
+      coreId,
+    )
+
+    const destMint = new Transaction()
+    mintAccess(destMint, config, {
+      entity: destId,
+      owner: signer,
+      transferable: true,
+    })
+    const destCapId = capObjectId(
+      await expectSuccess(client, destMint, { showObjectChanges: true }),
+      coreId,
+    )
+
+    const carrierMint = new Transaction()
+    mintAccess(carrierMint, config, {
+      entity: carrierEntityId,
+      owner: signer,
+      transferable: false,
+    })
+    const carrierCapId = capObjectId(
+      await expectSuccess(client, carrierMint, { showObjectChanges: true }),
+      coreId,
+    )
+
+    // tx5: configure freight actions + stock the source.
+    const enableTx = new Transaction()
+    const source = enableTx.object(sourceId)
+    const dest = enableTx.object(destId)
+    const sourceCap = enableTx.object(sourceCapId)
+    const destCap = enableTx.object(destCapId)
+
+    enableAction(
+      enableTx,
+      config,
+      source,
+      'bridge_in',
+      [
+        callerRequirement(enableTx, config),
+        bridgeInRequirement(enableTx, config, UNIT, { ephemeral: false }),
+      ],
+      sourceCap,
+    )
+    enableAction(
+      enableTx,
+      config,
+      source,
+      'freight_pickup',
+      [
+        callerRequirement(enableTx, config),
+        withdrawRequirement(enableTx, config, UNIT, {
+          ephemeral: false,
+          typeId: FUEL,
+        }),
+        pickupRequirement(enableTx, config, destId),
+      ],
+      sourceCap,
+    )
+    enableAction(
+      enableTx,
+      config,
+      dest,
+      'freight_dropoff',
+      [
+        callerRequirement(enableTx, config),
+        dropoffRequirement(enableTx, config),
+        depositRequirement(enableTx, config, UNIT, {
+          ephemeral: false,
+          typeId: FUEL,
+        }),
+      ],
+      destCap,
+    )
+
+    const stockReq = interact(enableTx, config, source, 'bridge_in')
+    verifyProximity(enableTx, config, stockReq)
+    verifyCaller(enableTx, config, stockReq, sourceCap)
+    gameItemToChain(enableTx, config, source, stockReq, {
+      typeId: FUEL,
+      quantity: 100n,
+      volume: VOL,
+    })
+    completeRequest(enableTx, config, source, stockReq)
+    await expectSuccess(client, enableTx)
+
+    // tx6: carrier pickup — withdraw + issue receipt.
+    const pickupTx = new Transaction()
+    const src = pickupTx.object(sourceId)
+    const carrierCap = pickupTx.object(carrierCapId)
+    const pickReq = interact(pickupTx, config, src, 'freight_pickup')
+    verifyProximity(pickupTx, config, pickReq)
+    verifyCaller(pickupTx, config, pickReq, carrierCap)
+    const item = withdraw(pickupTx, config, src, pickReq, {
+      typeId: FUEL,
+      quantity: QTY,
+    })
+    const receipt = pickup(pickupTx, config, src, pickReq, item)
+    completeRequest(pickupTx, config, src, pickReq)
+    pickupTx.transferObjects([item, receipt], signer)
+
+    const picked = await expectSuccess(client, pickupTx, {
+      showObjectChanges: true,
+      showEvents: true,
+    })
+    const itemId = createdObjectId(picked, '::item::Item')
+    const receiptId = createdObjectId(picked, '::freight::FreightReceipt')
+    const pickupEvents = picked.events?.filter((e) =>
+      e.type.endsWith('::freight::FreightPickedUp'),
+    )
+    expect(pickupEvents?.length).toBe(1)
+
+    // tx7: carrier dropoff — consume receipt + deposit exact Item.
+    const dropTx = new Transaction()
+    const dst = dropTx.object(destId)
+    const cCap = dropTx.object(carrierCapId)
+    const dropReq = interact(dropTx, config, dst, 'freight_dropoff')
+    verifyProximity(dropTx, config, dropReq)
+    verifyCaller(dropTx, config, dropReq, cCap)
+    dropoff(
+      dropTx,
+      config,
+      dst,
+      dropReq,
+      dropTx.object(itemId),
+      dropTx.object(receiptId),
+    )
+    deposit(dropTx, config, dst, dropReq, dropTx.object(itemId))
+    completeRequest(dropTx, config, dst, dropReq)
+
+    const delivered = await expectSuccess(client, dropTx, { showEvents: true })
+    const deliveredEvents = delivered.events?.filter((e) =>
+      e.type.endsWith('::freight::FreightDelivered'),
+    )
+    expect(deliveredEvents?.length).toBe(1)
+
+    const sourceBal = await readBalance(client, config, {
+      entity: sourceId,
+      name: UNIT,
+      authorizedId: sourceId,
+      typeId: FUEL,
+    })
+    const destBal = await readBalance(client, config, {
+      entity: destId,
+      name: UNIT,
+      authorizedId: destId,
+      typeId: FUEL,
+    })
+    expect(sourceBal).toBe(90n)
+    expect(destBal).toBe(QTY)
+  })
+})

--- a/sdk/world-sdk/src/index.ts
+++ b/sdk/world-sdk/src/index.ts
@@ -50,6 +50,12 @@ export {
   verifyProximity,
 } from './packages/core.js'
 export {
+  dropoff,
+  dropoffRequirement,
+  pickup,
+  pickupRequirement,
+} from './packages/freight.js'
+export {
   type BalanceOfArgs,
   type BridgeInArgs,
   balanceOf,

--- a/sdk/world-sdk/src/packages/freight.ts
+++ b/sdk/world-sdk/src/packages/freight.ts
@@ -1,0 +1,74 @@
+import type {
+  Transaction,
+  TransactionArgument,
+  TransactionResult,
+} from '@mysten/sui/transactions'
+import { mvrName } from '../config/env.js'
+import type { WorldConfig } from '../config/types.js'
+
+const FREIGHT_PACKAGE = 'freight'
+
+function pkg(config: WorldConfig): string {
+  return mvrName(config.env, FREIGHT_PACKAGE)
+}
+
+/**
+ * Build a pickup requirement that authorizes delivery to `destination`
+ * (entity object id).
+ */
+export function pickupRequirement(
+  tx: Transaction,
+  config: WorldConfig,
+  destination: string,
+): TransactionResult {
+  return tx.moveCall({
+    target: `${pkg(config)}::freight::pickup_requirement`,
+    arguments: [tx.pure.address(destination)],
+  })
+}
+
+/** Build a dropoff requirement that consumes a matching `FreightReceipt`. */
+export function dropoffRequirement(
+  tx: Transaction,
+  config: WorldConfig,
+): TransactionResult {
+  return tx.moveCall({
+    target: `${pkg(config)}::freight::dropoff_requirement`,
+  })
+}
+
+/**
+ * Issue a `FreightReceipt` binding `item` to this source entity and the
+ * destination configured on the pickup requirement. Call after `withdraw` in
+ * the same request. Returns the receipt object.
+ */
+export function pickup(
+  tx: Transaction,
+  config: WorldConfig,
+  entity: TransactionArgument,
+  request: TransactionArgument,
+  item: TransactionArgument,
+): TransactionResult {
+  return tx.moveCall({
+    target: `${pkg(config)}::freight::pickup`,
+    arguments: [entity, request, item],
+  })
+}
+
+/**
+ * Validate and consume `receipt` against this destination, the authorized
+ * carrier, and the exact `item`. Call before `deposit` in the same request.
+ */
+export function dropoff(
+  tx: Transaction,
+  config: WorldConfig,
+  entity: TransactionArgument,
+  request: TransactionArgument,
+  item: TransactionArgument,
+  receipt: TransactionArgument,
+): void {
+  tx.moveCall({
+    target: `${pkg(config)}::freight::dropoff`,
+    arguments: [entity, request, item, receipt],
+  })
+}


### PR DESCRIPTION
## Summary

Add a v1-native freight receipt that safely authorizes an exact withdrawn `Item` for one destination deposit.

- New additive `contracts/freight` package with `FreightReceipt`, pickup/dropoff requirements, and indexer-friendly events
- SDK builders + README usage for the two-transaction pickup/dropoff flow
- Deploy scripts include `freight` after `inventory`

This supersedes legacy `parent_id` reparenting ([PR #156](https://github.com/evefrontier/world-contracts/pull/156)). v1 transit `Item`s have no `parent_id` ([PR #164](https://github.com/evefrontier/world-contracts/pull/164), [PR #167](https://github.com/evefrontier/world-contracts/pull/167), [PR #199](https://github.com/evefrontier/world-contracts/pull/199)): `inventory::withdraw` creates a transferable Item and `inventory::deposit` consumes it. Freight binds that exact object to source, destination, tenant, and carrier without changing `core` or `inventory` layout.

### Action composition

- **pickup:** proximity (injected) → caller → inventory withdraw → freight pickup
- **dropoff:** proximity (injected) → caller → freight dropoff → inventory deposit

### Invariants

- Destination entity must match receipt
- Caller (`authorized_id`) must match receipt carrier
- Source and destination tenants must match
- Exact Item object id, type, and quantity must match
- Receipt is consumed on dropoff (no replay)

### Compatibility

- Additive package + SDK exports only
- No `core` / `inventory` object-layout changes
- No migration for existing callers

### Scope note

Current entity proximity is hash equality only (`location_service` TODO for signed proofs). This PR does **not** claim cryptographic anti-teleport locality. Payment, collateral, deadlines, cancellation, reassignment, and multi-hop freight are out of scope.

## Test plan

- [x] `sui move test --build-env testnet --path contracts/freight` (8/8 pass)
- [x] `pnpm --filter @evefrontier/world-sdk typecheck`
- [x] `pnpm --filter @evefrontier/world-sdk test`
- [x] Biome/Prettier on touched freight SDK + Move files
- [ ] `pnpm --filter @evefrontier/world-sdk test:integration` after localnet redeploy that publishes `freight`
- [ ] CI contracts + SDK + integration jobs on this PR

## Maintainer feedback requested

1. Requirement ordering (pickup after withdraw / dropoff before deposit)
2. `FreightReceipt` ownership/transfer semantics (`key, store`, carrier-held)
3. Event field set (`FreightPickedUp` / `FreightDelivered`)
4. Whether freight belongs in this repository before expanding scope