### PR TITLE
refactor: skip proximity inject for empty location_hash

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/app" \
+            -v "${{ github.workspace }}/docker/entrypoint-integration.sh:/entrypoint.sh:ro" \
             -w /app \
             -e CI=true \
             "$IMAGE" test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,6 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/app" \
-            -v "${{ github.workspace }}/docker/entrypoint-integration.sh:/entrypoint.sh:ro" \
             -w /app \
             -e CI=true \
             "$IMAGE" test

--- a/contracts/core/sources/entity.move
+++ b/contracts/core/sources/entity.move
@@ -59,7 +59,7 @@ public struct Entity has key {
     version: u64,
     /// Tenant-scoped game identifier used to derive this entity's object ID.
     key: EntityKey,
-    /// Location hash injected as a proximity requirement on every interaction.
+    /// Location hash; when non-empty, injected as a proximity requirement on interact.
     location_hash: vector<u8>,
 }
 
@@ -217,20 +217,20 @@ public fun disable_action(entity: &mut Entity, name: String, _ctx: &mut TxContex
     )
 }
 
-/// Interact with a registered action, producing the `Request` to satisfy. A
-/// proximity requirement for the entity's location is injected ahead of the
-/// action's own requirements, so it must be resolved first.
+/// Interact with a registered action, producing the `Request` to satisfy. When
+/// the entity has a location, proximity is injected first; the caller proves
+/// with the interactor's location (e.g. ship). Characters (empty hash) skip it.
 public fun interact(entity: &mut Entity, action: String, _ctx: &mut TxContext): Request {
     assert!(entity.version == VERSION, EWrongVersion);
 
     let actions: &VecMap<String, Action> = df::borrow(&entity.id, ActionsKey());
     assert!(actions.contains(&action), EUnknownAction);
-    let request = actions
-        .get(&action)
-        .to_request(
-            option::some(entity.id.to_inner()),
-            vector[location_service::proximity_requirement(entity.location_hash)],
-        );
+    let pre = if (entity.location_hash.is_empty()) {
+        vector[]
+    } else {
+        vector[location_service::proximity_requirement(entity.location_hash)]
+    };
+    let request = actions.get(&action).to_request(option::some(entity.id.to_inner()), pre);
 
     entity.lock();
     request

--- a/contracts/core/sources/services/location_service.move
+++ b/contracts/core/sources/services/location_service.move
@@ -1,4 +1,5 @@
-/// Proximity requirement injected by `entity::interact`.
+/// Proximity requirement injected by `entity::interact` when the entity has a
+/// non-empty `location_hash`.
 ///
 /// An interaction may only proceed when the caller proves they are within range
 /// of the entity. v1 uses an exact match between the supplied proof and the
@@ -27,8 +28,8 @@ public fun proximity_requirement(location_hash: vector<u8>): Requirement {
     requirement::from_config(option::none(), Proximity(location_hash))
 }
 
-/// Satisfy the next (proximity) requirement on `request`. Aborts unless `proof`
-/// matches the required location hash.
+/// Satisfy the next (proximity) requirement on `request`. `proof` is the
+/// interactor location; aborts unless it equals the target entity's hash.
 public fun verify_proximity(request: &mut Request, proof: vector<u8>) {
     // TODO: Replace hash equality with server-signed LocationProof verification
     // (authorized server registry, player == sender, target hash, deadline, sig_verify).

--- a/contracts/core/tests/access_cap_tests.move
+++ b/contracts/core/tests/access_cap_tests.move
@@ -7,7 +7,7 @@ use core::{
     admin_service,
     entity,
     location_service,
-    test_helpers::{setup, take_acl, create_entity}
+    test_helpers::{setup, take_acl, create_entity, location_hash}
 };
 use std::string;
 use sui::test_scenario as ts;
@@ -115,7 +115,7 @@ fun verify_passes_with_matching_cap() {
         let mut e = ts::take_shared<entity::Entity>(&scenario);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
         let mut req = e.interact(string::utf8(OWNER_ACTION), scenario.ctx());
-        location_service::verify_proximity(&mut req, vector[]);
+        location_service::verify_proximity(&mut req, location_hash());
         access_cap::verify(&mut req, &cap);
         assert!(req.authorized_id() == option::some(cap.entity()));
         e.complete_request(req);
@@ -139,7 +139,7 @@ fun verify_caller_records_owner_authorized_id() {
         let mut e = ts::take_shared<entity::Entity>(&scenario);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
         let mut req = e.interact(string::utf8(CALLER_ACTION), scenario.ctx());
-        location_service::verify_proximity(&mut req, vector[]);
+        location_service::verify_proximity(&mut req, location_hash());
         access_cap::verify_caller(&mut req, &cap);
         assert!(req.authorized_id() == option::some(entity_id));
         e.complete_request(req);
@@ -196,7 +196,7 @@ fun verify_caller_records_non_owner_authorized_id() {
         let mut e1 = ts::take_shared_by_id<entity::Entity>(&scenario, one);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
         let mut req = e1.interact(string::utf8(CALLER_ACTION), scenario.ctx());
-        location_service::verify_proximity(&mut req, vector[]);
+        location_service::verify_proximity(&mut req, location_hash());
         access_cap::verify_caller(&mut req, &cap);
         assert!(req.authorized_id() == option::some(two));
         assert!(two != one);
@@ -252,7 +252,7 @@ fun verify_aborts_with_wrong_entity_cap() {
     let mut e1 = ts::take_shared_by_id<entity::Entity>(&scenario, one);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
     let mut req = e1.interact(string::utf8(OWNER_ACTION), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify(&mut req, &cap);
 
     abort

--- a/contracts/core/tests/core_tests.move
+++ b/contracts/core/tests/core_tests.move
@@ -9,7 +9,7 @@ use core::{
     location_service,
     request,
     requirement::{Self, Requirement},
-    test_helpers::{setup, take_registry, take_acl, claim}
+    test_helpers::{setup, take_registry, take_acl, claim, location_hash, tenant}
 };
 use std::string;
 use sui::test_scenario as ts;
@@ -70,14 +70,49 @@ fun end_to_end_flow() {
     access_cap::verify(&mut req, &cap);
     e.complete_request(req);
 
-    // Interact: satisfy the injected proximity requirement first, then borrow the
-    // module by requirement, satisfy it, and mutate.
+    // Interact: satisfy injected proximity, then borrow the module and mutate.
     let mut req = e.interact(string::utf8(b"increment"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     let counter = e.module_mut<Counter>(&req, internal::permit<Counter>()).inner_mut();
     let (_requirement, frame) = req.take_next<Bump>(internal::permit<Bump>());
     counter.value = counter.value + 1;
     req.enqueue(frame);
+    e.complete_request(req);
+
+    ts::return_to_sender(&scenario, cap);
+    ts::return_shared(e);
+    scenario.end();
+}
+
+#[test]
+fun interact_injects_proximity_when_location_set() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let (mut e, mut req) = entity::new(&mut registry, 1, tenant(), b"loc");
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+
+    let mut req = e.mint_access(@0xA, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+    let e_id = e.id();
+    e.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(&scenario);
+    let mut req = e.enable_action(string::utf8(b"noop"), action::new(vector[]), scenario.ctx());
+    access_cap::verify(&mut req, &cap);
+    e.complete_request(req);
+
+    let mut req = e.interact(string::utf8(b"noop"), scenario.ctx());
+    location_service::verify_proximity(&mut req, b"loc");
     e.complete_request(req);
 
     ts::return_to_sender(&scenario, cap);

--- a/contracts/core/tests/core_tests.move
+++ b/contracts/core/tests/core_tests.move
@@ -9,7 +9,7 @@ use core::{
     location_service,
     request,
     requirement::{Self, Requirement},
-    test_helpers::{setup, take_registry, take_acl, claim, location_hash, tenant}
+    test_helpers::{setup, take_registry, take_acl, claim, claim_character, location_hash, tenant}
 };
 use std::string;
 use sui::test_scenario as ts;
@@ -118,6 +118,69 @@ fun interact_injects_proximity_when_location_set() {
     ts::return_to_sender(&scenario, cap);
     ts::return_shared(e);
     scenario.end();
+}
+
+#[test]
+fun interact_skips_proximity_when_location_empty() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let mut e = claim_character(&mut registry, &acl, 1, scenario.ctx());
+    let mut req = e.mint_access(@0xA, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+    let e_id = e.id();
+    e.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(&scenario);
+    let mut req = e.enable_action(string::utf8(b"noop"), action::new(vector[]), scenario.ctx());
+    access_cap::verify(&mut req, &cap);
+    e.complete_request(req);
+
+    // Empty location_hash: no proximity requirement — complete without verify_proximity.
+    let req = e.interact(string::utf8(b"noop"), scenario.ctx());
+    e.complete_request(req);
+
+    ts::return_to_sender(&scenario, cap);
+    ts::return_shared(e);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = request::ENoRequirements)]
+fun verify_proximity_aborts_when_location_empty() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let mut e = claim_character(&mut registry, &acl, 1, scenario.ctx());
+    let mut req = e.mint_access(@0xA, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+    let e_id = e.id();
+    e.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(&scenario);
+    let mut req = e.enable_action(string::utf8(b"noop"), action::new(vector[]), scenario.ctx());
+    access_cap::verify(&mut req, &cap);
+    e.complete_request(req);
+
+    let mut req = e.interact(string::utf8(b"noop"), scenario.ctx());
+    location_service::verify_proximity(&mut req, vector[]);
+
+    abort
 }
 
 #[test, expected_failure(abort_code = request::ERequestNotComplete)]

--- a/contracts/core/tests/object_registry_tests.move
+++ b/contracts/core/tests/object_registry_tests.move
@@ -91,7 +91,7 @@ fun claim_marks_key_existing() {
         let key = entity_key::new(99, tenant());
         let precomputed = object::id_from_address(registry.derive_id(key));
 
-        let (mut e, mut req) = entity::new(&mut registry, 99, tenant(), vector[]);
+        let (mut e, mut req) = entity::new(&mut registry, 99, tenant(), b"loc");
         admin_service::verify_admin(&mut req, &acl, scenario.ctx());
         e.complete_request(req);
 

--- a/contracts/core/tests/test_helpers.move
+++ b/contracts/core/tests/test_helpers.move
@@ -11,10 +11,14 @@ use sui::test_scenario as ts;
 
 const ADMIN: address = @0xA;
 const TENANT: vector<u8> = b"test";
+const LOCATION_HASH: vector<u8> = b"loc";
 
 public fun admin(): address { ADMIN }
 
 public fun tenant(): String { string::utf8(TENANT) }
+
+/// Default non-empty location used by structure/test entities.
+public fun location_hash(): vector<u8> { LOCATION_HASH }
 
 /// Init the object registry and admin service, seeding the deployer as admin.
 public fun setup(scenario: &mut ts::Scenario) {
@@ -30,20 +34,40 @@ public fun take_registry(scenario: &ts::Scenario): ObjectRegistry {
     ts::take_shared<ObjectRegistry>(scenario)
 }
 
-/// Claim and admin-approve an entity, returning it unlocked (not shared).
+/// Claim a located entity (structure) with the default test location hash.
 public fun claim(
     registry: &mut ObjectRegistry,
     acl: &AdminACL,
     id: u64,
     ctx: &mut TxContext,
 ): Entity {
-    let (mut e, mut req) = entity::new(registry, id, tenant(), vector[]);
+    claim_at(registry, acl, id, location_hash(), ctx)
+}
+
+/// Claim a character with empty location hash (no proximity on interact).
+public fun claim_character(
+    registry: &mut ObjectRegistry,
+    acl: &AdminACL,
+    id: u64,
+    ctx: &mut TxContext,
+): Entity {
+    claim_at(registry, acl, id, vector[], ctx)
+}
+
+public fun claim_at(
+    registry: &mut ObjectRegistry,
+    acl: &AdminACL,
+    id: u64,
+    location_hash: vector<u8>,
+    ctx: &mut TxContext,
+): Entity {
+    let (mut e, mut req) = entity::new(registry, id, tenant(), location_hash);
     admin_service::verify_admin(&mut req, acl, ctx);
     e.complete_request(req);
     e
 }
 
-/// Claim, admin-approve, and share an entity in an ADMIN tx, returning its id.
+/// Claim, admin-approve, and share a located entity in an ADMIN tx, returning its id.
 public fun create_entity(scenario: &mut ts::Scenario, id: u64): ID {
     ts::next_tx(scenario, ADMIN);
     let mut registry = take_registry(scenario);

--- a/contracts/inventory/tests/inventory_tests.move
+++ b/contracts/inventory/tests/inventory_tests.move
@@ -9,7 +9,7 @@ use core::{
     location_service,
     object_registry::ObjectRegistry,
     requirement::Requirement,
-    test_helpers::{claim, setup, take_acl, take_registry}
+    test_helpers::{claim, claim_character, location_hash, setup, take_acl, take_registry}
 };
 use inventory::{inventory, item::Item};
 use std::string::{Self, String};
@@ -144,7 +144,7 @@ fun configure_default_actions(scenario: &mut ts::Scenario, e_id: ID) {
 /// Create a separate "character" entity and mint a soulbound cap to PLAYER.
 /// Returns the character entity id (the key its ephemeral inventory routes to).
 fun create_player(scenario: &mut ts::Scenario, registry: &mut ObjectRegistry, acl: &AdminACL): ID {
-    let mut character = claim(registry, acl, 2, scenario.ctx());
+    let mut character = claim_character(registry, acl, 2, scenario.ctx());
     let mut req = character.mint_access(PLAYER, false, scenario.ctx());
     admin_service::verify_admin(&mut req, acl, scenario.ctx());
     character.complete_request(req);
@@ -165,7 +165,7 @@ fun bridge_in(
     vol: u64,
 ) {
     let mut req = e.interact(string::utf8(action), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, cap);
     inventory::game_item_to_chain_inventory(e, &mut req, type_id, qty, vol, scenario.ctx());
     e.complete_request(req);
@@ -180,7 +180,7 @@ fun bridge_out(
     qty: u64,
 ) {
     let mut req = e.interact(string::utf8(action), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, cap);
     inventory::chain_item_to_game_inventory(e, &mut req, type_id, qty, scenario.ctx());
     e.complete_request(req);
@@ -194,7 +194,7 @@ fun deposit(
     item: Item,
 ) {
     let mut req = e.interact(string::utf8(action), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, cap);
     inventory::deposit(e, &mut req, item, scenario.ctx());
     e.complete_request(req);
@@ -209,7 +209,7 @@ fun withdraw(
     qty: u64,
 ): Item {
     let mut req = e.interact(string::utf8(action), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, cap);
     let item = inventory::withdraw(e, &mut req, type_id, qty, scenario.ctx());
     e.complete_request(req);
@@ -313,7 +313,7 @@ fun main_inv_interaction_without_caller() {
     ts::next_tx(&mut scenario, PLAYER);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
     let mut req = e.interact(string::utf8(b"public_bridge"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL, 10, VOL, scenario.ctx());
     e.complete_request(req);
 
@@ -425,7 +425,7 @@ fun swap_moves_between_main_and_ephemeral_single_signer() {
     bridge_in(&mut scenario, &mut e, &player_cap, b"eph_bridge_in", FUEL, 1, VOL);
 
     let mut req = e.interact(string::utf8(b"swap"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, &player_cap);
     let fuel = inventory::withdraw(&mut e, &mut req, FUEL, 1, scenario.ctx()); // from ephemeral
     inventory::deposit(&mut e, &mut req, fuel, scenario.ctx()); // into main
@@ -476,7 +476,7 @@ fun ephemeral_interaction_without_caller_aborts() {
     ts::next_tx(&mut scenario, PLAYER);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
     let mut req = e.interact(string::utf8(b"eph_uncalled"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL, 10, VOL, scenario.ctx());
 
     abort
@@ -538,7 +538,7 @@ fun bridge_in_wrong_type_aborts() {
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
     let mut req = e.interact(string::utf8(b"bridge_fuel"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify_caller(&mut req, &cap);
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL + 1, 10, VOL, scenario.ctx());
 

--- a/contracts/metadata/tests/metadata_tests.move
+++ b/contracts/metadata/tests/metadata_tests.move
@@ -8,7 +8,7 @@ use core::{
     entity::{Self, Entity},
     location_service,
     object_registry::ObjectRegistry,
-    test_helpers::{claim, setup, take_acl, take_registry}
+    test_helpers::{claim, claim_character, location_hash, setup, take_acl, take_registry}
 };
 use metadata::metadata::{Self, MetadataChanged};
 use std::string;
@@ -52,7 +52,7 @@ fun create_character(
     registry: &mut ObjectRegistry,
     acl: &AdminACL,
 ): ID {
-    let character = claim(registry, acl, 2, scenario.ctx());
+    let character = claim_character(registry, acl, 2, scenario.ctx());
     let character_id = character.id();
     character.share();
     character_id
@@ -112,7 +112,7 @@ fun edit_via_character(
     let (owner_cap, receipt) = character.borrow_access(&char_cap, ticket);
 
     let mut req = e.interact(string::utf8(b"edit_metadata"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    location_service::verify_proximity(&mut req, location_hash());
     access_cap::verify(&mut req, &owner_cap);
     metadata::edit(
         &mut e,

--- a/docker/entrypoint-integration.sh
+++ b/docker/entrypoint-integration.sh
@@ -130,18 +130,36 @@ sui genesis --from-config "$GENESIS_RUNTIME_CONFIG" --working-dir "$DATA_DIR" --
 # Genesis writes its own fullnode.yaml; overwriting it breaks faucet tx execution.
 
 # ── 3. Start node ────────────────────────────────────────────────────────────
-log "Starting local Sui node..."
-sui start --network.config "$DATA_DIR" --with-faucet &
+NODE_LOG="$DATA_DIR/node.log"
+START_ARGS=(--network.config "$DATA_DIR")
+if [ "$MODE" != "test" ]; then
+  START_ARGS+=(--with-faucet)
+fi
+log "Starting local Sui node (${START_ARGS[*]})..."
+sui start "${START_ARGS[@]}" >"$NODE_LOG" 2>&1 &
 NODE_PID=$!
 trap 'kill "$NODE_PID" 2>/dev/null || true' EXIT
 
 log "Waiting for RPC at $RPC_URL ..."
-for i in $(seq 1 60); do
-  curl -sf -X POST "$RPC_URL" -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","method":"rpc.discover","id":1}' >/dev/null 2>&1 && break
-  if [ "$i" -eq 60 ]; then log "ERROR: RPC did not become ready"; exit 1; fi
+ready=0
+for i in $(seq 1 120); do
+  if ! kill -0 "$NODE_PID" 2>/dev/null; then
+    log "ERROR: node exited before RPC was ready"
+    tail -n 100 "$NODE_LOG" || true
+    exit 1
+  fi
+  if curl -sf -X POST "$RPC_URL" -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"rpc.discover","id":1}' >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
   sleep 1
 done
+if [ "$ready" -ne 1 ]; then
+  log "ERROR: RPC did not become ready"
+  tail -n 100 "$NODE_LOG" || true
+  exit 1
+fi
 sleep 2
 log "RPC ready."
 

--- a/sdk/world-sdk/scripts/seed-storage-units.ts
+++ b/sdk/world-sdk/scripts/seed-storage-units.ts
@@ -7,6 +7,7 @@ import { loadSeedFiles } from './seed-files.js'
 const UNIT_NAME = 'SU'
 const MAIN_CAPACITY = 1000n
 const EPHEMERAL_CAPACITY = 100n
+const LOCATION_HASH = Array.from(new TextEncoder().encode('loc'))
 
 const { repoRoot, config, client, keypair } = loadScriptContext()
 const { resources, accounts } = loadSeedFiles(repoRoot)
@@ -38,6 +39,7 @@ for (const [, unit] of entries) {
   createStorageUnit(createTx, config, {
     inGameId: BigInt(unit.itemId),
     tenant: resources.tenant,
+    locationHash: LOCATION_HASH,
     name: UNIT_NAME,
     mainCapacity: MAIN_CAPACITY,
     ephemeralCapacity: EPHEMERAL_CAPACITY,

--- a/sdk/world-sdk/src/__integration__/helpers.ts
+++ b/sdk/world-sdk/src/__integration__/helpers.ts
@@ -10,6 +10,8 @@ import type { WorldConfig } from '../config/types.js'
 import { mintAccess } from '../packages/core.js'
 import { balanceOf } from '../packages/inventory.js'
 
+export const TEST_LOCATION_HASH = Array.from(new TextEncoder().encode('loc'))
+
 export const LOCALNET_MANIFEST = fileURLToPath(
   new URL('../../../../deployments/localnet/world.json', import.meta.url),
 )

--- a/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
@@ -23,6 +23,7 @@ import {
   mintAccessCap,
   readBalance,
   signer,
+  TEST_LOCATION_HASH,
 } from './helpers.js'
 
 // A non-owner player brings items into their ephemeral inventory and
@@ -46,6 +47,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      locationHash: TEST_LOCATION_HASH,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 1000n,
@@ -104,7 +106,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     const playerCap = runTx.object(playerCapId)
 
     const inReq = interact(runTx, config, e, 'eph_bridge_in')
-    verifyProximity(runTx, config, inReq)
+    verifyProximity(runTx, config, inReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, inReq, playerCap)
     gameItemToChain(runTx, config, e, inReq, {
       typeId: FUEL,
@@ -114,7 +116,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     completeRequest(runTx, config, e, inReq)
 
     const outReq = interact(runTx, config, e, 'eph_withdraw')
-    verifyProximity(runTx, config, outReq)
+    verifyProximity(runTx, config, outReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, outReq, playerCap)
     const item = withdraw(runTx, config, e, outReq, {
       typeId: FUEL,

--- a/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
@@ -28,6 +28,7 @@ import {
   mintAccessCap,
   readBalance,
   signer,
+  TEST_LOCATION_HASH,
 } from './helpers.js'
 
 // The SU owner cap is parked on a Character. To use the owner path, borrow
@@ -50,6 +51,7 @@ describe('inventory owner-access via Character', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      locationHash: TEST_LOCATION_HASH,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 100n,
@@ -128,7 +130,7 @@ describe('inventory owner-access via Character', () => {
       const su = runTx.object(suId)
 
       const inReq = interact(runTx, config, su, 'bridge_in')
-      verifyProximity(runTx, config, inReq)
+      verifyProximity(runTx, config, inReq, TEST_LOCATION_HASH)
       verifyOwner(runTx, config, inReq, suCap)
       gameItemToChain(runTx, config, su, inReq, {
         typeId: FUEL,
@@ -138,7 +140,7 @@ describe('inventory owner-access via Character', () => {
       completeRequest(runTx, config, su, inReq)
 
       const wReq = interact(runTx, config, su, 'withdraw')
-      verifyProximity(runTx, config, wReq)
+      verifyProximity(runTx, config, wReq, TEST_LOCATION_HASH)
       verifyOwner(runTx, config, wReq, suCap)
       const item = withdraw(runTx, config, su, wReq, {
         typeId: FUEL,
@@ -147,7 +149,7 @@ describe('inventory owner-access via Character', () => {
       completeRequest(runTx, config, su, wReq)
 
       const dReq = interact(runTx, config, su, 'deposit')
-      verifyProximity(runTx, config, dReq)
+      verifyProximity(runTx, config, dReq, TEST_LOCATION_HASH)
       verifyOwner(runTx, config, dReq, suCap)
       deposit(runTx, config, su, dReq, item)
       completeRequest(runTx, config, su, dReq)

--- a/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
@@ -25,6 +25,7 @@ import {
   mintAccessCap,
   readBalance,
   signer,
+  TEST_LOCATION_HASH,
 } from './helpers.js'
 
 // Owner configures a multi-requirement swap (give a fuel from your ephemeral,
@@ -48,6 +49,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      locationHash: TEST_LOCATION_HASH,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 1000n,
@@ -130,7 +132,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     const stockTx = new Transaction()
     const se = stockTx.object(suId)
     const stockReq = interact(stockTx, config, se, 'bridge_in')
-    verifyProximity(stockTx, config, stockReq)
+    verifyProximity(stockTx, config, stockReq, TEST_LOCATION_HASH)
     verifyCaller(stockTx, config, stockReq, stockTx.object(ownerCapId))
     gameItemToChain(stockTx, config, se, stockReq, {
       typeId: LENS,
@@ -146,7 +148,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     const playerCap = runTx.object(playerCapId)
 
     const inReq = interact(runTx, config, e, 'eph_bridge_in')
-    verifyProximity(runTx, config, inReq)
+    verifyProximity(runTx, config, inReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, inReq, playerCap)
     gameItemToChain(runTx, config, e, inReq, {
       typeId: FUEL,
@@ -156,7 +158,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     completeRequest(runTx, config, e, inReq)
 
     const swapReq = interact(runTx, config, e, 'swap')
-    verifyProximity(runTx, config, swapReq)
+    verifyProximity(runTx, config, swapReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, swapReq, playerCap)
     const fuel = withdraw(runTx, config, e, swapReq, {
       typeId: FUEL,

--- a/sdk/world-sdk/src/__integration__/inventory.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory.test.ts
@@ -24,6 +24,7 @@ import {
   mintAccessCap,
   readBalance,
   signer,
+  TEST_LOCATION_HASH,
 } from './helpers.js'
 
 // Exercise the inventory bindings in isolation. Create a storage-unit entity,
@@ -46,6 +47,7 @@ describe('inventory owner round-trip (localnet)', () => {
     createStorageUnit(createTx, config, {
       inGameId: key.id,
       tenant: key.tenant,
+      locationHash: TEST_LOCATION_HASH,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 100n,
@@ -104,7 +106,7 @@ describe('inventory owner round-trip (localnet)', () => {
     const c = runTx.object(capId)
 
     const bridgeReqObj = interact(runTx, config, e, 'bridge_in')
-    verifyProximity(runTx, config, bridgeReqObj)
+    verifyProximity(runTx, config, bridgeReqObj, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, bridgeReqObj, c)
     gameItemToChain(runTx, config, e, bridgeReqObj, {
       typeId: FUEL,
@@ -114,7 +116,7 @@ describe('inventory owner round-trip (localnet)', () => {
     completeRequest(runTx, config, e, bridgeReqObj)
 
     const wReq = interact(runTx, config, e, 'withdraw')
-    verifyProximity(runTx, config, wReq)
+    verifyProximity(runTx, config, wReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, wReq, c)
     const item = withdraw(runTx, config, e, wReq, {
       typeId: FUEL,
@@ -123,7 +125,7 @@ describe('inventory owner round-trip (localnet)', () => {
     completeRequest(runTx, config, e, wReq)
 
     const dReq = interact(runTx, config, e, 'deposit')
-    verifyProximity(runTx, config, dReq)
+    verifyProximity(runTx, config, dReq, TEST_LOCATION_HASH)
     verifyCaller(runTx, config, dReq, c)
     deposit(runTx, config, e, dReq, item)
     completeRequest(runTx, config, e, dReq)

--- a/sdk/world-sdk/src/__integration__/metadata.test.ts
+++ b/sdk/world-sdk/src/__integration__/metadata.test.ts
@@ -26,6 +26,7 @@ import {
   loadLocalnetWorld,
   mintAccessCap,
   signer,
+  TEST_LOCATION_HASH,
 } from './helpers.js'
 
 // Entity owner cap is parked on a Character. Borrow it to enable/edit, then return.
@@ -43,6 +44,7 @@ describe('metadata owner-access via Character', () => {
       const [entity, claimReq] = entityNew(setupTx, config, {
         inGameId: entityKey.id,
         tenant: entityKey.tenant,
+        locationHash: TEST_LOCATION_HASH,
       })
       verifyAdmin(setupTx, config, claimReq)
       completeRequest(setupTx, config, entity, claimReq)
@@ -106,7 +108,7 @@ describe('metadata owner-access via Character', () => {
       )
       const e = editTx.object(entityId)
       const req = interact(editTx, config, e, 'edit_metadata')
-      verifyProximity(editTx, config, req)
+      verifyProximity(editTx, config, req, TEST_LOCATION_HASH)
       verifyOwner(editTx, config, req, entityCap)
       editMetadata(editTx, config, e, req, {
         name: 'Beta',

--- a/sdk/world-sdk/src/packages/character.ts
+++ b/sdk/world-sdk/src/packages/character.ts
@@ -25,6 +25,7 @@ export function createCharacter(
   const [character, claimReq] = entityNew(tx, config, {
     inGameId: args.inGameId,
     tenant: args.tenant,
+    locationHash: [],
   })
   verifyAdmin(tx, config, claimReq)
   completeRequest(tx, config, character, claimReq)

--- a/sdk/world-sdk/src/packages/core.ts
+++ b/sdk/world-sdk/src/packages/core.ts
@@ -60,7 +60,8 @@ export function deriveObjectId(
 export interface EntityNewArgs {
   inGameId: bigint
   tenant: string
-  locationHash?: number[]
+  /** Empty for principals (Character); non-empty for structures. */
+  locationHash: number[]
 }
 
 /**
@@ -79,7 +80,7 @@ export function entityNew(
       sharedRef(tx, objectRegistry(config), true),
       tx.pure.u64(args.inGameId),
       tx.pure.string(args.tenant),
-      tx.pure.vector('u8', args.locationHash ?? []),
+      tx.pure.vector('u8', args.locationHash),
     ],
   })
 }
@@ -199,12 +200,12 @@ export function verifyCaller(
   })
 }
 
-/** Satisfy a proximity requirement. `proof`/location hash defaults to empty. */
+/** Satisfy a proximity requirement injected when the entity has a location hash. */
 export function verifyProximity(
   tx: Transaction,
   config: WorldConfig,
   request: TransactionArgument,
-  proof: number[] = [],
+  proof: number[],
 ): void {
   tx.moveCall({
     target: `${mvrName(config.env, CORE_PACKAGE)}::location_service::verify_proximity`,

--- a/sdk/world-sdk/src/packages/inventory.ts
+++ b/sdk/world-sdk/src/packages/inventory.ts
@@ -119,6 +119,7 @@ export function uninstallInventory(
 export interface CreateStorageUnitArgs {
   inGameId: bigint
   tenant: string
+  /** Non-empty so `interact` injects proximity. */
   locationHash: number[]
   name: string
   mainCapacity: bigint

--- a/sdk/world-sdk/src/packages/inventory.ts
+++ b/sdk/world-sdk/src/packages/inventory.ts
@@ -119,6 +119,7 @@ export function uninstallInventory(
 export interface CreateStorageUnitArgs {
   inGameId: bigint
   tenant: string
+  locationHash: number[]
   name: string
   mainCapacity: bigint
   ephemeralCapacity: bigint
@@ -136,6 +137,7 @@ export function createStorageUnit(
   const [entity, claimReq] = entityNew(tx, config, {
     inGameId: args.inGameId,
     tenant: args.tenant,
+    locationHash: args.locationHash,
   })
   verifyAdmin(tx, config, claimReq)
   completeRequest(tx, config, entity, claimReq)


### PR DESCRIPTION
## Summary
- Skip proximity injection on `interact` when `location_hash` is empty (Character).
- Structures keep a non-empty hash.
- Proximity proof = interactor location (e.g. ship) matched against the target entity hash.
