### PR TITLE
fix: migrate ts-scripts from JSON-RPC to Sui gRPC

### DIFF
--- a/contracts/world/Move.lock
+++ b/contracts/world/Move.lock
@@ -22,6 +22,24 @@ use_environment = "testnet"
 manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
 deps = { std = "MoveStdlib", sui = "Sui" }
 
+[pinned.testnet_dev.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "06734f6ff0af45d8632a14a4dc4b100197f6b1a2" }
+use_environment = "testnet_dev"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet_dev.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "06734f6ff0af45d8632a14a4dc4b100197f6b1a2" }
+use_environment = "testnet_dev"
+manifest_digest = "12739FD1CC149512A4DFE790E398E0811A5F413F9577B96590282885253F5747"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet_dev.world]
+source = { root = true }
+use_environment = "testnet_dev"
+manifest_digest = "EA5230FD8A7BE615AA04159F136073B3AB3EBB4380F812FCE55A8BD2482968E8"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
 [pinned.testnet_internal.MoveStdlib]
 source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "b38bca86f0323b3fe8b6b7f4ca0cd7ae7faebe4b" }
 use_environment = "testnet_internal"

--- a/contracts/world/Move.toml
+++ b/contracts/world/Move.toml
@@ -25,3 +25,4 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 testnet_internal = "4c78adac"
 testnet_utopia = "4c78adac"
 testnet_stillness = "4c78adac"
+testnet_dev = "4c78adac"

--- a/contracts/world/Published.toml
+++ b/contracts/world/Published.toml
@@ -13,12 +13,12 @@ upgrade-capability = "0x44b53f8e17777bd96ca5bcdc3ddf1c87842507f7dd00d729ccf30059
 
 [published.testnet_dev]
 chain-id = "4c78adac"
-published-at = "0x955353d44137c3e73a4d83a02bf558223642b1902f3758c6abef40b448d4e3fc"
-original-id = "0x955353d44137c3e73a4d83a02bf558223642b1902f3758c6abef40b448d4e3fc"
+published-at = "0xc7cf7d22a2875dba899d5410d61600c15477d82d1cf132133f522271f205a4e3"
+original-id = "0xc7cf7d22a2875dba899d5410d61600c15477d82d1cf132133f522271f205a4e3"
 version = 1
 toolchain-version = "1.77.2"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0xd36124703037c55f081c8e4314c7022cb1c60aaf874bc56cdf46c1c61fe42d9f"
+upgrade-capability = "0x7c933421556c1572b22d4608da87e553baf806318e8e197d8d9836066ca4f1ce"
 
 [published.testnet_internal]
 chain-id = "4c78adac"

--- a/contracts/world/Published.toml
+++ b/contracts/world/Published.toml
@@ -11,6 +11,15 @@ toolchain-version = "1.68.0"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0x44b53f8e17777bd96ca5bcdc3ddf1c87842507f7dd00d729ccf300593aaa611a"
 
+[published.testnet_dev]
+chain-id = "4c78adac"
+published-at = "0x955353d44137c3e73a4d83a02bf558223642b1902f3758c6abef40b448d4e3fc"
+original-id = "0x955353d44137c3e73a4d83a02bf558223642b1902f3758c6abef40b448d4e3fc"
+version = 1
+toolchain-version = "1.77.2"
+build-config = { flavor = "sui", edition = "2024" }
+upgrade-capability = "0xd36124703037c55f081c8e4314c7022cb1c60aaf874bc56cdf46c1c61fe42d9f"
+
 [published.testnet_internal]
 chain-id = "4c78adac"
 published-at = "0xe148a2146cffc32181e7e984c0f6f5229ba26b0234a68251dff2958df01f1cc0"

--- a/env.example
+++ b/env.example
@@ -3,8 +3,9 @@
 # ============================================
 SUI_NETWORK=localnet
 
-# Custom RPC URL (optional, defaults to public endpoints)
-# SUI_RPC_URL=https://fullnode.devnet.sui.io:443
+# Custom gRPC fullnode URL (optional, defaults to public endpoints)
+# SUI_GRPC_URL=https://fullnode.devnet.sui.io:443
+# SUI_RPC_URL is still accepted as a fallback alias for SUI_GRPC_URL
 # For localnet in Docker, use: http://host.docker.internal:9000 (Mac/Windows)
 # For localnet in Docker on Linux, use: http://172.17.0.1:9000 (or your host IP)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mysten/sui": "^2.0.0",
         "@noble/hashes": "^1.8.0",
         "dotenv": "^17.2.3",
