### PR TITLE
ci: improve snapshot image

### DIFF
--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -26,6 +26,27 @@ KEY_SCHEME="ed25519"
 
 log() { echo "[integration] $*"; }
 
+# Snapshot bake must reach epoch >= 1 so downstream tests that depend on
+# epoch-1 cases don't fail against a sealed epoch-0 chain.
+wait_for_epoch() {
+  local min_epoch="${1:-1}"
+  local epoch=0
+  log "Waiting for epoch >= ${min_epoch}..."
+  for i in $(seq 1 60); do
+    epoch="$(curl -sf -X POST "$RPC_URL" \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"suix_getLatestSuiSystemState","params":[]}' \
+      | jq -r '.result.epoch // 0')"
+    [ "$epoch" -ge "$min_epoch" ] && break
+    sleep 2
+  done
+  if [ "${epoch:-0}" -lt "$min_epoch" ]; then
+    log "ERROR: timed out waiting for epoch >= ${min_epoch}"
+    exit 1
+  fi
+  log "Epoch is ${epoch}."
+}
+
 # Graceful node shutdown so RocksDB flushes before the snapshot is committed.
 stop_node() {
   local timeout="${SHUTDOWN_TIMEOUT:-60}"
@@ -98,6 +119,12 @@ mkdir -p "$DATA_DIR"
   done < <(jq -r '.accounts | keys_unsorted[]' "$ACCOUNTS_JSON")
 } > "$GENESIS_RUNTIME_CONFIG"
 
+# Snapshot mode needs short epochs so we can reach epoch >= 1 before sealing.
+if [ "$MODE" = "snapshot" ]; then
+  sed -i 's/epoch_duration_ms: .*/epoch_duration_ms: 30000/' "$GENESIS_RUNTIME_CONFIG"
+  log "Snapshot mode: epoch_duration_ms overridden to 30000"
+fi
+
 log "Generating genesis from $GENESIS_RUNTIME_CONFIG (funding ${#ADDR[@]} accounts)"
 sui genesis --from-config "$GENESIS_RUNTIME_CONFIG" --working-dir "$DATA_DIR" --with-faucet -f
 # Genesis writes its own fullnode.yaml; overwriting it breaks faucet tx execution.
@@ -169,6 +196,7 @@ case "$MODE" in
     ;;
   snapshot)
     fund_exchange_eve
+    wait_for_epoch 1
     log "Baking snapshot: stopping node cleanly..."
     stop_node
     log "Staging world.json + accounts.json + test-resources.json for runtime host seeding..."

--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -36,7 +36,7 @@ wait_for_epoch() {
     epoch="$(curl -sf -X POST "$RPC_URL" \
       -H "Content-Type: application/json" \
       -d '{"jsonrpc":"2.0","id":1,"method":"suix_getLatestSuiSystemState","params":[]}' \
-      | jq -r '.result.epoch // 0')"
+      | jq -r '(.result.epoch // 0) | tonumber' || echo 0)"
     [ "$epoch" -ge "$min_epoch" ] && break
     sleep 2
   done
@@ -121,7 +121,7 @@ mkdir -p "$DATA_DIR"
 
 # Snapshot mode needs short epochs so we can reach epoch >= 1 before sealing.
 if [ "$MODE" = "snapshot" ]; then
-  sed -i 's/epoch_duration_ms: .*/epoch_duration_ms: 30000/' "$GENESIS_RUNTIME_CONFIG"
+  sed -i 's/^\([[:space:]]*\)epoch_duration_ms: .*/\1epoch_duration_ms: 30000/' "$GENESIS_RUNTIME_CONFIG"
   log "Snapshot mode: epoch_duration_ms overridden to 30000"
 fi
 


### PR DESCRIPTION
- this solves the issues when snapshot ships with epoch 0 that affects the downstream tests that depends on epoch-1 cases.