### PR TITLE
refactor: drop entity location; pass hashes at interact

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,10 +26,10 @@ These five are the load-bearing nouns of v1. All live in [`contracts/core/source
   fixed struct fields, so new behavior never changes the base type. Created/claimed
   deterministically from the `ObjectRegistry`. A single Entity type plays one of two **roles**,
   not a fixed sub-type:
-  - **Structure** — a spatial, anchored Entity (gate, storage unit, turret) with a non-empty
-    `location_hash`, reachable via proximity.
-  - **Principal** — an Entity with no location (empty `location_hash`) that represents an
-    account-like actor and **owns AccessCaps** (a Character or a Tribe). See **Keychain**.
+  - **Structure** — a spatial Entity (gate, storage unit, turret, ship). Modules define
+    behavior; location is supplied at interact time, not stored on the Entity.
+  - **Principal** — an Entity that represents an account-like actor and **owns AccessCaps**
+    (a Character or a Tribe). See **Keychain**.
 - **Module** — typed state installed on an Entity ([`mod.move`](contracts/core/sources/mod.move)).
   `Module<T>` wraps a user-defined state `T` (e.g. `Module<Inventory>`) under a human-readable
   name, so one Entity can host several modules, even of the same type.
@@ -66,9 +66,10 @@ These five are the load-bearing nouns of v1. All live in [`contracts/core/source
   Maps an in-game ID to exactly one on-chain object.
 - **ObjectRegistry** — shared object that derives and tracks Entity object IDs, guaranteeing one
   on-chain object per `EntityKey` ([`object_registry.move`](contracts/core/sources/object_registry.move)).
-- **Location service / Proximity** — a service that supplies a `Proximity` requirement, injected
-  by `interact` on every interaction so actions can require the user to be physically near the
-  structure ([`services/location_service.move`](contracts/core/sources/services/location_service.move)).
+- **Location service / Proximity** — `interact` injects a `Proximity` requirement carrying the
+  target location hash. The caller satisfies it with `verify_proximity` by supplying their
+  caller location hash (player, or the ship/structure they are boarded on). v1 is an exact match
+  ([`services/location_service.move`](contracts/core/sources/services/location_service.move)).
 
 ## Game modules
 

--- a/contracts/character/tests/character_tests.move
+++ b/contracts/character/tests/character_tests.move
@@ -37,7 +37,7 @@ fun create_character(
     let mut registry = ts::take_shared<ObjectRegistry>(scenario);
     let acl = ts::take_shared<AdminACL>(scenario);
 
-    let (mut character, mut req) = entity::new(&mut registry, in_game_id, tenant, vector[]);
+    let (mut character, mut req) = entity::new(&mut registry, in_game_id, tenant);
     admin_service::verify_admin(&mut req, &acl, scenario.ctx());
     character.complete_request(req);
 
@@ -69,7 +69,6 @@ fun create_installs_identity() {
         assert!(e.has_module(string::utf8(b"identity")));
         assert!(identity::tribe_id(&e) == TRIBE_ID);
         assert!(identity::owner(&e) == OWNER);
-        assert!(e.location_hash() == vector[]);
         assert!(e.key() == entity_key::new(IN_GAME_ID, tenant()));
         ts::return_shared(e);
     };
@@ -123,7 +122,7 @@ fun uninstall_without_identity_aborts() {
     ts::next_tx(&mut scenario, ADMIN);
     let mut registry = ts::take_shared<ObjectRegistry>(&scenario);
     let acl = ts::take_shared<AdminACL>(&scenario);
-    let (mut e, mut req) = entity::new(&mut registry, IN_GAME_ID, tenant(), vector[]);
+    let (mut e, mut req) = entity::new(&mut registry, IN_GAME_ID, tenant());
     admin_service::verify_admin(&mut req, &acl, scenario.ctx());
     e.complete_request(req);
 

--- a/contracts/core/sources/entity.move
+++ b/contracts/core/sources/entity.move
@@ -59,8 +59,6 @@ public struct Entity has key {
     version: u64,
     /// Tenant-scoped game identifier used to derive this entity's object ID.
     key: EntityKey,
-    /// Location hash injected as a proximity requirement on every interaction.
-    location_hash: vector<u8>,
 }
 
 // === Events ===
@@ -76,17 +74,12 @@ public struct EntityCreated has copy, drop {
 /// in-game ID can only ever back a single entity. Locked on return with an admin
 /// requirement: the caller must `admin_service::verify_admin` then
 /// `complete_request` before configuring the entity.
-public fun new(
-    registry: &mut ObjectRegistry,
-    id: u64,
-    tenant: String,
-    location_hash: vector<u8>,
-): (Entity, Request) {
+public fun new(registry: &mut ObjectRegistry, id: u64, tenant: String): (Entity, Request) {
     let key = entity_key::new(id, tenant);
     assert!(!registry.exists(key), EEntityAlreadyExists);
 
     let uid = derived_object::claim(registry.borrow_id(), key);
-    let mut entity = Entity { id: uid, version: VERSION, key, location_hash };
+    let mut entity = Entity { id: uid, version: VERSION, key };
     df::add(&mut entity.id, ActionsKey(), vec_map::empty<String, Action>());
 
     event::emit(EntityCreated { entity_id: entity.id.to_inner(), key });
@@ -218,9 +211,14 @@ public fun disable_action(entity: &mut Entity, name: String, _ctx: &mut TxContex
 }
 
 /// Interact with a registered action, producing the `Request` to satisfy. A
-/// proximity requirement for the entity's location is injected ahead of the
+/// proximity requirement for `target_location_hash` is injected ahead of the
 /// action's own requirements, so it must be resolved first.
-public fun interact(entity: &mut Entity, action: String, _ctx: &mut TxContext): Request {
+public fun interact(
+    entity: &mut Entity,
+    action: String,
+    target_location_hash: vector<u8>,
+    _ctx: &mut TxContext,
+): Request {
     assert!(entity.version == VERSION, EWrongVersion);
 
     let actions: &VecMap<String, Action> = df::borrow(&entity.id, ActionsKey());
@@ -229,7 +227,7 @@ public fun interact(entity: &mut Entity, action: String, _ctx: &mut TxContext): 
         .get(&action)
         .to_request(
             option::some(entity.id.to_inner()),
-            vector[location_service::proximity_requirement(entity.location_hash)],
+            vector[location_service::proximity_requirement(target_location_hash)],
         );
 
     entity.lock();
@@ -286,10 +284,6 @@ public fun has_module_with_type<T: store>(entity: &Entity, name: String): bool {
 
 public fun version(entity: &Entity): u64 {
     entity.version
-}
-
-public fun location_hash(entity: &Entity): vector<u8> {
-    entity.location_hash
 }
 
 // === Private Functions ===

--- a/contracts/core/sources/services/location_service.move
+++ b/contracts/core/sources/services/location_service.move
@@ -1,9 +1,10 @@
 /// Proximity requirement injected by `entity::interact`.
 ///
 /// An interaction may only proceed when the caller proves they are within range
-/// of the entity. v1 uses an exact match between the supplied proof and the
-/// entity's stored location hash; cryptographic proximity proofs are out of
-/// scope for this module and will be layered on later.
+/// of the target. v1 uses an exact match between `caller_location_hash` (player,
+/// or the ship/structure they are boarded on) and the `target_location_hash`
+/// baked into the requirement at interact; cryptographic proximity proofs are
+/// out of scope for this module and will be layered on later.
 module core::location_service;
 
 use core::{request::Request, requirement::{Self, Requirement}};
@@ -13,28 +14,28 @@ use sui::bcs;
 // === Errors ===
 
 #[error(code = 0)]
-const EProximityMismatch: vector<u8> = b"Location proof does not match the required proximity";
+const EProximityMismatch: vector<u8> = b"Caller location does not match the target";
 
 // === Structs ===
 
-/// Requirement marker; wraps the required location hash.
+/// Requirement marker; wraps the target location hash.
 public struct Proximity(vector<u8>) has drop;
 
 // === Public Functions ===
 
-/// Build a proximity requirement for `location_hash`.
-public fun proximity_requirement(location_hash: vector<u8>): Requirement {
-    requirement::from_config(option::none(), Proximity(location_hash))
+/// Build a proximity requirement for `target_location_hash`.
+public fun proximity_requirement(target_location_hash: vector<u8>): Requirement {
+    requirement::from_config(option::none(), Proximity(target_location_hash))
 }
 
-/// Satisfy the next (proximity) requirement on `request`. Aborts unless `proof`
-/// matches the required location hash.
-public fun verify_proximity(request: &mut Request, proof: vector<u8>) {
+/// Satisfy the next (proximity) requirement on `request`. Aborts unless
+/// `caller_location_hash` matches the target location hash.
+public fun verify_proximity(request: &mut Request, caller_location_hash: vector<u8>) {
     // TODO: Replace hash equality with server-signed LocationProof verification
     // (authorized server registry, player == sender, target hash, deadline, sig_verify).
     let (requirement, frame) = request.take_next(permit());
     let required = bcs::new(requirement.data()).peel_vec_u8();
-    assert!(proof == required, EProximityMismatch);
+    assert!(caller_location_hash == required, EProximityMismatch);
     frame.destroy_empty_frame();
 }
 

--- a/contracts/core/tests/access_cap_tests.move
+++ b/contracts/core/tests/access_cap_tests.move
@@ -114,7 +114,7 @@ fun verify_passes_with_matching_cap() {
     {
         let mut e = ts::take_shared<entity::Entity>(&scenario);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
-        let mut req = e.interact(string::utf8(OWNER_ACTION), scenario.ctx());
+        let mut req = e.interact(string::utf8(OWNER_ACTION), vector[], scenario.ctx());
         location_service::verify_proximity(&mut req, vector[]);
         access_cap::verify(&mut req, &cap);
         assert!(req.authorized_id() == option::some(cap.entity()));
@@ -138,7 +138,7 @@ fun verify_caller_records_owner_authorized_id() {
     {
         let mut e = ts::take_shared<entity::Entity>(&scenario);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
-        let mut req = e.interact(string::utf8(CALLER_ACTION), scenario.ctx());
+        let mut req = e.interact(string::utf8(CALLER_ACTION), vector[], scenario.ctx());
         location_service::verify_proximity(&mut req, vector[]);
         access_cap::verify_caller(&mut req, &cap);
         assert!(req.authorized_id() == option::some(entity_id));
@@ -195,7 +195,7 @@ fun verify_caller_records_non_owner_authorized_id() {
     {
         let mut e1 = ts::take_shared_by_id<entity::Entity>(&scenario, one);
         let cap = ts::take_from_sender<AccessCap>(&scenario);
-        let mut req = e1.interact(string::utf8(CALLER_ACTION), scenario.ctx());
+        let mut req = e1.interact(string::utf8(CALLER_ACTION), vector[], scenario.ctx());
         location_service::verify_proximity(&mut req, vector[]);
         access_cap::verify_caller(&mut req, &cap);
         assert!(req.authorized_id() == option::some(two));
@@ -251,7 +251,7 @@ fun verify_aborts_with_wrong_entity_cap() {
     ts::next_tx(&mut scenario, OWNER);
     let mut e1 = ts::take_shared_by_id<entity::Entity>(&scenario, one);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
-    let mut req = e1.interact(string::utf8(OWNER_ACTION), scenario.ctx());
+    let mut req = e1.interact(string::utf8(OWNER_ACTION), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify(&mut req, &cap);
 

--- a/contracts/core/tests/core_tests.move
+++ b/contracts/core/tests/core_tests.move
@@ -70,10 +70,10 @@ fun end_to_end_flow() {
     access_cap::verify(&mut req, &cap);
     e.complete_request(req);
 
-    // Interact: satisfy the injected proximity requirement first, then borrow the
-    // module by requirement, satisfy it, and mutate.
-    let mut req = e.interact(string::utf8(b"increment"), scenario.ctx());
-    location_service::verify_proximity(&mut req, vector[]);
+    // Interact: target location is baked into proximity; caller must match, then
+    // borrow the module by requirement, satisfy it, and mutate.
+    let mut req = e.interact(string::utf8(b"increment"), b"loc", scenario.ctx());
+    location_service::verify_proximity(&mut req, b"loc");
     let counter = e.module_mut<Counter>(&req, internal::permit<Counter>()).inner_mut();
     let (_requirement, frame) = req.take_next<Bump>(internal::permit<Bump>());
     counter.value = counter.value + 1;
@@ -120,8 +120,40 @@ fun cannot_complete_with_pending_requirement() {
     e.complete_request(req);
 
     // Try to complete without satisfying the requirement.
-    let req = e.interact(string::utf8(b"increment"), scenario.ctx());
+    let req = e.interact(string::utf8(b"increment"), b"loc", scenario.ctx());
     e.complete_request(req);
+
+    abort
+}
+
+#[test, expected_failure(abort_code = location_service::EProximityMismatch)]
+fun interact_proximity_caller_mismatch_aborts() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let acl = take_acl(&scenario);
+    let mut e = claim_test_entity(&mut scenario, &acl);
+    let mut req = e.mint_access(@0xA, false, scenario.ctx());
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+    let e_id = e.id();
+    e.share();
+    ts::return_shared(acl);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
+    let cap = ts::take_from_sender<AccessCap>(&scenario);
+    let mut req = e.enable_action(
+        string::utf8(b"noop"),
+        action::new(vector[]),
+        scenario.ctx(),
+    );
+    access_cap::verify(&mut req, &cap);
+    e.complete_request(req);
+
+    let mut req = e.interact(string::utf8(b"noop"), b"dest", scenario.ctx());
+    location_service::verify_proximity(&mut req, b"src");
 
     abort
 }

--- a/contracts/core/tests/entity_tests.move
+++ b/contracts/core/tests/entity_tests.move
@@ -30,12 +30,11 @@ fun new_sets_initial_fields() {
     {
         let mut registry = take_registry(&scenario);
         let acl = take_acl(&scenario);
-        let (mut e, mut req) = entity::new(&mut registry, 1, tenant(), b"loc");
+        let (mut e, mut req) = entity::new(&mut registry, 1, tenant());
         admin_service::verify_admin(&mut req, &acl, scenario.ctx());
         e.complete_request(req);
 
         assert!(entity::version(&e) == 1);
-        assert!(entity::location_hash(&e) == b"loc");
         assert!(entity::key(&e).id() == 1);
         assert!(entity::key(&e).tenant() == tenant());
         assert!(!entity::has_module(&e, counter_name()));
@@ -316,7 +315,7 @@ fun interact_unknown_action_aborts() {
     let mut e = claim(&mut registry, &acl, 1, scenario.ctx());
     let ctx = scenario.ctx();
 
-    let req = e.interact(string::utf8(b"missing"), ctx);
+    let req = e.interact(string::utf8(b"missing"), vector[], ctx);
     e.complete_request(req);
 
     abort

--- a/contracts/core/tests/object_registry_tests.move
+++ b/contracts/core/tests/object_registry_tests.move
@@ -91,7 +91,7 @@ fun claim_marks_key_existing() {
         let key = entity_key::new(99, tenant());
         let precomputed = object::id_from_address(registry.derive_id(key));
 
-        let (mut e, mut req) = entity::new(&mut registry, 99, tenant(), vector[]);
+        let (mut e, mut req) = entity::new(&mut registry, 99, tenant());
         admin_service::verify_admin(&mut req, &acl, scenario.ctx());
         e.complete_request(req);
 

--- a/contracts/core/tests/test_helpers.move
+++ b/contracts/core/tests/test_helpers.move
@@ -37,7 +37,7 @@ public fun claim(
     id: u64,
     ctx: &mut TxContext,
 ): Entity {
-    let (mut e, mut req) = entity::new(registry, id, tenant(), vector[]);
+    let (mut e, mut req) = entity::new(registry, id, tenant());
     admin_service::verify_admin(&mut req, acl, ctx);
     e.complete_request(req);
     e

--- a/contracts/inventory/tests/inventory_tests.move
+++ b/contracts/inventory/tests/inventory_tests.move
@@ -164,7 +164,7 @@ fun bridge_in(
     qty: u64,
     vol: u64,
 ) {
-    let mut req = e.interact(string::utf8(action), scenario.ctx());
+    let mut req = e.interact(string::utf8(action), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, cap);
     inventory::game_item_to_chain_inventory(e, &mut req, type_id, qty, vol, scenario.ctx());
@@ -179,7 +179,7 @@ fun bridge_out(
     type_id: u64,
     qty: u64,
 ) {
-    let mut req = e.interact(string::utf8(action), scenario.ctx());
+    let mut req = e.interact(string::utf8(action), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, cap);
     inventory::chain_item_to_game_inventory(e, &mut req, type_id, qty, scenario.ctx());
@@ -193,7 +193,7 @@ fun deposit(
     action: vector<u8>,
     item: Item,
 ) {
-    let mut req = e.interact(string::utf8(action), scenario.ctx());
+    let mut req = e.interact(string::utf8(action), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, cap);
     inventory::deposit(e, &mut req, item, scenario.ctx());
@@ -208,7 +208,7 @@ fun withdraw(
     type_id: u64,
     qty: u64,
 ): Item {
-    let mut req = e.interact(string::utf8(action), scenario.ctx());
+    let mut req = e.interact(string::utf8(action), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, cap);
     let item = inventory::withdraw(e, &mut req, type_id, qty, scenario.ctx());
@@ -312,7 +312,7 @@ fun main_inv_interaction_without_caller() {
     // PLAYER (not the owner, no cap presented) still lands in main.
     ts::next_tx(&mut scenario, PLAYER);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
-    let mut req = e.interact(string::utf8(b"public_bridge"), scenario.ctx());
+    let mut req = e.interact(string::utf8(b"public_bridge"), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL, 10, VOL, scenario.ctx());
     e.complete_request(req);
@@ -424,7 +424,7 @@ fun swap_moves_between_main_and_ephemeral_single_signer() {
     let player_cap = ts::take_from_sender<AccessCap>(&scenario);
     bridge_in(&mut scenario, &mut e, &player_cap, b"eph_bridge_in", FUEL, 1, VOL);
 
-    let mut req = e.interact(string::utf8(b"swap"), scenario.ctx());
+    let mut req = e.interact(string::utf8(b"swap"), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, &player_cap);
     let fuel = inventory::withdraw(&mut e, &mut req, FUEL, 1, scenario.ctx()); // from ephemeral
@@ -475,7 +475,7 @@ fun ephemeral_interaction_without_caller_aborts() {
 
     ts::next_tx(&mut scenario, PLAYER);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
-    let mut req = e.interact(string::utf8(b"eph_uncalled"), scenario.ctx());
+    let mut req = e.interact(string::utf8(b"eph_uncalled"), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL, 10, VOL, scenario.ctx());
 
@@ -537,7 +537,7 @@ fun bridge_in_wrong_type_aborts() {
     ts::next_tx(&mut scenario, OWNER);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
-    let mut req = e.interact(string::utf8(b"bridge_fuel"), scenario.ctx());
+    let mut req = e.interact(string::utf8(b"bridge_fuel"), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify_caller(&mut req, &cap);
     inventory::game_item_to_chain_inventory(&mut e, &mut req, FUEL + 1, 10, VOL, scenario.ctx());

--- a/contracts/metadata/tests/metadata_tests.move
+++ b/contracts/metadata/tests/metadata_tests.move
@@ -111,7 +111,7 @@ fun edit_via_character(
     let ticket = ts::receiving_ticket_by_id<AccessCap>(parked_cap_id(character_id));
     let (owner_cap, receipt) = character.borrow_access(&char_cap, ticket);
 
-    let mut req = e.interact(string::utf8(b"edit_metadata"), scenario.ctx());
+    let mut req = e.interact(string::utf8(b"edit_metadata"), vector[], scenario.ctx());
     location_service::verify_proximity(&mut req, vector[]);
     access_cap::verify(&mut req, &owner_cap);
     metadata::edit(

--- a/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
@@ -103,8 +103,8 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     const e = runTx.object(suId)
     const playerCap = runTx.object(playerCapId)
 
-    const inReq = interact(runTx, config, e, 'eph_bridge_in')
-    verifyProximity(runTx, config, inReq)
+    const inReq = interact(runTx, config, e, 'eph_bridge_in', [])
+    verifyProximity(runTx, config, inReq, [])
     verifyCaller(runTx, config, inReq, playerCap)
     gameItemToChain(runTx, config, e, inReq, {
       typeId: FUEL,
@@ -113,8 +113,8 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     })
     completeRequest(runTx, config, e, inReq)
 
-    const outReq = interact(runTx, config, e, 'eph_withdraw')
-    verifyProximity(runTx, config, outReq)
+    const outReq = interact(runTx, config, e, 'eph_withdraw', [])
+    verifyProximity(runTx, config, outReq, [])
     verifyCaller(runTx, config, outReq, playerCap)
     const item = withdraw(runTx, config, e, outReq, {
       typeId: FUEL,

--- a/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
@@ -127,8 +127,8 @@ describe('inventory owner-access via Character', () => {
       )
       const su = runTx.object(suId)
 
-      const inReq = interact(runTx, config, su, 'bridge_in')
-      verifyProximity(runTx, config, inReq)
+      const inReq = interact(runTx, config, su, 'bridge_in', [])
+      verifyProximity(runTx, config, inReq, [])
       verifyOwner(runTx, config, inReq, suCap)
       gameItemToChain(runTx, config, su, inReq, {
         typeId: FUEL,
@@ -137,8 +137,8 @@ describe('inventory owner-access via Character', () => {
       })
       completeRequest(runTx, config, su, inReq)
 
-      const wReq = interact(runTx, config, su, 'withdraw')
-      verifyProximity(runTx, config, wReq)
+      const wReq = interact(runTx, config, su, 'withdraw', [])
+      verifyProximity(runTx, config, wReq, [])
       verifyOwner(runTx, config, wReq, suCap)
       const item = withdraw(runTx, config, su, wReq, {
         typeId: FUEL,
@@ -146,8 +146,8 @@ describe('inventory owner-access via Character', () => {
       })
       completeRequest(runTx, config, su, wReq)
 
-      const dReq = interact(runTx, config, su, 'deposit')
-      verifyProximity(runTx, config, dReq)
+      const dReq = interact(runTx, config, su, 'deposit', [])
+      verifyProximity(runTx, config, dReq, [])
       verifyOwner(runTx, config, dReq, suCap)
       deposit(runTx, config, su, dReq, item)
       completeRequest(runTx, config, su, dReq)

--- a/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
@@ -129,8 +129,8 @@ describe('inventory owner-configured swap (localnet)', () => {
     // Owner stocks a lens in main.
     const stockTx = new Transaction()
     const se = stockTx.object(suId)
-    const stockReq = interact(stockTx, config, se, 'bridge_in')
-    verifyProximity(stockTx, config, stockReq)
+    const stockReq = interact(stockTx, config, se, 'bridge_in', [])
+    verifyProximity(stockTx, config, stockReq, [])
     verifyCaller(stockTx, config, stockReq, stockTx.object(ownerCapId))
     gameItemToChain(stockTx, config, se, stockReq, {
       typeId: LENS,
@@ -145,8 +145,8 @@ describe('inventory owner-configured swap (localnet)', () => {
     const e = runTx.object(suId)
     const playerCap = runTx.object(playerCapId)
 
-    const inReq = interact(runTx, config, e, 'eph_bridge_in')
-    verifyProximity(runTx, config, inReq)
+    const inReq = interact(runTx, config, e, 'eph_bridge_in', [])
+    verifyProximity(runTx, config, inReq, [])
     verifyCaller(runTx, config, inReq, playerCap)
     gameItemToChain(runTx, config, e, inReq, {
       typeId: FUEL,
@@ -155,8 +155,8 @@ describe('inventory owner-configured swap (localnet)', () => {
     })
     completeRequest(runTx, config, e, inReq)
 
-    const swapReq = interact(runTx, config, e, 'swap')
-    verifyProximity(runTx, config, swapReq)
+    const swapReq = interact(runTx, config, e, 'swap', [])
+    verifyProximity(runTx, config, swapReq, [])
     verifyCaller(runTx, config, swapReq, playerCap)
     const fuel = withdraw(runTx, config, e, swapReq, {
       typeId: FUEL,

--- a/sdk/world-sdk/src/__integration__/inventory.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory.test.ts
@@ -103,8 +103,8 @@ describe('inventory owner round-trip (localnet)', () => {
     const e = runTx.object(entityId)
     const c = runTx.object(capId)
 
-    const bridgeReqObj = interact(runTx, config, e, 'bridge_in')
-    verifyProximity(runTx, config, bridgeReqObj)
+    const bridgeReqObj = interact(runTx, config, e, 'bridge_in', [])
+    verifyProximity(runTx, config, bridgeReqObj, [])
     verifyCaller(runTx, config, bridgeReqObj, c)
     gameItemToChain(runTx, config, e, bridgeReqObj, {
       typeId: FUEL,
@@ -113,8 +113,8 @@ describe('inventory owner round-trip (localnet)', () => {
     })
     completeRequest(runTx, config, e, bridgeReqObj)
 
-    const wReq = interact(runTx, config, e, 'withdraw')
-    verifyProximity(runTx, config, wReq)
+    const wReq = interact(runTx, config, e, 'withdraw', [])
+    verifyProximity(runTx, config, wReq, [])
     verifyCaller(runTx, config, wReq, c)
     const item = withdraw(runTx, config, e, wReq, {
       typeId: FUEL,
@@ -122,8 +122,8 @@ describe('inventory owner round-trip (localnet)', () => {
     })
     completeRequest(runTx, config, e, wReq)
 
-    const dReq = interact(runTx, config, e, 'deposit')
-    verifyProximity(runTx, config, dReq)
+    const dReq = interact(runTx, config, e, 'deposit', [])
+    verifyProximity(runTx, config, dReq, [])
     verifyCaller(runTx, config, dReq, c)
     deposit(runTx, config, e, dReq, item)
     completeRequest(runTx, config, e, dReq)

--- a/sdk/world-sdk/src/__integration__/metadata.test.ts
+++ b/sdk/world-sdk/src/__integration__/metadata.test.ts
@@ -105,8 +105,8 @@ describe('metadata owner-access via Character', () => {
         await getObjectRef(client, entityCapId),
       )
       const e = editTx.object(entityId)
-      const req = interact(editTx, config, e, 'edit_metadata')
-      verifyProximity(editTx, config, req)
+      const req = interact(editTx, config, e, 'edit_metadata', [])
+      verifyProximity(editTx, config, req, [])
       verifyOwner(editTx, config, req, entityCap)
       editMetadata(editTx, config, e, req, {
         name: 'Beta',

--- a/sdk/world-sdk/src/packages/core.ts
+++ b/sdk/world-sdk/src/packages/core.ts
@@ -60,7 +60,6 @@ export function deriveObjectId(
 export interface EntityNewArgs {
   inGameId: bigint
   tenant: string
-  locationHash?: number[]
 }
 
 /**
@@ -79,7 +78,6 @@ export function entityNew(
       sharedRef(tx, objectRegistry(config), true),
       tx.pure.u64(args.inGameId),
       tx.pure.string(args.tenant),
-      tx.pure.vector('u8', args.locationHash ?? []),
     ],
   })
 }
@@ -199,16 +197,16 @@ export function verifyCaller(
   })
 }
 
-/** Satisfy a proximity requirement. `proof`/location hash defaults to empty. */
+/** Satisfy a proximity requirement. `callerLocationHash` must match the target baked at `interact`. */
 export function verifyProximity(
   tx: Transaction,
   config: WorldConfig,
   request: TransactionArgument,
-  proof: number[] = [],
+  callerLocationHash: number[],
 ): void {
   tx.moveCall({
     target: `${mvrName(config.env, CORE_PACKAGE)}::location_service::verify_proximity`,
-    arguments: [request, tx.pure.vector('u8', proof)],
+    arguments: [request, tx.pure.vector('u8', callerLocationHash)],
   })
 }
 
@@ -218,10 +216,15 @@ export function interact(
   config: WorldConfig,
   entity: TransactionArgument,
   action: string,
+  targetLocationHash: number[],
 ): TransactionResult {
   return tx.moveCall({
     target: `${mvrName(config.env, CORE_PACKAGE)}::entity::interact`,
-    arguments: [entity, tx.pure.string(action)],
+    arguments: [
+      entity,
+      tx.pure.string(action),
+      tx.pure.vector('u8', targetLocationHash),
+    ],
   })
 }
 


### PR DESCRIPTION
## Summary
- Remove `location_hash` from Entity. Location is not fixed at creation (structure can later move / become a ship).
- `interact` takes `target_location_hash` and injects proximity. 
- `verify_proximity` takes `caller_location_hash` (player, or the ship/structure they are boarded on).
-  refactor the sdk for the change