+        "pnpm": "^11.22.0",
         "prettier": "^3.7.4"
       },
       "devDependencies": {
@@ -852,6 +853,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "11.22.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz",
+      "integrity": "sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==",
+      "license": "MIT",
+      "bin": {
+        "pn": "bin/pnpm.mjs",
+        "pnpm": "bin/pnpm.mjs",
+        "pnpx": "bin/pnpx.mjs",
+        "pnx": "bin/pnpx.mjs"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/poseidon-lite": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@mysten/sui": "^2.0.0",
     "@noble/hashes": "^1.8.0",
     "dotenv": "^17.2.3",
+    "pnpm": "^11.22.0",
     "prettier": "^3.7.4"
   },
   "author": "EVE Frontier",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      pnpm:
+        specifier: ^11.22.0
+        version: 11.22.0
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -305,6 +308,11 @@ packages:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  pnpm@11.22.0:
+    resolution: {integrity: sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
   poseidon-lite@0.2.1:
     resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
 
@@ -563,6 +571,8 @@ snapshots:
       - graphql
 
   graphql@16.12.0: {}
+
+  pnpm@11.22.0: {}
 
   poseidon-lite@0.2.1: {}
 

--- a/ts-scripts/access/setup-access.ts
+++ b/ts-scripts/access/setup-access.ts
@@ -16,14 +16,14 @@ function getAccessSetupEnv() {
     const network = (process.env.SUI_NETWORK as Network) || "testnet";
     // during development, we use the same private key for governor and admin
     const governorKey = process.env.GOVERNOR_PRIVATE_KEY || requireEnv("ADMIN_PRIVATE_KEY");
-    const adminAddress = requireEnv("ADMIN_ADDRESS").trim().toLowerCase();
+    const adminAddresses = getAddresses(requireEnv("ADMIN_ADDRESS"));
     const sponsorAddresses = getAddresses(requireEnv("SPONSOR_ADDRESSES"));
 
-    return { network, governorKey, adminAddress, sponsorAddresses };
+    return { network, governorKey, adminAddresses, sponsorAddresses };
 }
 
 async function setupAccess() {
-    const { network, governorKey, adminAddress, sponsorAddresses } = getAccessSetupEnv();
+    const { network, governorKey, adminAddresses, sponsorAddresses } = getAccessSetupEnv();
     const ctx = initializeContext(network, governorKey);
     const { client, keypair } = ctx;
     const config = await hydrateWorldConfig(ctx);
@@ -37,22 +37,27 @@ async function setupAccess() {
         throw new Error(`Config missing`);
     }
 
+    if (adminAddresses.length === 0) {
+        throw new Error("ADMIN_ADDRESS must contain at least one address");
+    }
     if (sponsorAddresses.length === 0) {
         throw new Error("SPONSOR_ADDRESSES must contain at least one address");
     }
 
     const target = `${packageId}::${MODULES.ACCESS}`;
 
-    console.log("1. register_server_address...");
+    console.log(`1. register_server_address (${adminAddresses.length} admins, atomic)...`);
     const tx1 = new Transaction();
-    tx1.moveCall({
-        target: `${target}::register_server_address`,
-        arguments: [
-            tx1.object(serverAddressRegistry),
-            tx1.object(governorCap),
-            tx1.pure.address(adminAddress),
-        ],
-    });
+    for (const adminAddress of adminAddresses) {
+        tx1.moveCall({
+            target: `${target}::register_server_address`,
+            arguments: [
+                tx1.object(serverAddressRegistry),
+                tx1.object(governorCap),
+                tx1.pure.address(adminAddress),
+            ],
+        });
+    }
     const r1 = await signAndExecute(client, {
         signer: keypair,
         transaction: tx1,

--- a/ts-scripts/access/setup-access.ts
+++ b/ts-scripts/access/setup-access.ts
@@ -16,7 +16,7 @@ function getAccessSetupEnv() {
     const network = (process.env.SUI_NETWORK as Network) || "testnet";
     // during development, we use the same private key for governor and admin
     const governorKey = process.env.GOVERNOR_PRIVATE_KEY || requireEnv("ADMIN_PRIVATE_KEY");
-    const adminAddress = getAddresses(requireEnv("ADMIN_ADDRESS"));
+    const adminAddress = requireEnv("ADMIN_ADDRESS").trim().toLowerCase();
     const sponsorAddresses = getAddresses(requireEnv("SPONSOR_ADDRESSES"));
 
     return { network, governorKey, adminAddress, sponsorAddresses };

--- a/ts-scripts/access/setup-access.ts
+++ b/ts-scripts/access/setup-access.ts
@@ -3,8 +3,9 @@ import { Transaction } from "@mysten/sui/transactions";
 import { MODULES, Network } from "../utils/config";
 import { delay } from "../utils/delay";
 import { handleError, hydrateWorldConfig, initializeContext, requireEnv } from "../utils/helper";
+import { signAndExecute } from "../utils/client";
 
-function getSponsorAddresses(raw: string): string[] {
+function getAddresses(raw: string): string[] {
     return raw
         .split(",")
         .map((s) => s.trim().toLowerCase())
@@ -15,8 +16,8 @@ function getAccessSetupEnv() {
     const network = (process.env.SUI_NETWORK as Network) || "testnet";
     // during development, we use the same private key for governor and admin
     const governorKey = process.env.GOVERNOR_PRIVATE_KEY || requireEnv("ADMIN_PRIVATE_KEY");
-    const adminAddress = requireEnv("ADMIN_ADDRESS");
-    const sponsorAddresses = getSponsorAddresses(requireEnv("SPONSOR_ADDRESSES"));
+    const adminAddress = getAddresses(requireEnv("ADMIN_ADDRESS"));
+    const sponsorAddresses = getAddresses(requireEnv("SPONSOR_ADDRESSES"));
 
     return { network, governorKey, adminAddress, sponsorAddresses };
 }
@@ -52,15 +53,11 @@ async function setupAccess() {
             tx1.pure.address(adminAddress),
         ],
     });
-    const r1 = await client.signAndExecuteTransaction({
+    const r1 = await signAndExecute(client, {
         signer: keypair,
         transaction: tx1,
-        options: { showObjectChanges: true },
     });
     console.log("   Digest:", r1.digest);
-    if (r1.effects?.status?.status === "failure") {
-        throw new Error(`register_server_address failed: ${JSON.stringify(r1.effects.status)}`);
-    }
     await delay(5000);
 
     console.log(`2. add_sponsor_to_acl (${sponsorAddresses.length} sponsors, atomic)...`);
@@ -75,15 +72,11 @@ async function setupAccess() {
             ],
         });
     }
-    const r2 = await client.signAndExecuteTransaction({
+    const r2 = await signAndExecute(client, {
         signer: keypair,
         transaction: tx2,
-        options: { showObjectChanges: true },
     });
     console.log("   Digest:", r2.digest);
-    if (r2.effects?.status?.status === "failure") {
-        throw new Error(`add_sponsor_to_acl failed: ${JSON.stringify(r2.effects.status)}`);
-    }
 
     console.log("\n==== Access setup complete ====");
 }

--- a/ts-scripts/assembly/create-assembly.ts
+++ b/ts-scripts/assembly/create-assembly.ts
@@ -18,6 +18,7 @@ import {
     ASSEMBLY_ITEM_ID,
 } from "../utils/constants";
 import { deriveObjectId } from "../utils/derive-object-id";
+import { signAndExecute } from "../utils/client";
 
 async function createAssembly(
     characterObjectId: string,
@@ -49,10 +50,9 @@ async function createAssembly(
         arguments: [assembly, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEvents: true },
     });
 
     const assemblyEvent = extractEvent<{ assembly_id: string; owner_cap_id: string }>(

--- a/ts-scripts/assembly/online.ts
+++ b/ts-scripts/assembly/online.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import { bcs } from "@mysten/sui/bcs";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { HydratedWorldConfig, getConfig, MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -14,12 +13,13 @@ import {
     requireEnv,
 } from "../utils/helper";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 export async function online(
     networkObjectId: string,
     assemblyId: string,
     ownerCapId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: HydratedWorldConfig
 ) {
@@ -54,10 +54,9 @@ export async function online(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("\n Assembly brought online successfully!");
@@ -67,7 +66,7 @@ export async function online(
 
 export async function getOwnerCap(
     assemblyId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: HydratedWorldConfig,
     senderAddress?: string
 ): Promise<string | null> {

--- a/ts-scripts/assets/finalize-eve-currency.ts
+++ b/ts-scripts/assets/finalize-eve-currency.ts
@@ -9,7 +9,7 @@
  */
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { createClient, keypairFromPrivateKey } from "../utils/client";
+import { createClient, keypairFromPrivateKey, signAndExecute } from "../utils/client";
 import { loadExtractedObjectIds } from "../utils/helper";
 import type { Network } from "../utils/config";
 
@@ -40,13 +40,12 @@ async function main() {
 
     const coinType = `${packageId}::EVE::EVE`;
 
-    const res = await client.getObject({ id: currencyObjectId });
-    if (!res.data) {
-        console.error("Currency object not found:", currencyObjectId, res.error ?? "");
-        process.exit(1);
-    }
-    const { objectId, version, digest } = res.data;
-    const currencyRef = { objectId, version, digest };
+    const { object } = await client.getObject({ objectId: currencyObjectId });
+    const currencyRef = {
+        objectId: object.objectId,
+        version: object.version,
+        digest: object.digest,
+    };
 
     const tx = new Transaction();
     tx.setSender(sender);
@@ -56,19 +55,13 @@ async function main() {
         arguments: [tx.object(COIN_REGISTRY_ID), tx.receivingRef(currencyRef)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
-    if (result.effects?.status?.status === "success") {
-        console.log("EVE currency finalized in CoinRegistry.");
-        console.log("Digest:", result.digest);
-    } else {
-        console.error("Finalize failed:", result.effects?.status);
-        process.exit(1);
-    }
+    console.log("EVE currency finalized in CoinRegistry.");
+    console.log("Digest:", result.digest);
 }
 
 main().catch((e) => {

--- a/ts-scripts/assets/transfer-eve.ts
+++ b/ts-scripts/assets/transfer-eve.ts
@@ -10,6 +10,7 @@ import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
 import { Network } from "../utils/config";
 import { initializeContext, loadExtractedObjectIds, requireEnv } from "../utils/helper";
+import { signAndExecute } from "../utils/client";
 
 const EVE_DECIMALS = 9;
 const SCALE = 10n ** BigInt(EVE_DECIMALS);
@@ -55,13 +56,13 @@ async function main() {
     const coinType = `${packageId}::EVE::EVE`;
 
     // Assume the deployer has a single EVE coin object.
-    const coinsRes = await client.getCoins({
+    const coinsRes = await client.listCoins({
         owner: sender,
         coinType,
         limit: 1,
     });
 
-    const coin = coinsRes.data[0];
+    const coin = coinsRes.objects[0];
     if (!coin) {
         console.error("Deployer has no EVE coins.");
         process.exit(1);
@@ -75,22 +76,16 @@ async function main() {
 
     const tx = new Transaction();
     tx.setSender(sender);
-    const [toSend] = tx.splitCoins(tx.object(coin.coinObjectId), [amountRaw]);
+    const [toSend] = tx.splitCoins(tx.object(coin.objectId), [amountRaw]);
     tx.transferObjects([toSend], recipient);
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         signer: keypair,
         transaction: tx,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
-    if (result.effects?.status?.status === "success") {
-        console.log(`Transferred ${amountEve} EVE to ${recipient}`);
-        console.log("Digest:", result.digest);
-    } else {
-        console.error("Transfer failed:", result.effects?.status);
-        process.exit(1);
-    }
+    console.log(`Transferred ${amountEve} EVE to ${recipient}`);
+    console.log("Digest:", result.digest);
 }
 
 main().catch((e) => {

--- a/ts-scripts/builder_extension/authorise-gate.ts
+++ b/ts-scripts/builder_extension/authorise-gate.ts
@@ -14,6 +14,7 @@ import { requireBuilderPackageId } from "../utils/builder-extension";
 import { getOwnerCap as getGateOwnerCap } from "../gate/helper";
 import { MODULE as extensionModule } from "./modules";
 import { delay, getDelayMs } from "../utils/delay";
+import { signAndExecute } from "../utils/client";
 
 const builderPackageId = requireBuilderPackageId();
 const characterItemId = GAME_CHARACTER_ID;
@@ -57,10 +58,9 @@ async function authoriseGate(
         arguments: [tx.object(characterId), gateOwnerCap!, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
 
     console.log("\nExtension authorized successfully!");

--- a/ts-scripts/builder_extension/authorise-storage-unit.ts
+++ b/ts-scripts/builder_extension/authorise-storage-unit.ts
@@ -13,6 +13,7 @@ import {
 import { requireBuilderPackageId } from "../utils/builder-extension";
 import { getOwnerCap as getStorageUnitOwnerCap } from "../storage-unit/helper";
 import { MODULE as extensionModule } from "./modules";
+import { signAndExecute } from "../utils/client";
 
 const builderPackageId = requireBuilderPackageId();
 const characterItemId = GAME_CHARACTER_ID;
@@ -64,10 +65,9 @@ async function authoriseStorageUnit(
         arguments: [tx.object(characterId), storageUnitOwnerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
 
     console.log("\nExtension authorized successfully!");

--- a/ts-scripts/builder_extension/authorize-turret.ts
+++ b/ts-scripts/builder_extension/authorize-turret.ts
@@ -13,6 +13,7 @@ import {
 import { getOwnerCap } from "../turret/helper";
 import { requireBuilderPackageId } from "../utils/builder-extension";
 import { MODULE as extensionModule } from "./modules";
+import { signAndExecute } from "../utils/client";
 
 const builderPackageId = requireBuilderPackageId();
 
@@ -52,10 +53,9 @@ async function authorizeExtension(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
     console.log("Extension authorized. Auth type:", authType);
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/builder_extension/collect-corpse-bounty.ts
+++ b/ts-scripts/builder_extension/collect-corpse-bounty.ts
@@ -94,8 +94,7 @@ async function collectCorpseBounty(
         keypair,
         adminKeypair,
         address,
-        adminAddress,
-        { showEffects: true, showObjectChanges: true, showEvents: true }
+        adminAddress
     );
 
     console.log("\nCorpse bounty collected + JumpPermit issued!");

--- a/ts-scripts/builder_extension/configure-rules.ts
+++ b/ts-scripts/builder_extension/configure-rules.ts
@@ -4,6 +4,7 @@ import { getEnvConfig, handleError, hydrateWorldConfig, initializeContext } from
 import { resolveBuilderGateExtensionIds } from "../utils/builder-extension";
 import { ITEM_A_TYPE_ID } from "../utils/constants";
 import { MODULE } from "./modules";
+import { signAndExecute } from "../utils/client";
 
 async function main() {
     console.log("============= Configure Builder Gate Rules ==============\n");
@@ -33,10 +34,9 @@ async function main() {
             ],
         });
 
-        const result = await client.signAndExecuteTransaction({
+        const result = await signAndExecute(client, {
             transaction: tx,
             signer: keypair,
-            options: { showEffects: true, showObjectChanges: true },
         });
 
         console.log("\nBuilder extension gate config updated!");

--- a/ts-scripts/builder_extension/delete-jump-permit-extension.ts
+++ b/ts-scripts/builder_extension/delete-jump-permit-extension.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
 import { MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -12,23 +11,23 @@ import {
 } from "../utils/helper";
 import { GATE_ITEM_ID_1 } from "../utils/constants";
 import { MODULE as extensionModule } from "./modules";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 // Upgraded builder package ID (published-at from Move.toml)
 const BUILDER_PACKAGE_LATEST = process.env.UPGRADED_BUILDER_PACKAGE_ID || "";
 
 async function getOwnedJumpPermitId(
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     owner: string,
     worldPackageId: string
 ): Promise<string | null> {
     const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
-    const res = await client.getOwnedObjects({
+    const res = await client.listOwnedObjects({
         owner,
-        filter: { StructType: type },
+        type,
         limit: 1,
     });
-    const first = res.data?.[0]?.data;
-    return first?.objectId ?? null;
+    return res.objects[0]?.objectId ?? null;
 }
 
 async function voidJumpPermitViaExtension(ctx: ReturnType<typeof initializeContext>) {
@@ -53,10 +52,9 @@ async function voidJumpPermitViaExtension(ctx: ReturnType<typeof initializeConte
         arguments: [tx.object(sourceGateId), tx.object(jumpPermitId)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
 
     console.log("JumpPermit deleted via extension (tribe_permit):", jumpPermitId);

--- a/ts-scripts/builder_extension/delete-jump-permit.ts
+++ b/ts-scripts/builder_extension/delete-jump-permit.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
 import { MODULES } from "../utils/config";
+import { SuiClient, signAndExecute } from "../utils/client";
 import {
     getEnvConfig,
     handleError,
@@ -14,18 +14,17 @@ import {
 const WORLD_PACKAGE_LATEST = process.env.UPGRADED_WORLD_PACKAGE_ID || "";
 
 async function getOwnedJumpPermitId(
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     owner: string,
     worldPackageId: string
 ): Promise<string | null> {
     const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
-    const res = await client.getOwnedObjects({
+    const res = await client.listOwnedObjects({
         owner,
-        filter: { StructType: type },
+        type,
         limit: 1,
     });
-    const first = res.data?.[0]?.data;
-    return first?.objectId ?? null;
+    return res.objects[0]?.objectId ?? null;
 }
 
 async function deleteJumpPermit(ctx: ReturnType<typeof initializeContext>) {
@@ -48,10 +47,9 @@ async function deleteJumpPermit(ctx: ReturnType<typeof initializeContext>) {
         arguments: [tx.object(jumpPermitId)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
 
     console.log("JumpPermit deleted:", jumpPermitId);

--- a/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
+++ b/ts-scripts/builder_extension/issue-tribe-jump-permit.ts
@@ -11,6 +11,7 @@ import {
 import { getEnvConfig, handleError, hydrateWorldConfig, initializeContext } from "../utils/helper";
 import { resolveBuilderGateExtensionIds } from "../utils/builder-extension";
 import { MODULE as extensionModule } from "./modules";
+import { signAndExecute } from "../utils/client";
 
 async function issueJumpPermit(
     ctx: ReturnType<typeof initializeContext>,
@@ -45,10 +46,9 @@ async function issueJumpPermit(
         ],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true, showEvents: true },
     });
 
     console.log("\nJumpPermit issued!");

--- a/ts-scripts/builder_extension/jump-with-permit.ts
+++ b/ts-scripts/builder_extension/jump-with-permit.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
 import { MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -17,22 +16,21 @@ import {
     initializeContext,
     requireEnv,
 } from "../utils/helper";
-import { keypairFromPrivateKey } from "../utils/client";
+import { keypairFromPrivateKey, SuiClient } from "../utils/client";
 import { executeSponsoredTransaction } from "../utils/transaction";
 
 async function getOwnedJumpPermitId(
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     owner: string,
     worldPackageId: string
 ): Promise<string | null> {
     const type = `${worldPackageId}::${MODULES.GATE}::JumpPermit`;
-    const res = await client.getOwnedObjects({
+    const res = await client.listOwnedObjects({
         owner,
-        filter: { StructType: type },
+        type,
         limit: 1,
     });
-    const first = res.data?.[0]?.data;
-    return first?.objectId ?? null;
+    return res.objects[0]?.objectId ?? null;
 }
 
 async function jumpWithPermit(

--- a/ts-scripts/character/create-character.ts
+++ b/ts-scripts/character/create-character.ts
@@ -7,7 +7,7 @@ import {
     getEnvConfig,
     requireEnv,
 } from "../utils/helper";
-import { keypairFromPrivateKey } from "../utils/client";
+import { keypairFromPrivateKey, signAndExecute } from "../utils/client";
 import { MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { GAME_CHARACTER_B_ID, GAME_CHARACTER_C_ID, GAME_CHARACTER_ID } from "../utils/constants";
@@ -54,10 +54,9 @@ async function createCharacter(
         arguments: [character, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true },
     });
 
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/character/helper.ts
+++ b/ts-scripts/character/helper.ts
@@ -1,11 +1,11 @@
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { getConfig, MODULES } from "../utils/config";
 import { bcs } from "@mysten/sui/bcs";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient } from "../utils/client";
 
 export async function getCharacterOwnerCap(
     characterId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string | null> {

--- a/ts-scripts/crypto/sig-verify.ts
+++ b/ts-scripts/crypto/sig-verify.ts
@@ -64,30 +64,27 @@ async function main() {
             ],
         });
 
-        const result = await client.devInspectTransactionBlock({
-            transactionBlock: tx,
-            sender: address,
+        tx.setSender(address);
+        const result = await client.simulateTransaction({
+            transaction: tx,
+            include: { commandResults: true, effects: true },
         });
 
         console.log("====Verification result======");
 
-        if (result.effects.status.status === "success") {
-            const returnValues = result.results?.[0]?.returnValues;
+        if (result.FailedTransaction) {
+            console.log("Transaction Failed");
+            console.log("Error:", result.FailedTransaction.status.error?.message);
+        } else {
+            const verificationResult = result.commandResults?.[0]?.returnValues?.[0]?.bcs?.[0];
 
-            if (returnValues && returnValues.length > 0) {
-                const verificationResult = returnValues[0][0][0];
-
-                if (verificationResult === 1) {
-                    console.log("Signature is VALID");
-                } else {
-                    console.log("Signature is INVALID (verification returned false)");
-                }
+            if (verificationResult === 1) {
+                console.log("Signature is VALID");
+            } else if (verificationResult === 0) {
+                console.log("Signature is INVALID (verification returned false)");
             } else {
                 console.log("Could not read return value");
             }
-        } else {
-            console.log("Transaction Failed");
-            console.log("Error:", result.effects.status.error);
         }
     } catch (error) {
         console.log("Error during verification:", error);

--- a/ts-scripts/gate/configure-distance.ts
+++ b/ts-scripts/gate/configure-distance.ts
@@ -9,6 +9,7 @@ import {
     parseBigIntArray,
 } from "../utils/helper";
 import { delay } from "../utils/delay";
+import { signAndExecute } from "../utils/client";
 
 async function setGateMaxDistanceByType(
     gateConfigId: string,
@@ -30,10 +31,9 @@ async function setGateMaxDistanceByType(
         ],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true },
     });
 
     console.log("\nGate max distance updated!");

--- a/ts-scripts/gate/create-gates.ts
+++ b/ts-scripts/gate/create-gates.ts
@@ -20,6 +20,7 @@ import {
 } from "../utils/constants";
 import { delay, getDelayMs } from "../utils/delay";
 import { deriveObjectId } from "../utils/derive-object-id";
+import { signAndExecute } from "../utils/client";
 
 async function createGate(
     ctx: ReturnType<typeof initializeContext>,
@@ -52,10 +53,9 @@ async function createGate(
         arguments: [gate, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEvents: true, showEffects: true, showObjectChanges: true },
     });
 
     const gateEvent = extractEvent<{ assembly_id: string; owner_cap_id: string }>(

--- a/ts-scripts/gate/helper.ts
+++ b/ts-scripts/gate/helper.ts
@@ -1,11 +1,11 @@
 import { bcs } from "@mysten/sui/bcs";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { getConfig, MODULES } from "../utils/config";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient } from "../utils/client";
 
 export async function getOwnerCap(
     gateId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string | null> {

--- a/ts-scripts/gate/link-gates.ts
+++ b/ts-scripts/gate/link-gates.ts
@@ -97,8 +97,7 @@ async function linkGates(
         keypair,
         adminKeypair,
         address,
-        adminAddress,
-        { showEffects: true, showObjectChanges: true, showEvents: true }
+        adminAddress
     );
 
     console.log("\nGates linked successfully!");

--- a/ts-scripts/gate/online.ts
+++ b/ts-scripts/gate/online.ts
@@ -12,6 +12,7 @@ import { GAME_CHARACTER_ID, GATE_ITEM_ID_1, GATE_ITEM_ID_2, NWN_ITEM_ID } from "
 import { delay, getDelayMs } from "../utils/delay";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { getOwnerCap } from "./helper";
+import { signAndExecute } from "../utils/client";
 
 async function onlineGate(
     ctx: ReturnType<typeof initializeContext>,
@@ -54,10 +55,9 @@ async function onlineGate(
         arguments: [tx.object(characterObjectId), gateOwnerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true, showEvents: true },
     });
 
     console.log("\nGates brought online successfully!");

--- a/ts-scripts/network-node/configure-fuel-energy.ts
+++ b/ts-scripts/network-node/configure-fuel-energy.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import {
@@ -11,12 +10,13 @@ import {
     parseBigIntArray,
 } from "../utils/helper";
 import { delay } from "../utils/delay";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 async function setFuelEfficiency(
     fuelTypeId: bigint,
     fuelEfficiency: bigint,
     adminAcl: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -37,10 +37,9 @@ async function setFuelEfficiency(
         ],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("\n Fuel efficiency set successfully!");
@@ -52,7 +51,7 @@ async function setEnergyConfig(
     assemblyTypeId: bigint,
     energyRequired: bigint,
     adminAcl: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -72,10 +71,9 @@ async function setEnergyConfig(
         ],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("\n Energy configuration set successfully!");

--- a/ts-scripts/network-node/create-nwn.ts
+++ b/ts-scripts/network-node/create-nwn.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/helper";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { LOCATION_HASH, GAME_CHARACTER_ID, NWN_TYPE_ID, NWN_ITEM_ID } from "../utils/constants";
+import { signAndExecute } from "../utils/client";
 
 export const FUEL_MAX_CAPACITY = 10000n;
 export const FUEL_BURN_RATE_IN_MS = BigInt(3600 * 1000); // 1 hour
@@ -47,10 +48,9 @@ async function createNetworkNode(
         arguments: [nwn, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEvents: true },
     });
 
     const networkNodeEvent = extractEvent<{ network_node_id: string; owner_cap_id: string }>(

--- a/ts-scripts/network-node/helper.ts
+++ b/ts-scripts/network-node/helper.ts
@@ -1,8 +1,8 @@
 import "dotenv/config";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { getConfig, MODULES } from "../utils/config";
 import { bcs } from "@mysten/sui/bcs";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient } from "../utils/client";
 
 export interface AssemblyTypeInfo {
     id: string;
@@ -11,7 +11,7 @@ export interface AssemblyTypeInfo {
 
 export async function getFuelQuantity(
     networkNodeId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<bigint | null> {
@@ -40,7 +40,7 @@ export async function getFuelQuantity(
 
 export async function getConnectedAssemblies(
     networkNodeId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string[] | null> {
@@ -69,7 +69,7 @@ export async function getConnectedAssemblies(
 
 export async function isNetworkNodeOnline(
     networkNodeId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<boolean | null> {
@@ -97,7 +97,7 @@ export async function isNetworkNodeOnline(
 
 export async function getOwnerCap(
     networkNodeId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string | null> {
@@ -121,16 +121,13 @@ export async function getOwnerCap(
 
 export async function getAssemblyTypes(
     assemblyIds: string[],
-    client: SuiJsonRpcClient
+    client: SuiClient
 ): Promise<AssemblyTypeInfo[]> {
     return await Promise.all(
         assemblyIds.map(async (assemblyId) => {
             try {
-                const object = await client.getObject({
-                    id: assemblyId,
-                    options: { showType: true },
-                });
-                const type = object.data?.type;
+                const { object } = await client.getObject({ objectId: assemblyId });
+                const type = object.type;
 
                 // connected_assembly_ids can include multiple "assembly-like" structs,
                 // including `Gate` and `StorageUnit`, which require different Move entrypoints.

--- a/ts-scripts/network-node/offline-nwn.ts
+++ b/ts-scripts/network-node/offline-nwn.ts
@@ -1,11 +1,11 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { getConnectedAssemblies, getOwnerCap, getAssemblyTypes } from "./helper";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { CLOCK_OBJECT_ID, GAME_CHARACTER_ID, NWN_ITEM_ID } from "../utils/constants";
+import { SuiClient, signAndExecute } from "../utils/client";
 import {
     hydrateWorldConfig,
     initializeContext,
@@ -45,7 +45,7 @@ function getConnectedOfflineCall(kind: string): { module: string; functionName: 
 async function offline(
     networkNodeId: string,
     ownerCapId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -110,10 +110,9 @@ async function offline(
         });
     }
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/network-node/online-nwn.ts
+++ b/ts-scripts/network-node/online-nwn.ts
@@ -11,6 +11,7 @@ import {
 import { CLOCK_OBJECT_ID, GAME_CHARACTER_ID, NWN_ITEM_ID } from "../utils/constants";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { getOwnerCap } from "./helper";
+import { signAndExecute } from "../utils/client";
 
 async function online(
     networkNodeId: string,
@@ -44,10 +45,9 @@ async function online(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("\n Network Node brought online successfully!");

--- a/ts-scripts/network-node/unanchor-nwn.ts
+++ b/ts-scripts/network-node/unanchor-nwn.ts
@@ -1,12 +1,12 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { getConnectedAssemblies, getAssemblyTypes } from "./helper";
 import { deriveObjectId } from "../utils/derive-object-id";
 import { NWN_ITEM_ID } from "../utils/constants";
 import { hydrateWorldConfig, initializeContext, handleError, getEnvConfig } from "../utils/helper";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 const ORPHANED_OFFLINE_BY_KIND: Record<string, { module: string; functionName: string }> = {
     storage_unit: { module: MODULES.STORAGE_UNIT, functionName: "offline_orphaned_storage_unit" },
@@ -38,7 +38,7 @@ function getOrphanedOfflineCall(kind: string): { module: string; functionName: s
 async function unanchor(
     networkNodeId: string,
     adminAcl: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -79,10 +79,9 @@ async function unanchor(
         arguments: [tx.object(networkNodeId), currentHotPotato, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/network-node/update-fuel.ts
+++ b/ts-scripts/network-node/update-fuel.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import {
@@ -12,6 +11,7 @@ import {
 import { deriveObjectId } from "../utils/derive-object-id";
 import { CLOCK_OBJECT_ID, GAME_CHARACTER_ID, NWN_ITEM_ID } from "../utils/constants";
 import { hydrateWorldConfig, initializeContext, handleError, getEnvConfig } from "../utils/helper";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 /**
  * Updates fuel for a network node and handles fuel depletion if it occurs.
@@ -33,7 +33,7 @@ import { hydrateWorldConfig, initializeContext, handleError, getEnvConfig } from
 async function updateFuel(
     networkNodeId: string,
     adminAcl: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -96,10 +96,9 @@ async function updateFuel(
         arguments: [currentHotPotato],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     // Get fuel quantity after update

--- a/ts-scripts/storage-unit/chain-item-to-game.ts
+++ b/ts-scripts/storage-unit/chain-item-to-game.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
 import { bcs } from "@mysten/sui/bcs";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { hexToBytes } from "../utils/helper";
@@ -21,7 +20,7 @@ import {
     initializeContext,
     requireEnv,
 } from "../utils/helper";
-import { keypairFromPrivateKey } from "../utils/client";
+import { keypairFromPrivateKey, SuiClient, signAndExecute } from "../utils/client";
 import { generateLocationProof } from "../utils/proof";
 
 async function chainItemToGame(
@@ -31,7 +30,7 @@ async function chainItemToGame(
     typeId: bigint,
     quantity: number,
     proofHex: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     playerKeypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -65,15 +64,14 @@ async function chainItemToGame(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: playerKeypair,
-        options: { showEvents: true },
     });
     console.log("Transaction digest:", result.digest);
 
     const burnedEvent = result.events?.find((event) =>
-        event.type.endsWith("::inventory::ItemBurnedEvent")
+        event.eventType.endsWith("::inventory::ItemBurnedEvent")
     );
 
     console.log("burnedEvent:", burnedEvent);

--- a/ts-scripts/storage-unit/chain-item-to-game.ts
+++ b/ts-scripts/storage-unit/chain-item-to-game.ts
@@ -3,7 +3,7 @@ import { Transaction } from "@mysten/sui/transactions";
 import { bcs } from "@mysten/sui/bcs";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
-import { hexToBytes } from "../utils/helper";
+import { eventTypeOf, hexToBytes } from "../utils/helper";
 import {
     CLOCK_OBJECT_ID,
     GAME_CHARACTER_ID,
@@ -71,7 +71,7 @@ async function chainItemToGame(
     console.log("Transaction digest:", result.digest);
 
     const burnedEvent = result.events?.find((event) =>
-        event.eventType.endsWith("::inventory::ItemBurnedEvent")
+        eventTypeOf(event).endsWith("::inventory::ItemBurnedEvent")
     );
 
     console.log("burnedEvent:", burnedEvent);

--- a/ts-scripts/storage-unit/create-storage-unit.ts
+++ b/ts-scripts/storage-unit/create-storage-unit.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
 import { bcs } from "@mysten/sui/bcs";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { hexToBytes } from "../utils/helper";
@@ -14,6 +13,7 @@ import {
     STORAGE_A_ITEM_ID,
 } from "../utils/constants";
 import { deriveObjectId } from "../utils/derive-object-id";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 const MAX_CAPACITY = 1000000000000n;
 
@@ -23,7 +23,7 @@ async function createStorageUnit(
     typeId: bigint,
     itemId: bigint,
     adminAcl: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -48,28 +48,21 @@ async function createStorageUnit(
         arguments: [storageUnit, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEvents: true },
     });
 
     console.log("Transaction digest:", result.digest);
 
     const storageUnitEvent = result.events?.find((event) =>
-        event.type.endsWith("::storage_unit::StorageUnitCreatedEvent")
+        event.eventType.endsWith("::storage_unit::StorageUnitCreatedEvent")
     );
 
-    if (!storageUnitEvent?.parsedJson) {
+    if (!storageUnitEvent) {
         throw new Error("StorageUnitCreatedEvent not found in transaction result");
     }
-
-    const storageUnitId = (storageUnitEvent.parsedJson as { storage_unit_id: string })
-        .storage_unit_id;
-    console.log("Storage Unit Object Id: ", storageUnitId);
-
-    const ownerCapObjectId = (storageUnitEvent.parsedJson as { owner_cap_id: string }).owner_cap_id;
-    console.log("OwnerCap Object Id: ", ownerCapObjectId);
+    console.log("StorageUnitCreatedEvent:", storageUnitEvent.eventType);
 }
 
 async function main() {

--- a/ts-scripts/storage-unit/create-storage-unit.ts
+++ b/ts-scripts/storage-unit/create-storage-unit.ts
@@ -3,8 +3,14 @@ import { Transaction } from "@mysten/sui/transactions";
 import { bcs } from "@mysten/sui/bcs";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
-import { hexToBytes } from "../utils/helper";
-import { hydrateWorldConfig, initializeContext, handleError, getEnvConfig } from "../utils/helper";
+import {
+    eventTypeOf,
+    hexToBytes,
+    hydrateWorldConfig,
+    initializeContext,
+    handleError,
+    getEnvConfig,
+} from "../utils/helper";
 import {
     LOCATION_HASH,
     GAME_CHARACTER_ID,
@@ -56,13 +62,13 @@ async function createStorageUnit(
     console.log("Transaction digest:", result.digest);
 
     const storageUnitEvent = result.events?.find((event) =>
-        event.eventType.endsWith("::storage_unit::StorageUnitCreatedEvent")
+        eventTypeOf(event).endsWith("::storage_unit::StorageUnitCreatedEvent")
     );
 
     if (!storageUnitEvent) {
         throw new Error("StorageUnitCreatedEvent not found in transaction result");
     }
-    console.log("StorageUnitCreatedEvent:", storageUnitEvent.eventType);
+    console.log("StorageUnitCreatedEvent:", eventTypeOf(storageUnitEvent));
 }
 
 async function main() {

--- a/ts-scripts/storage-unit/deposit-to-ephemeral-inventory.ts
+++ b/ts-scripts/storage-unit/deposit-to-ephemeral-inventory.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -20,6 +19,7 @@ import {
     ITEM_A_ITEM_ID,
 } from "../utils/constants";
 import { getCharacterOwnerCap } from "../character/helper";
+import { SuiClient } from "../utils/client";
 
 async function gameItemToChain(
     storageUnit: string,
@@ -31,7 +31,7 @@ async function gameItemToChain(
     volume: bigint,
     quantity: number,
     adminAddress: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     playerKeypair: Ed25519Keypair,
     adminKeypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
@@ -75,8 +75,7 @@ async function gameItemToChain(
         playerKeypair,
         adminKeypair,
         playerAddress,
-        adminAddress,
-        { showEvents: true }
+        adminAddress
     );
 
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/storage-unit/game-item-to-chain.ts
+++ b/ts-scripts/storage-unit/game-item-to-chain.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -20,6 +19,7 @@ import {
     ITEM_A_ITEM_ID,
 } from "../utils/constants";
 import { getOwnerCap } from "./helper";
+import { SuiClient } from "../utils/client";
 
 async function gameItemToChain(
     storageUnit: string,
@@ -31,7 +31,7 @@ async function gameItemToChain(
     volume: bigint,
     quantity: number,
     adminAddress: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     playerKeypair: Ed25519Keypair,
     adminKeypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
@@ -75,8 +75,7 @@ async function gameItemToChain(
         playerKeypair,
         adminKeypair,
         playerAddress,
-        adminAddress,
-        { showEvents: true }
+        adminAddress
     );
 
     console.log("Transaction digest:", result.digest);

--- a/ts-scripts/storage-unit/helper.ts
+++ b/ts-scripts/storage-unit/helper.ts
@@ -1,11 +1,11 @@
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { getConfig, MODULES } from "../utils/config";
 import { bcs } from "@mysten/sui/bcs";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient } from "../utils/client";
 
 export async function getOwnerCap(
     assemblyId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string | null> {

--- a/ts-scripts/storage-unit/online.ts
+++ b/ts-scripts/storage-unit/online.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { deriveObjectId } from "../utils/derive-object-id";
@@ -13,12 +12,13 @@ import {
     requireEnv,
 } from "../utils/helper";
 import { getOwnerCap } from "./helper";
+import { SuiClient, signAndExecute } from "../utils/client";
 
 export async function online(
     networkObjectId: string,
     assemblyId: string,
     ownerCapId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     keypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
 ) {
@@ -48,10 +48,9 @@ export async function online(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showObjectChanges: true, showEffects: true },
     });
 
     console.log("\n Storage Unit brought online successfully!");

--- a/ts-scripts/storage-unit/withdraw-deposit.ts
+++ b/ts-scripts/storage-unit/withdraw-deposit.ts
@@ -6,6 +6,7 @@ import { GAME_CHARACTER_ID, STORAGE_A_ITEM_ID, ITEM_A_TYPE_ID } from "../utils/c
 import { getOwnerCap } from "./helper";
 import { deriveObjectId } from "../utils/derive-object-id";
 import {
+    eventTypeOf,
     getEnvConfig,
     handleError,
     hydrateWorldConfig,
@@ -73,7 +74,7 @@ async function withdraw(
     console.log("Transaction digest:", result.digest);
 
     const withdrawEvent = result.events?.find((event) =>
-        event.eventType.endsWith("::inventory::ItemWithdrawnEventV2")
+        eventTypeOf(event).endsWith("::inventory::ItemWithdrawnEventV2")
     );
 
     if (!withdrawEvent) {

--- a/ts-scripts/storage-unit/withdraw-deposit.ts
+++ b/ts-scripts/storage-unit/withdraw-deposit.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { getConfig, MODULES } from "../utils/config";
 import { GAME_CHARACTER_ID, STORAGE_A_ITEM_ID, ITEM_A_TYPE_ID } from "../utils/constants";
@@ -15,6 +14,7 @@ import {
     requireEnv,
 } from "../utils/helper";
 import { executeSponsoredTransaction } from "../utils/transaction";
+import { SuiClient } from "../utils/client";
 
 async function withdraw(
     storageUnit: string,
@@ -23,7 +23,7 @@ async function withdraw(
     typeId: bigint,
     playerAddress: string,
     adminAddress: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     playerKeypair: Ed25519Keypair,
     adminKeypair: Ed25519Keypair,
     config: ReturnType<typeof getConfig>
@@ -68,13 +68,12 @@ async function withdraw(
         playerKeypair,
         adminKeypair,
         playerAddress,
-        adminAddress,
-        { showEvents: true }
+        adminAddress
     );
     console.log("Transaction digest:", result.digest);
 
     const withdrawEvent = result.events?.find((event) =>
-        event.type.endsWith("::inventory::ItemWithdrawnEventV2")
+        event.eventType.endsWith("::inventory::ItemWithdrawnEventV2")
     );
 
     if (!withdrawEvent) {

--- a/ts-scripts/turret/anchor.ts
+++ b/ts-scripts/turret/anchor.ts
@@ -18,6 +18,7 @@ import {
     NWN_ITEM_ID,
 } from "../utils/constants";
 import { deriveObjectId } from "../utils/derive-object-id";
+import { signAndExecute } from "../utils/client";
 
 async function anchorTurret(
     characterObjectId: string,
@@ -49,10 +50,9 @@ async function anchorTurret(
         arguments: [turret, tx.object(adminAcl)],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEvents: true },
     });
 
     const event = extractEvent<{ turret_id: string; owner_cap_id: string; type_id: string }>(

--- a/ts-scripts/turret/get-priority-list.ts
+++ b/ts-scripts/turret/get-priority-list.ts
@@ -24,7 +24,7 @@ import {
 import { deriveObjectId } from "../utils/derive-object-id";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
 import { GAME_CHARACTER_ID, TURRET_ITEM_ID } from "../utils/constants";
-import type { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { SuiClient } from "../utils/client";
 
 export type TurretExtensionInfo = {
     hasExtension: boolean;
@@ -79,7 +79,7 @@ export const ReturnTargetPriorityListBcs = bcs.struct("ReturnTargetPriorityList"
  * Mandatory: always call is_extension_configured first; extension_type aborts if no extension is configured.
  */
 export async function getTurretExtensionInfo(
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     worldPackageId: string,
     turretId: string
 ): Promise<TurretExtensionInfo> {
@@ -129,12 +129,27 @@ export function parseReturnPriorityList(returnBytes: Uint8Array): ReturnTargetPr
     }));
 }
 
-function parseDevInspectReturn(returnValues: unknown): ReturnTargetPriorityListArg[] {
-    const arr = returnValues as [Uint8Array | number[], unknown][] | undefined;
-    if (!arr?.length) return [];
-    const raw = arr[0][0];
-    const returnBytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
+function parseDevInspectReturn(
+    returnBytes: Uint8Array | null | undefined
+): ReturnTargetPriorityListArg[] {
+    if (!returnBytes?.length) return [];
     return parseReturnPriorityList(returnBytes);
+}
+
+async function simulatePriorityList(
+    client: SuiClient,
+    tx: Transaction,
+    sender: string
+): Promise<ReturnTargetPriorityListArg[]> {
+    tx.setSender(sender);
+    const result = await client.simulateTransaction({
+        transaction: tx,
+        include: { commandResults: true, effects: true },
+    });
+    if (result.FailedTransaction) {
+        throw new Error(`Simulation failed: ${JSON.stringify(result.FailedTransaction.status)}`);
+    }
+    return parseDevInspectReturn(result.commandResults?.[1]?.returnValues?.[0]?.bcs);
 }
 
 /**
@@ -167,17 +182,7 @@ export async function getTurretPriorityListFromWorld(
         ],
     });
 
-    const result = await client.devInspectTransactionBlock({
-        sender: keypair.getPublicKey().toSuiAddress(),
-        transactionBlock: tx,
-    });
-
-    if (result.effects?.status?.status !== "success") {
-        const err = result.effects?.status?.error ?? result.effects?.status;
-        throw new Error(`DevInspect failed: ${JSON.stringify(err)}`);
-    }
-
-    return parseDevInspectReturn(result.results?.[1]?.returnValues);
+    return simulatePriorityList(client, tx, keypair.getPublicKey().toSuiAddress());
 }
 
 /**
@@ -215,15 +220,7 @@ export async function getTurretPriorityList(
             ],
         });
 
-        const result = await client.devInspectTransactionBlock({
-            sender: keypair.getPublicKey().toSuiAddress(),
-            transactionBlock: tx,
-        });
-        if (result.effects?.status?.status !== "success") {
-            const err = result.effects?.status?.error ?? result.effects?.status;
-            throw new Error(`DevInspect failed: ${JSON.stringify(err)}`);
-        }
-        return parseDevInspectReturn(result.results?.[1]?.returnValues);
+        return simulatePriorityList(client, tx, keypair.getPublicKey().toSuiAddress());
     }
 
     return getTurretPriorityListFromWorld(turretId, characterId, candidates, ctx);

--- a/ts-scripts/turret/helper.ts
+++ b/ts-scripts/turret/helper.ts
@@ -1,11 +1,11 @@
 import { bcs } from "@mysten/sui/bcs";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { getConfig, MODULES } from "../utils/config";
 import { devInspectMoveCallFirstReturnValueBytes } from "../utils/dev-inspect";
+import { SuiClient } from "../utils/client";
 
 export async function getOwnerCap(
     turretId: string,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     config: ReturnType<typeof getConfig>,
     senderAddress?: string
 ): Promise<string | null> {

--- a/ts-scripts/turret/online.ts
+++ b/ts-scripts/turret/online.ts
@@ -11,6 +11,7 @@ import {
     requireEnv,
 } from "../utils/helper";
 import { getOwnerCap } from "./helper";
+import { signAndExecute } from "../utils/client";
 
 async function onlineTurret(
     turretId: string,
@@ -46,10 +47,9 @@ async function onlineTurret(
         arguments: [tx.object(characterId), ownerCap, receipt],
     });
 
-    const result = await client.signAndExecuteTransaction({
+    const result = await signAndExecute(client, {
         transaction: tx,
         signer: keypair,
-        options: { showEffects: true, showObjectChanges: true },
     });
     console.log("Turret brought online. Digest:", result.digest);
     return result;

--- a/ts-scripts/utils/client.ts
+++ b/ts-scripts/utils/client.ts
@@ -1,11 +1,19 @@
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import type { SuiClientTypes } from "@mysten/sui/client";
+import { decodeSuiPrivateKey, type Signer } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
+import type { Transaction } from "@mysten/sui/transactions";
 import { getConfig, Network } from "./config";
 
-export function createClient(network: Network = "localnet"): SuiJsonRpcClient {
+export type SuiClient = SuiGrpcClient;
+export type ExecutedTransaction = SuiClientTypes.Transaction<{
+    effects: true;
+    events: true;
+}>;
+
+export function createClient(network: Network = "localnet"): SuiClient {
     const config = getConfig(network);
-    return new SuiJsonRpcClient({ url: config.url, network });
+    return new SuiGrpcClient({ network, baseUrl: config.url });
 }
 
 export function keypairFromPrivateKey(privateKey: string): Ed25519Keypair {
@@ -14,4 +22,29 @@ export function keypairFromPrivateKey(privateKey: string): Ed25519Keypair {
         throw new Error("Only ED25519 keys are supported");
     }
     return Ed25519Keypair.fromSecretKey(secretKey);
+}
+
+export function requireExecutedTx<Include extends SuiClientTypes.TransactionInclude>(
+    result: SuiClientTypes.TransactionResult<Include>
+): SuiClientTypes.Transaction<Include> {
+    if (result.FailedTransaction) {
+        const error = result.FailedTransaction.status.error;
+        throw new Error(`Transaction failed: ${error?.message ?? "unknown error"}`);
+    }
+    return result.Transaction;
+}
+
+export async function signAndExecute(
+    client: SuiClient,
+    input: {
+        transaction: Transaction;
+        signer: Signer;
+    }
+): Promise<ExecutedTransaction> {
+    const result = await client.signAndExecuteTransaction({
+        transaction: input.transaction,
+        signer: input.signer,
+        include: { effects: true, events: true },
+    });
+    return requireExecutedTx(result);
 }

--- a/ts-scripts/utils/config.ts
+++ b/ts-scripts/utils/config.ts
@@ -35,6 +35,7 @@ export type HydratedWorldConfig = WorldConfig;
 
 export type Network = "localnet" | "testnet" | "devnet" | "mainnet";
 
+/** Public fullnode gRPC base URLs. JSON-RPC is deprecated. */
 export const DEFAULT_RPC_URLS: Record<Network, string> = {
     localnet: "http://127.0.0.1:9000",
     testnet: "https://fullnode.testnet.sui.io:443",
@@ -43,7 +44,7 @@ export const DEFAULT_RPC_URLS: Record<Network, string> = {
 };
 
 export function getConfig(network: Network = "localnet"): WorldConfig {
-    const url = process.env.SUI_RPC_URL || DEFAULT_RPC_URLS[network];
+    const url = process.env.SUI_GRPC_URL || process.env.SUI_RPC_URL || DEFAULT_RPC_URLS[network];
     const packageId = process.env.WORLD_PACKAGE_ID || "";
 
     return {

--- a/ts-scripts/utils/dev-inspect.ts
+++ b/ts-scripts/utils/dev-inspect.ts
@@ -1,5 +1,5 @@
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
+import type { SuiClient } from "./client";
 import { requireEnv } from "./helper";
 
 function resolveDevInspectSender(senderAddress?: string): string {
@@ -7,7 +7,7 @@ function resolveDevInspectSender(senderAddress?: string): string {
 }
 
 export async function devInspectMoveCallFirstReturnValueBytes(
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     params: {
         target: string;
         typeArguments?: string[];
@@ -16,24 +16,21 @@ export async function devInspectMoveCallFirstReturnValueBytes(
     }
 ): Promise<Uint8Array | null> {
     const tx = new Transaction();
+    tx.setSender(resolveDevInspectSender(params.senderAddress));
     tx.moveCall({
         target: params.target,
         typeArguments: params.typeArguments,
         arguments: params.arguments(tx),
     });
 
-    const result = await client.devInspectTransactionBlock({
-        sender: resolveDevInspectSender(params.senderAddress),
-        transactionBlock: tx,
+    const result = await client.simulateTransaction({
+        transaction: tx,
+        include: { commandResults: true, effects: true },
     });
 
-    if (result.effects?.status?.status !== "success") {
+    if (result.FailedTransaction) {
         return null;
     }
 
-    const returnValues = result.results?.[0]?.returnValues;
-    if (!returnValues?.length) return null;
-
-    const [valueBytes] = returnValues[0];
-    return Uint8Array.from(valueBytes);
+    return result.commandResults?.[0]?.returnValues?.[0]?.bcs ?? null;
 }

--- a/ts-scripts/utils/helper.ts
+++ b/ts-scripts/utils/helper.ts
@@ -214,8 +214,8 @@ export function readPublishOutputFile(filePath: string): { objectChanges: Publis
     const objectChanges = Array.isArray(parsed.objectChanges)
         ? parsed.objectChanges
         : Array.isArray(parsed.effects?.objectChanges)
-            ? parsed.effects.objectChanges
-            : undefined;
+          ? parsed.effects.objectChanges
+          : undefined;
 
     if (!objectChanges) {
         throw new Error(`Invalid publish output file (missing objectChanges[]): ${filePath}`);

--- a/ts-scripts/utils/helper.ts
+++ b/ts-scripts/utils/helper.ts
@@ -212,8 +212,8 @@ export function readPublishOutputFile(filePath: string): { objectChanges: Publis
     const objectChanges = Array.isArray(parsed.objectChanges)
         ? parsed.objectChanges
         : Array.isArray(parsed.effects?.objectChanges)
-            ? parsed.effects.objectChanges
-            : undefined;
+          ? parsed.effects.objectChanges
+          : undefined;
 
     if (!objectChanges) {
         throw new Error(`Invalid publish output file (missing objectChanges[]): ${filePath}`);

--- a/ts-scripts/utils/helper.ts
+++ b/ts-scripts/utils/helper.ts
@@ -124,6 +124,10 @@ export function initializeContext(network: Network, privateKey: string): Initial
     return { client, keypair, config, address };
 }
 
+export function eventTypeOf(event: { eventType?: string; type?: string }): string {
+    return event.eventType ?? event.type ?? "";
+}
+
 export function extractEvent<T = unknown>(
     result: {
         events?: Array<{
@@ -135,9 +139,7 @@ export function extractEvent<T = unknown>(
     eventTypeSuffix: string
 ): T | null {
     const events = result.events || [];
-    const event = events.find((event) =>
-        (event.eventType ?? event.type ?? "").endsWith(eventTypeSuffix)
-    );
+    const event = events.find((event) => eventTypeOf(event).endsWith(eventTypeSuffix));
     return (event?.parsedJson as T) || null;
 }
 

--- a/ts-scripts/utils/helper.ts
+++ b/ts-scripts/utils/helper.ts
@@ -214,8 +214,8 @@ export function readPublishOutputFile(filePath: string): { objectChanges: Publis
     const objectChanges = Array.isArray(parsed.objectChanges)
         ? parsed.objectChanges
         : Array.isArray(parsed.effects?.objectChanges)
-          ? parsed.effects.objectChanges
-          : undefined;
+            ? parsed.effects.objectChanges
+            : undefined;
 
     if (!objectChanges) {
         throw new Error(`Invalid publish output file (missing objectChanges[]): ${filePath}`);

--- a/ts-scripts/utils/helper.ts
+++ b/ts-scripts/utils/helper.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { createClient, keypairFromPrivateKey } from "./client";
+import { createClient, keypairFromPrivateKey, type SuiClient } from "./client";
 import {
     HydratedWorldConfig,
     WorldConfig,
@@ -22,7 +21,7 @@ export interface EnvConfig {
 }
 
 export interface InitializedContext {
-    client: SuiJsonRpcClient;
+    client: SuiClient;
     keypair: Ed25519Keypair;
     config: WorldConfig;
     address: string;
@@ -96,7 +95,7 @@ export function requireEnv(name: string): string {
 
 export function getEnvConfig(): EnvConfig {
     const network = (process.env.SUI_NETWORK as Network) || "localnet";
-    const rpcUrl = process.env.SUI_RPC_URL || DEFAULT_RPC_URLS[network];
+    const rpcUrl = process.env.SUI_GRPC_URL || process.env.SUI_RPC_URL || DEFAULT_RPC_URLS[network];
     const packageId = getDefaultWorldPackageId(network);
     if (!packageId) {
         throw new Error("WORLD_PACKAGE_ID is required");
@@ -126,11 +125,19 @@ export function initializeContext(network: Network, privateKey: string): Initial
 }
 
 export function extractEvent<T = unknown>(
-    result: { events?: Array<{ type: string; parsedJson?: unknown }> | null | undefined },
+    result: {
+        events?: Array<{
+            eventType?: string;
+            type?: string;
+            parsedJson?: unknown;
+        }> | null;
+    },
     eventTypeSuffix: string
 ): T | null {
     const events = result.events || [];
-    const event = events.find((event) => event.type.endsWith(eventTypeSuffix));
+    const event = events.find((event) =>
+        (event.eventType ?? event.type ?? "").endsWith(eventTypeSuffix)
+    );
     return (event?.parsedJson as T) || null;
 }
 
@@ -205,8 +212,8 @@ export function readPublishOutputFile(filePath: string): { objectChanges: Publis
     const objectChanges = Array.isArray(parsed.objectChanges)
         ? parsed.objectChanges
         : Array.isArray(parsed.effects?.objectChanges)
-          ? parsed.effects.objectChanges
-          : undefined;
+            ? parsed.effects.objectChanges
+            : undefined;
 
     if (!objectChanges) {
         throw new Error(`Invalid publish output file (missing objectChanges[]): ${filePath}`);

--- a/ts-scripts/utils/transaction.ts
+++ b/ts-scripts/utils/transaction.ts
@@ -1,34 +1,32 @@
 import { Transaction } from "@mysten/sui/transactions";
-import { SuiJsonRpcClient, ExecuteTransactionBlockParams } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { requireExecutedTx, type SuiClient } from "./client";
 
 export async function executeSponsoredTransaction(
     tx: Transaction,
-    client: SuiJsonRpcClient,
+    client: SuiClient,
     playerKeypair: Ed25519Keypair,
     adminKeypair: Ed25519Keypair,
     playerAddress: string,
-    adminAddress: string,
-    options?: ExecuteTransactionBlockParams["options"]
+    adminAddress: string
 ) {
     const transactionKindBytes = await tx.build({ client, onlyTransactionKind: true });
-    const gasCoins = await client.getCoins({
+    const gasCoins = await client.listCoins({
         owner: adminAddress,
         coinType: "0x2::sui::SUI",
         limit: 1,
     });
 
-    if (gasCoins.data.length === 0) {
+    if (gasCoins.objects.length === 0) {
         throw new Error("Admin has no gas coins to sponsor the transaction");
     }
 
-    const gasPayment = gasCoins.data.map((coin) => ({
-        objectId: coin.coinObjectId,
+    const gasPayment = gasCoins.objects.map((coin) => ({
+        objectId: coin.objectId,
         version: coin.version,
         digest: coin.digest,
     }));
 
-    // Reconstruct transaction with gas payment
     const sponsoredTx = Transaction.fromKind(transactionKindBytes);
     sponsoredTx.setSender(playerAddress);
     sponsoredTx.setGasOwner(adminAddress);
@@ -38,10 +36,11 @@ export async function executeSponsoredTransaction(
     const playerSignature = await playerKeypair.signTransaction(transactionBytes);
     const adminSignature = await adminKeypair.signTransaction(transactionBytes);
 
-    // Execute with both signatures
-    return await client.executeTransactionBlock({
-        transactionBlock: transactionBytes,
-        signature: [playerSignature.signature, adminSignature.signature],
-        options: options || { showObjectChanges: true, showEffects: true, showEvents: true },
-    });
+    return requireExecutedTx(
+        await client.executeTransaction({
+            transaction: transactionBytes,
+            signatures: [playerSignature.signature, adminSignature.signature],
+            include: { effects: true, events: true },
+        })
+    );
 }

--- a/ts-scripts/utils/world-object-ids.ts
+++ b/ts-scripts/utils/world-object-ids.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import type { SuiClient } from "./client";
 import { MODULES, WorldObjectIds } from "./config";
 import {
     resolvePublishOutputPath,
@@ -25,7 +25,7 @@ function getWorldPublishOutputPath(network: string): string {
 }
 
 export async function resolveWorldObjectIds(
-    _client: SuiJsonRpcClient,
+    _client: SuiClient,
     worldPackageId: string,
     governorAddress: string,
     network?: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,12 @@
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "strict": true,
+    "types": [
+      "node"
+    ],
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "rootDir": "./ts-scripts",
     "outDir": "./dist"
   },
   "include": [


### PR DESCRIPTION
Issue: 
- Public Sui fullnodes deprecated JSON-RPC

## Summary
- Switch the shared client to `SuiGrpcClient` and update script helpers (`signAndExecute`, `listCoins`, `simulateTransaction`, `listOwnedObjects`)