### PR TITLE
refactor: key installed modules by unique module id instead of name

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,8 +31,11 @@ These five are the load-bearing nouns of v1. All live in [`contracts/core/source
   - **Principal** — an Entity that represents an account-like actor and **owns AccessCaps**
     (a Character or a Tribe). See **Keychain**.
 - **Module** — typed state installed on an Entity ([`mod.move`](contracts/core/sources/mod.move)).
-  `Module<T>` wraps a user-defined state `T` (e.g. `Module<Inventory>`) under a human-readable
-  name, so one Entity can host several modules, even of the same type.
+  `Module<T>` wraps a user-defined state `T` (e.g. `Module<Inventory>`) under a caller-supplied
+  `u64`, so one Entity can host several modules, even of the same type. An optional display
+  `name` may be stored on the wrapper; it is not unique and is not used for targeting.
+  Well-known singletons (identity, metadata) derive their id as the first 8 bytes (LE) of
+  `blake2b256(name)`.
 - **Action** — a named, ordered list of Requirements an Entity exposes
   ([`action.move`](contracts/core/sources/action.move)). It carries no logic of its own; it
   only describes what must be satisfied. (Stored reversed internally so `pop_back` yields
@@ -44,7 +47,7 @@ These five are the load-bearing nouns of v1. All live in [`contracts/core/source
   mid-transaction (dynamic follow-ups).
 - **Requirement** — a single typed rule instance on an Action
   ([`requirement.move`](contracts/core/sources/requirement.move)). Carries `type_name` (which
-  handler may satisfy it, e.g. `inventory::Deposit`), an optional module `name` (which installed
+  handler may satisfy it, e.g. `inventory::Deposit`), an optional module `u64` id (which installed
   module it targets), and `data` (BCS-encoded config). Handlers prove ownership of the rule type
   via a package-private `internal::Permit<T>`.
 

--- a/contracts/character/sources/identity.move
+++ b/contracts/character/sources/identity.move
@@ -19,6 +19,7 @@ const EModuleMissing: vector<u8> = b"Identity module is not installed on this en
 // === Constants ===
 
 const VERSION: u64 = 1;
+const NAME: vector<u8> = b"identity";
 
 // === Structs ===
 
@@ -37,6 +38,10 @@ public fun owner(entity: &Entity): address {
     borrow(entity).owner
 }
 
+public fun module_id(): u64 {
+    mod::id_from_name(NAME)
+}
+
 // === Public Functions ===
 
 /// Build and install the identity module on a character entity.
@@ -47,14 +52,21 @@ public fun install(
     ctx: &mut TxContext,
 ): Request {
     let identity = Identity { tribe_id, owner };
-    entity.install(module_name(), identity, VERSION, module_permit(), ctx)
+    entity.install(
+        module_id(),
+        option::some(module_label()),
+        identity,
+        VERSION,
+        module_permit(),
+        ctx,
+    )
 }
 
 /// Remove the identity module, discarding its state. Aborts if it was never installed.
 public fun uninstall(entity: &mut Entity, ctx: &mut TxContext): Request {
-    assert!(entity.has_module_with_type<Identity>(module_name()), EModuleMissing);
+    assert!(entity.has_module_with_type<Identity>(module_id()), EModuleMissing);
 
-    let (m, req) = entity.uninstall<Identity>(module_name(), module_permit(), ctx);
+    let (m, req) = entity.uninstall<Identity>(module_id(), module_permit(), ctx);
     let Identity { tribe_id: _, owner: _ } = m.unwrap(module_permit());
     req
 }
@@ -62,13 +74,13 @@ public fun uninstall(entity: &mut Entity, ctx: &mut TxContext): Request {
 // === Private Functions ===
 
 fun borrow(entity: &Entity): &Identity {
-    let m: &Module<Identity> = entity.module_ref(module_name(), module_permit());
+    let m: &Module<Identity> = entity.module_ref(module_id(), module_permit());
     assert!(mod::version(m) == VERSION, EWrongVersion);
     m.inner()
 }
 
-fun module_name(): String {
-    string::utf8(b"identity")
+fun module_label(): String {
+    string::utf8(NAME)
 }
 
 fun module_permit(): Permit<Identity> {

--- a/contracts/character/tests/character_tests.move
+++ b/contracts/character/tests/character_tests.move
@@ -6,6 +6,7 @@ use core::{
     admin_service::{Self, AdminACL},
     entity::{Self, Entity, EntityCreated},
     entity_key,
+    mod,
     object_registry::{Self, ObjectRegistry}
 };
 use std::string::{Self, String};
@@ -66,7 +67,8 @@ fun create_installs_identity() {
     ts::next_tx(&mut scenario, ADMIN);
     {
         let e = ts::take_shared<Entity>(&scenario);
-        assert!(e.has_module(string::utf8(b"identity")));
+        assert!(e.has_module(identity::module_id()));
+        assert!(identity::module_id() == mod::id_from_name(b"identity"));
         assert!(identity::tribe_id(&e) == TRIBE_ID);
         assert!(identity::owner(&e) == OWNER);
         assert!(e.key() == entity_key::new(IN_GAME_ID, tenant()));
@@ -105,7 +107,7 @@ fun uninstall_identity_removes_module() {
         admin_service::verify_admin(&mut req, &acl, scenario.ctx());
         e.complete_request(req);
 
-        assert!(!e.has_module(string::utf8(b"identity")));
+        assert!(!e.has_module(identity::module_id()));
         ts::return_shared(acl);
         ts::return_shared(e);
     };

--- a/contracts/core/sources/entity.move
+++ b/contracts/core/sources/entity.move
@@ -50,7 +50,7 @@ const VERSION: u64 = 1;
 
 // === Structs ===
 
-public struct ModuleKey(String) has copy, drop, store;
+public struct ModuleKey(u64) has copy, drop, store;
 public struct ActionsKey() has copy, drop, store;
 public struct InFlight() has copy, drop, store;
 
@@ -133,20 +133,22 @@ public fun return_access(entity: &mut Entity, cap: AccessCap, receipt: ReturnRec
     access_cap::return_to(&mut entity.id, cap, receipt)
 }
 
-/// Install module state `T` under `name`. The `Permit<T>` proves the caller's
-/// package authored `T`. Returns a `Request` the transaction must complete.
+/// Install module state `T` under `module_id`. `name` is an optional
+/// display label and is not unique. The `Permit<T>` proves the caller's package
+/// authored `T`. Returns a `Request` the transaction must complete.
 public fun install<T: store>(
     entity: &mut Entity,
-    name: String,
+    module_id: u64,
+    name: Option<String>,
     inner: T,
     version: u64,
     _: Permit<T>,
     _ctx: &mut TxContext,
 ): Request {
     assert!(entity.version == VERSION, EWrongVersion);
-    assert!(!df::exists_(&entity.id, ModuleKey(name)), EModuleExists);
+    assert!(!df::exists_(&entity.id, ModuleKey(module_id)), EModuleExists);
 
-    df::add(&mut entity.id, ModuleKey(name), mod::new(name, inner, version));
+    df::add(&mut entity.id, ModuleKey(module_id), mod::new(name, inner, version));
     entity.lock();
     request::new(
         option::some(entity.id.to_inner()),
@@ -154,17 +156,17 @@ public fun install<T: store>(
     )
 }
 
-/// Remove module `name`, returning its wrapped state to the caller.
+/// Remove the module at `module_id`, returning its wrapped state to the caller.
 public fun uninstall<T: store>(
     entity: &mut Entity,
-    name: String,
+    module_id: u64,
     _: Permit<T>,
     _ctx: &mut TxContext,
 ): (Module<T>, Request) {
     assert!(entity.version == VERSION, EWrongVersion);
-    assert!(df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(name)), EModuleMissing);
+    assert!(df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(module_id)), EModuleMissing);
 
-    let m: Module<T> = df::remove(&mut entity.id, ModuleKey(name));
+    let m: Module<T> = df::remove(&mut entity.id, ModuleKey(module_id));
     entity.lock();
     let req = request::new(
         option::some(entity.id.to_inner()),
@@ -235,24 +237,24 @@ public fun interact(
 }
 
 /// Mutable access to a module, only valid mid-interaction. The target module
-/// name is read off the request's next requirement (not the caller's args), so
+/// id is read off the request's next requirement (not the caller's args), so
 /// a handler can never mutate the wrong module.
 public fun module_mut<T: store>(entity: &mut Entity, req: &Request, _: Permit<T>): &mut Module<T> {
     assert!(entity.version == VERSION, EWrongVersion);
     assert!(entity.is_locked(), ENotLocked);
     assert!(req.entity_id().is_some_and!(|id| id == entity.id.to_inner()), EWrongEntity);
 
-    let name = req.next().module_name().destroy_or!(abort ERequirementNotModuleScoped);
-    df::borrow_mut(&mut entity.id, ModuleKey(name))
+    let module_id = req.next().module_id().destroy_or!(abort ERequirementNotModuleScoped);
+    df::borrow_mut(&mut entity.id, ModuleKey(module_id))
 }
 
-/// Read-only access to a module by name. `Permit<T>` enforces that only the
+/// Read-only access to a module by `module_id`. `Permit<T>` enforces that only the
 /// package that authored `T` can read it; no lock is required since nothing
 /// is mutated.
-public fun module_ref<T: store>(entity: &Entity, name: String, _: Permit<T>): &Module<T> {
+public fun module_ref<T: store>(entity: &Entity, module_id: u64, _: Permit<T>): &Module<T> {
     assert!(entity.version == VERSION, EWrongVersion);
-    assert!(df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(name)), EModuleMissing);
-    df::borrow(&entity.id, ModuleKey(name))
+    assert!(df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(module_id)), EModuleMissing);
+    df::borrow(&entity.id, ModuleKey(module_id))
 }
 
 /// Complete a request against this entity and unlock it.
@@ -274,12 +276,12 @@ public fun key(entity: &Entity): EntityKey {
     entity.key
 }
 
-public fun has_module(entity: &Entity, name: String): bool {
-    df::exists_(&entity.id, ModuleKey(name))
+public fun has_module(entity: &Entity, module_id: u64): bool {
+    df::exists_(&entity.id, ModuleKey(module_id))
 }
 
-public fun has_module_with_type<T: store>(entity: &Entity, name: String): bool {
-    df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(name))
+public fun has_module_with_type<T: store>(entity: &Entity, module_id: u64): bool {
+    df::exists_with_type<_, Module<T>>(&entity.id, ModuleKey(module_id))
 }
 
 public fun version(entity: &Entity): u64 {

--- a/contracts/core/sources/mod.move
+++ b/contracts/core/sources/mod.move
@@ -1,18 +1,27 @@
 /// Thin wrapper around typed module state installed on an `Entity`.
-/// Adds a human-readable name and a version to the inner behavior type `T`.
+/// Adds an optional display name and a version to the inner behavior type `T`.
+/// Identity is the caller-supplied `module_id` (`u64`) used as the dynamic-field key, not `name`.
 module core::mod;
 
 use std::{internal::Permit, string::String};
+use sui::{bcs, hash};
 
 // === Structs ===
 
 public struct Module<T: store> has store {
     version: u64,
     inner: T,
-    name: String,
+    name: Option<String>,
 }
 
 // === Public Functions ===
+
+/// Deterministic slot for a well-known module name: first 8 bytes (LE) of
+/// `blake2b256(name)` as a `u64`.
+public fun id_from_name(name: vector<u8>): u64 {
+    let mut b = bcs::new(hash::blake2b256(&name));
+    b.peel_u64()
+}
 
 /// Unwrap the inner state. Requires a `Permit<T>`, so only `T`'s defining
 /// package can extract it.
@@ -35,13 +44,13 @@ public fun version<T: store>(m: &Module<T>): u64 {
     m.version
 }
 
-public fun name<T: store>(m: &Module<T>): String {
+public fun name<T: store>(m: &Module<T>): Option<String> {
     m.name
 }
 
 // === Package Functions ===
 
 /// Only `core::entity` may wrap module state.
-public(package) fun new<T: store>(name: String, inner: T, version: u64): Module<T> {
+public(package) fun new<T: store>(name: Option<String>, inner: T, version: u64): Module<T> {
     Module { version, inner, name }
 }

--- a/contracts/core/sources/request.move
+++ b/contracts/core/sources/request.move
@@ -42,9 +42,9 @@ public struct Frame {
 /// Pop the next requirement, proving the caller owns type `T` via a `Permit`.
 /// Returns the requirement plus a `Frame` the handler can push follow-ups into.
 ///
-/// Only the requirement *type* is checked here. Structure-ID and module-name
+/// Only the requirement *type* is checked here. Structure-ID and module-id
 /// targeting are enforced when the handler borrows the module via
-/// `entity::module_mut`, which reads `entity_id()` and `next().module_name()`
+/// `entity::module_mut`, which reads `entity_id()` and `next().module_id()`
 /// off the request.
 public fun take_next<T>(request: &mut Request, _: Permit<T>): (Requirement, Frame) {
     assert!(request.requires.length() > 0, ENoRequirements);

--- a/contracts/core/sources/requirement.move
+++ b/contracts/core/sources/requirement.move
@@ -1,19 +1,19 @@
 /// A typed rule attached to an `Action` and resolved through a `Request`.
 ///
 /// - `type_name` identifies which handler may satisfy it (e.g. `inventory::Deposit`).
-/// - `name` optionally targets an installed module (e.g. `some("storage unit (01)")`).
+/// - `module_id` optionally targets an installed module.
 /// - `data` is the BCS encoding of the rule's typed config.
 module core::requirement;
 
-use std::{bcs, string::String, type_name::{Self, TypeName}};
+use std::{bcs, type_name::{Self, TypeName}};
 
 // === Structs ===
 
 public struct Requirement has drop, store {
     // Identifies which handler type may satisfy this requirement.
     type_name: TypeName,
-    // Optional target module name; `None` when not module-scoped.
-    name: Option<String>,
+    // Optional target module id; `None` when not module-scoped.
+    module_id: Option<u64>,
     // BCS-encoded typed config the handler enforces.
     data: vector<u8>,
 }
@@ -23,11 +23,11 @@ public struct Requirement has drop, store {
 /// Build a requirement from a typed config `c`. The type identity is recorded
 /// from `T`, so only the package that defines `T` can later satisfy it, while
 /// `data` carries the BCS-encoded configuration the handler enforces.
-public fun from_config<T: drop>(name: Option<String>, c: T): Requirement {
+public fun from_config<T: drop>(module_id: Option<u64>, c: T): Requirement {
     Requirement {
         type_name: type_name::with_original_ids<T>(),
         data: bcs::to_bytes(&c),
-        name,
+        module_id,
     }
 }
 
@@ -44,8 +44,8 @@ public fun type_name(r: &Requirement): TypeName {
 
 /// The module this requirement targets, if any. `None` means the requirement
 /// is not module-scoped (e.g. an admin/sponsor approval).
-public fun module_name(r: &Requirement): Option<String> {
-    r.name
+public fun module_id(r: &Requirement): Option<u64> {
+    r.module_id
 }
 
 public fun data(r: &Requirement): vector<u8> {
@@ -57,7 +57,7 @@ public fun data(r: &Requirement): vector<u8> {
 public(package) fun clone(r: &Requirement): Requirement {
     Requirement {
         type_name: r.type_name,
-        name: r.name,
+        module_id: r.module_id,
         data: r.data,
     }
 }

--- a/contracts/core/tests/core_tests.move
+++ b/contracts/core/tests/core_tests.move
@@ -21,8 +21,12 @@ public struct Counter has store {
 /// Requirement marker satisfied by this test's handler.
 public struct Bump has drop {}
 
-fun increment_requirement(module_name: vector<u8>): Requirement {
-    requirement::from_config(option::some(string::utf8(module_name)), Bump {})
+fun increment_requirement(module_id: u64): Requirement {
+    requirement::from_config(option::some(module_id), Bump {})
+}
+
+fun counter_id(): u64 {
+    0xC0
 }
 
 fun claim_test_entity(scenario: &mut ts::Scenario, acl: &AdminACL): entity::Entity {
@@ -41,9 +45,12 @@ fun end_to_end_flow() {
     let acl = take_acl(&scenario);
     let mut e = claim_test_entity(&mut scenario, &acl);
 
+    let counter_id = counter_id();
+
     // Install a module (admin-gated), then close out the install request.
     let mut req = e.install(
-        string::utf8(b"counter"),
+        counter_id,
+        option::some(string::utf8(b"counter")),
         Counter { value: 0 },
         1,
         internal::permit<Counter>(),
@@ -51,7 +58,7 @@ fun end_to_end_flow() {
     );
     admin_service::verify_admin(&mut req, &acl, scenario.ctx());
     e.complete_request(req);
-    assert!(e.has_module(string::utf8(b"counter")));
+    assert!(e.has_module(counter_id));
 
     // Mint the owner cap so the owner can configure actions.
     let mut req = e.mint_access(@0xA, false, scenario.ctx());
@@ -65,7 +72,7 @@ fun end_to_end_flow() {
     ts::next_tx(&mut scenario, @0xA);
     let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
-    let action = action::new(vector[increment_requirement(b"counter")]);
+    let action = action::new(vector[increment_requirement(counter_id())]);
     let mut req = e.enable_action(string::utf8(b"increment"), action, scenario.ctx());
     access_cap::verify(&mut req, &cap);
     e.complete_request(req);
@@ -94,8 +101,11 @@ fun cannot_complete_with_pending_requirement() {
     let acl = take_acl(&scenario);
     let mut e = claim_test_entity(&mut scenario, &acl);
 
+    let counter_id = counter_id();
+
     let mut req = e.install(
-        string::utf8(b"counter"),
+        counter_id,
+        option::some(string::utf8(b"counter")),
         Counter { value: 0 },
         1,
         internal::permit<Counter>(),
@@ -114,7 +124,7 @@ fun cannot_complete_with_pending_requirement() {
     ts::next_tx(&mut scenario, @0xA);
     let mut e = ts::take_shared_by_id<entity::Entity>(&scenario, e_id);
     let cap = ts::take_from_sender<AccessCap>(&scenario);
-    let action = action::new(vector[increment_requirement(b"counter")]);
+    let action = action::new(vector[increment_requirement(counter_id())]);
     let mut req = e.enable_action(string::utf8(b"increment"), action, scenario.ctx());
     access_cap::verify(&mut req, &cap);
     e.complete_request(req);

--- a/contracts/core/tests/entity_tests.move
+++ b/contracts/core/tests/entity_tests.move
@@ -15,6 +15,10 @@ public struct Counter has store {
     value: u64,
 }
 
+fun counter_id(): u64 {
+    0xC0
+}
+
 fun counter_name(): string::String {
     string::utf8(b"counter")
 }
@@ -37,7 +41,7 @@ fun new_sets_initial_fields() {
         assert!(entity::version(&e) == 1);
         assert!(entity::key(&e).id() == 1);
         assert!(entity::key(&e).tenant() == tenant());
-        assert!(!entity::has_module(&e, counter_name()));
+        assert!(!entity::has_module(&e, counter_id()));
 
         entity::share(e);
         ts::return_shared(acl);
@@ -96,7 +100,8 @@ fun install_adds_module() {
     let ctx = scenario.ctx();
 
     let mut req = e.install(
-        counter_name(),
+        counter_id(),
+        option::some(counter_name()),
         Counter { value: 0 },
         1,
         internal::permit<Counter>(),
@@ -105,8 +110,8 @@ fun install_adds_module() {
     admin_service::verify_admin(&mut req, &acl, ctx);
     e.complete_request(req);
 
-    assert!(e.has_module(counter_name()));
-    assert!(e.has_module_with_type<Counter>(counter_name()));
+    assert!(e.has_module(counter_id()));
+    assert!(e.has_module_with_type<Counter>(counter_id()));
 
     entity::share(e);
     ts::return_shared(acl);
@@ -126,7 +131,8 @@ fun install_duplicate_module_aborts() {
     let ctx = scenario.ctx();
 
     let mut req = e.install(
-        counter_name(),
+        counter_id(),
+        option::some(counter_name()),
         Counter { value: 0 },
         1,
         internal::permit<Counter>(),
@@ -135,7 +141,14 @@ fun install_duplicate_module_aborts() {
     admin_service::verify_admin(&mut req, &acl, ctx);
     e.complete_request(req);
 
-    let req = e.install(counter_name(), Counter { value: 1 }, 1, internal::permit<Counter>(), ctx);
+    let req = e.install(
+        counter_id(),
+        option::some(counter_name()),
+        Counter { value: 1 },
+        1,
+        internal::permit<Counter>(),
+        ctx,
+    );
     e.complete_request(req);
 
     abort
@@ -153,7 +166,8 @@ fun uninstall_removes_and_returns_module() {
     let ctx = scenario.ctx();
 
     let mut req = e.install(
-        counter_name(),
+        counter_id(),
+        option::some(counter_name()),
         Counter { value: 9 },
         1,
         internal::permit<Counter>(),
@@ -162,11 +176,11 @@ fun uninstall_removes_and_returns_module() {
     admin_service::verify_admin(&mut req, &acl, ctx);
     e.complete_request(req);
 
-    let (m, mut req) = e.uninstall<Counter>(counter_name(), internal::permit<Counter>(), ctx);
+    let (m, mut req) = e.uninstall<Counter>(counter_id(), internal::permit<Counter>(), ctx);
     admin_service::verify_admin(&mut req, &acl, ctx);
     e.complete_request(req);
 
-    assert!(!e.has_module(counter_name()));
+    assert!(!e.has_module(counter_id()));
     let Counter { value } = m.unwrap(internal::permit<Counter>());
     assert!(value == 9);
 
@@ -187,9 +201,54 @@ fun uninstall_missing_module_aborts() {
     let mut e = claim(&mut registry, &acl, 1, scenario.ctx());
     let ctx = scenario.ctx();
 
-    let (_m, _req) = e.uninstall<Counter>(counter_name(), internal::permit<Counter>(), ctx);
+    let (_m, _req) = e.uninstall<Counter>(counter_id(), internal::permit<Counter>(), ctx);
 
     abort
+}
+
+#[test]
+fun install_two_modules_of_same_type() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let mut e = claim(&mut registry, &acl, 1, scenario.ctx());
+    let ctx = scenario.ctx();
+    let second_id = 0xC1;
+
+    let mut req = e.install(
+        counter_id(),
+        option::some(counter_name()),
+        Counter { value: 0 },
+        1,
+        internal::permit<Counter>(),
+        ctx,
+    );
+    admin_service::verify_admin(&mut req, &acl, ctx);
+    e.complete_request(req);
+
+    let mut req = e.install(
+        second_id,
+        option::some(string::utf8(b"counter-2")),
+        Counter { value: 1 },
+        1,
+        internal::permit<Counter>(),
+        ctx,
+    );
+    admin_service::verify_admin(&mut req, &acl, ctx);
+    e.complete_request(req);
+
+    assert!(e.has_module_with_type<Counter>(counter_id()));
+    assert!(e.has_module_with_type<Counter>(second_id));
+    assert!(e.module_ref<Counter>(counter_id(), internal::permit<Counter>()).inner().value == 0);
+    assert!(e.module_ref<Counter>(second_id, internal::permit<Counter>()).inner().value == 1);
+
+    entity::share(e);
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+    scenario.end();
 }
 
 // === Actions ===

--- a/contracts/core/tests/mod_tests.move
+++ b/contracts/core/tests/mod_tests.move
@@ -1,0 +1,13 @@
+#[test_only]
+module core::mod_tests;
+
+use core::mod;
+use sui::{bcs, hash};
+
+#[test]
+fun id_from_name_is_first_8_le_bytes_of_blake2b256() {
+    let mut identity = bcs::new(hash::blake2b256(&b"identity"));
+    let mut metadata = bcs::new(hash::blake2b256(&b"metadata"));
+    assert!(mod::id_from_name(b"identity") == identity.peel_u64());
+    assert!(mod::id_from_name(b"metadata") == metadata.peel_u64());
+}

--- a/contracts/inventory/sources/inventory.move
+++ b/contracts/inventory/sources/inventory.move
@@ -89,11 +89,13 @@ public struct Withdrawal(ItemRequirement) has drop;
 
 // === Public Functions ===
 
-/// Build and install the storage module under `name` with independent main and
-/// ephemeral volume capacities.
+/// Build and install the storage module under `module_id` with
+/// independent main and ephemeral volume capacities. `name` is an optional
+/// display label and is not unique.
 public fun install(
     entity: &mut Entity,
-    name: String,
+    module_id: u64,
+    name: Option<String>,
     main_capacity: u64,
     ephemeral_capacity: u64,
     ctx: &mut TxContext,
@@ -105,17 +107,17 @@ public fun install(
         Inventory { capacity: main_capacity, used: 0, items: item::new_bag(ctx) },
     );
     let storage = StorageInventory { ephemeral_capacity, inventories };
-    entity.install(name, storage, VERSION, module_permit(), ctx)
+    entity.install(module_id, name, storage, VERSION, module_permit(), ctx)
 }
 
 /// Remove the storage module. Aborts if it was never installed. Burns every
 /// inventory's balances (emitting `ItemBurned` per type) so the game client is
 /// notified.
-public fun uninstall(entity: &mut Entity, name: String, ctx: &mut TxContext): Request {
-    assert!(entity.has_module_with_type<StorageInventory>(name), EModuleMissing);
+public fun uninstall(entity: &mut Entity, module_id: u64, ctx: &mut TxContext): Request {
+    assert!(entity.has_module_with_type<StorageInventory>(module_id), EModuleMissing);
 
     let tenant = entity.key().tenant();
-    let (inv_module, req) = entity.uninstall<StorageInventory>(name, module_permit(), ctx);
+    let (inv_module, req) = entity.uninstall<StorageInventory>(module_id, module_permit(), ctx);
     let StorageInventory { ephemeral_capacity: _, inventories } = inv_module.unwrap(
         module_permit(),
     );
@@ -200,68 +202,68 @@ public fun withdraw(
     item
 }
 
-/// Build a bridge-in requirement on module `name`. `ephemeral` selects the
+/// Build a bridge-in requirement on module `module_id`. `ephemeral` selects the
 /// target: false = main, true = the caller's ephemeral inventory.
 public fun bridge_in_requirement(
-    name: String,
+    module_id: u64,
     ephemeral: bool,
     type_id: Option<u64>,
     min_quantity: Option<u64>,
     max_quantity: Option<u64>,
 ): Requirement {
     requirement::from_config(
-        option::some(name),
+        option::some(module_id),
         BridgeIn(rule(ephemeral, type_id, min_quantity, max_quantity)),
     )
 }
 
-/// Build a bridge-out requirement on module `name`. See `bridge_in_requirement`.
+/// Build a bridge-out requirement on module `module_id`. See `bridge_in_requirement`.
 public fun bridge_out_requirement(
-    name: String,
+    module_id: u64,
     ephemeral: bool,
     type_id: Option<u64>,
     min_quantity: Option<u64>,
     max_quantity: Option<u64>,
 ): Requirement {
     requirement::from_config(
-        option::some(name),
+        option::some(module_id),
         BridgeOut(rule(ephemeral, type_id, min_quantity, max_quantity)),
     )
 }
 
-/// Build a deposit requirement on module `name`. See `bridge_in_requirement`.
+/// Build a deposit requirement on module `module_id`. See `bridge_in_requirement`.
 public fun deposit_requirement(
-    name: String,
+    module_id: u64,
     ephemeral: bool,
     type_id: Option<u64>,
     min_quantity: Option<u64>,
     max_quantity: Option<u64>,
 ): Requirement {
     requirement::from_config(
-        option::some(name),
+        option::some(module_id),
         Deposit(rule(ephemeral, type_id, min_quantity, max_quantity)),
     )
 }
 
-/// Build a withdraw requirement on module `name`. See `bridge_in_requirement`.
+/// Build a withdraw requirement on module `module_id`. See `bridge_in_requirement`.
 public fun withdraw_requirement(
-    name: String,
+    module_id: u64,
     ephemeral: bool,
     type_id: Option<u64>,
     min_quantity: Option<u64>,
     max_quantity: Option<u64>,
 ): Requirement {
     requirement::from_config(
-        option::some(name),
+        option::some(module_id),
         Withdrawal(rule(ephemeral, type_id, min_quantity, max_quantity)),
     )
 }
 
 // === View Functions ===
 
-/// Read the installed storage state by module `name`.
-public fun storage(entity: &Entity, name: String): &StorageInventory {
-    let m: &Module<StorageInventory> = entity.module_ref(name, module_permit());
+/// Read the installed storage state by `module_id`.
+public fun storage(entity: &Entity, module_id: u64): &StorageInventory {
+    let m: &Module<StorageInventory> = entity.module_ref(module_id, module_permit());
     assert!(mod::version(m) == VERSION, EWrongVersion);
     m.inner()
 }
@@ -295,8 +297,8 @@ public fun inventory(storage: &StorageInventory, authorized_id: ID): &Inventory 
 /// Current balance of `type_id` in the inventory routed to `authorized_id`
 /// (the entity's own id for main, a caller's id for ephemeral). 0 if that
 /// inventory does not exist yet. Read-only; for clients querying state.
-public fun balance_of(entity: &Entity, name: String, authorized_id: ID, type_id: u64): u64 {
-    let storage = storage(entity, name);
+public fun balance_of(entity: &Entity, module_id: u64, authorized_id: ID, type_id: u64): u64 {
+    let storage = storage(entity, module_id);
     if (!storage.has_inventory(authorized_id)) return 0;
     storage.inventory(authorized_id).items.balance(type_id)
 }

--- a/contracts/inventory/tests/inventory_tests.move
+++ b/contracts/inventory/tests/inventory_tests.move
@@ -21,6 +21,8 @@ const PLAYER: address = @0xC;
 const FUEL: u64 = 88834;
 const LENS: u64 = 55;
 const VOL: u64 = 2;
+const MODULE_ID: u64 = 0x51;
+const MODULE_ID_2: u64 = 0x52;
 
 fun unit_name(): String { string::utf8(b"SU-01") }
 
@@ -50,7 +52,14 @@ fun build_storage_unit(
 ): Entity {
     let mut e = claim(registry, acl, 1, scenario.ctx());
 
-    let mut req = inventory::install(&mut e, unit_name(), main_cap, eph_cap, scenario.ctx());
+    let mut req = inventory::install(
+        &mut e,
+        MODULE_ID,
+        option::some(unit_name()),
+        main_cap,
+        eph_cap,
+        scenario.ctx(),
+    );
     admin_service::verify_admin(&mut req, acl, scenario.ctx());
     e.complete_request(req);
 
@@ -79,61 +88,60 @@ fun configure_default_actions(scenario: &mut ts::Scenario, e_id: ID) {
     ts::next_tx(scenario, OWNER);
     let mut e = ts::take_shared_by_id<Entity>(scenario, e_id);
     let cap = ts::take_from_sender<AccessCap>(scenario);
-    let name = unit_name();
     let any = option::none();
     enable(
         &mut e,
         b"bridge_in",
-        inventory::bridge_in_requirement(name, false, any, any, any),
+        inventory::bridge_in_requirement(MODULE_ID, false, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"bridge_out",
-        inventory::bridge_out_requirement(name, false, any, any, any),
+        inventory::bridge_out_requirement(MODULE_ID, false, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"deposit",
-        inventory::deposit_requirement(name, false, any, any, any),
+        inventory::deposit_requirement(MODULE_ID, false, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"withdraw",
-        inventory::withdraw_requirement(name, false, any, any, any),
+        inventory::withdraw_requirement(MODULE_ID, false, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"eph_bridge_in",
-        inventory::bridge_in_requirement(name, true, any, any, any),
+        inventory::bridge_in_requirement(MODULE_ID, true, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"eph_bridge_out",
-        inventory::bridge_out_requirement(name, true, any, any, any),
+        inventory::bridge_out_requirement(MODULE_ID, true, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"eph_deposit",
-        inventory::deposit_requirement(name, true, any, any, any),
+        inventory::deposit_requirement(MODULE_ID, true, any, any, any),
         &cap,
         scenario.ctx(),
     );
     enable(
         &mut e,
         b"eph_withdraw",
-        inventory::withdraw_requirement(name, true, any, any, any),
+        inventory::withdraw_requirement(MODULE_ID, true, any, any, any),
         &cap,
         scenario.ctx(),
     );
@@ -219,11 +227,11 @@ fun withdraw(
 // === View helpers ===
 
 fun main_inv(e: &Entity): &inventory::Inventory {
-    inventory::inventory(inventory::storage(e, unit_name()), e.id())
+    inventory::inventory(inventory::storage(e, MODULE_ID), e.id())
 }
 
 fun eph_inv(e: &Entity, player_id: ID): &inventory::Inventory {
-    inventory::inventory(inventory::storage(e, unit_name()), player_id)
+    inventory::inventory(inventory::storage(e, MODULE_ID), player_id)
 }
 
 #[test]
@@ -236,10 +244,53 @@ fun install_reports_module_and_capacities() {
     let acl = take_acl(&scenario);
 
     let e = build_storage_unit(&mut scenario, &mut registry, &acl, 1000, 100);
-    assert!(e.has_module(unit_name()));
+    assert!(e.has_module(MODULE_ID));
     assert!(main_inv(&e).capacity() == 1000);
     assert!(main_inv(&e).used() == 0);
-    assert!(inventory::ephemeral_capacity(inventory::storage(&e, unit_name())) == 100);
+    assert!(inventory::ephemeral_capacity(inventory::storage(&e, MODULE_ID)) == 100);
+
+    e.share();
+    ts::return_shared(acl);
+    ts::return_shared(registry);
+    scenario.end();
+}
+
+#[test]
+fun install_two_inventories_on_one_entity() {
+    let mut scenario = ts::begin(ADMIN);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, ADMIN);
+    let mut registry = take_registry(&scenario);
+    let acl = take_acl(&scenario);
+    let mut e = claim(&mut registry, &acl, 1, scenario.ctx());
+
+    let mut req = inventory::install(
+        &mut e,
+        MODULE_ID,
+        option::some(unit_name()),
+        1000,
+        100,
+        scenario.ctx(),
+    );
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+
+    let mut req = inventory::install(
+        &mut e,
+        MODULE_ID_2,
+        option::some(string::utf8(b"SU-02")),
+        500,
+        50,
+        scenario.ctx(),
+    );
+    admin_service::verify_admin(&mut req, &acl, scenario.ctx());
+    e.complete_request(req);
+
+    assert!(e.has_module(MODULE_ID));
+    assert!(e.has_module(MODULE_ID_2));
+    assert!(inventory::inventory(inventory::storage(&e, MODULE_ID), e.id()).capacity() == 1000);
+    assert!(inventory::inventory(inventory::storage(&e, MODULE_ID_2), e.id()).capacity() == 500);
 
     e.share();
     ts::return_shared(acl);
@@ -300,7 +351,7 @@ fun main_inv_interaction_without_caller() {
         b"public_bridge",
         action::new(vector[
             inventory::bridge_in_requirement(
-                unit_name(),
+                MODULE_ID,
                 false,
                 option::none(),
                 option::none(),
@@ -365,7 +416,6 @@ fun swap_moves_between_main_and_ephemeral_single_signer() {
     let mut registry = take_registry(&scenario);
     let acl = take_acl(&scenario);
     let e = build_storage_unit(&mut scenario, &mut registry, &acl, 1000, 1000);
-    let name = unit_name();
     let e_id = e.id();
     let player_id = create_player(&mut scenario, &mut registry, &acl);
     e.share();
@@ -380,28 +430,28 @@ fun swap_moves_between_main_and_ephemeral_single_signer() {
         action::new(vector[
             access_cap::caller_requirement(),
             inventory::withdraw_requirement(
-                name,
+                MODULE_ID,
                 true,
                 option::some(FUEL),
                 option::none(),
                 option::none(),
             ),
             inventory::deposit_requirement(
-                name,
+                MODULE_ID,
                 false,
                 option::some(FUEL),
                 option::none(),
                 option::none(),
             ),
             inventory::withdraw_requirement(
-                name,
+                MODULE_ID,
                 false,
                 option::some(LENS),
                 option::none(),
                 option::none(),
             ),
             inventory::deposit_requirement(
-                name,
+                MODULE_ID,
                 true,
                 option::some(LENS),
                 option::none(),
@@ -464,7 +514,7 @@ fun ephemeral_interaction_without_caller_aborts() {
         b"eph_uncalled",
         action::new(vector[
             inventory::bridge_in_requirement(
-                unit_name(),
+                MODULE_ID,
                 true,
                 option::none(),
                 option::none(),
@@ -525,7 +575,7 @@ fun bridge_in_wrong_type_aborts() {
         action::new(vector[
             access_cap::caller_requirement(),
             inventory::bridge_in_requirement(
-                unit_name(),
+                MODULE_ID,
                 false,
                 option::some(FUEL),
                 option::none(),
@@ -578,10 +628,10 @@ fun uninstall_burns_all_inventories() {
     ts::next_tx(&mut scenario, ADMIN);
     let mut e = ts::take_shared_by_id<Entity>(&scenario, e_id);
     let acl = take_acl(&scenario);
-    let mut req = inventory::uninstall(&mut e, unit_name(), scenario.ctx());
+    let mut req = inventory::uninstall(&mut e, MODULE_ID, scenario.ctx());
     admin_service::verify_admin(&mut req, &acl, scenario.ctx());
     e.complete_request(req);
-    assert!(!e.has_module(unit_name()));
+    assert!(!e.has_module(MODULE_ID));
 
     ts::return_shared(acl);
     ts::return_shared(e);

--- a/contracts/metadata/sources/metadata.move
+++ b/contracts/metadata/sources/metadata.move
@@ -24,6 +24,7 @@ const EModuleMissing: vector<u8> = b"Metadata module is not installed on this en
 // === Constants ===
 
 const VERSION: u64 = 1;
+const NAME: vector<u8> = b"metadata";
 
 // === Structs ===
 
@@ -59,14 +60,21 @@ public fun install(
 ): Request {
     let metadata = Metadata { name, description, url };
     emit_changed(entity, &metadata);
-    entity.install(module_name(), metadata, VERSION, module_permit(), ctx)
+    entity.install(
+        module_id(),
+        option::some(module_label()),
+        metadata,
+        VERSION,
+        module_permit(),
+        ctx,
+    )
 }
 
 /// Remove the metadata module, discarding its state. Aborts if missing.
 public fun uninstall(entity: &mut Entity, ctx: &mut TxContext): Request {
-    assert!(entity.has_module_with_type<Metadata>(module_name()), EModuleMissing);
+    assert!(entity.has_module_with_type<Metadata>(module_id()), EModuleMissing);
 
-    let (m, req) = entity.uninstall<Metadata>(module_name(), module_permit(), ctx);
+    let (m, req) = entity.uninstall<Metadata>(module_id(), module_permit(), ctx);
     let Metadata { name: _, description: _, url: _ } = m.unwrap(module_permit());
     req
 }
@@ -98,9 +106,9 @@ public fun edit(
     frame.destroy_empty_frame();
 }
 
-/// Build an edit requirement targeting the fixed `"metadata"` module slot.
+/// Build an edit requirement targeting the metadata module slot.
 public fun edit_requirement(): Requirement {
-    requirement::from_config(option::some(module_name()), Edit())
+    requirement::from_config(option::some(module_id()), Edit())
 }
 
 // === View Functions ===
@@ -117,10 +125,14 @@ public fun url(entity: &Entity): String {
     borrow(entity).url
 }
 
+public fun module_id(): u64 {
+    mod::id_from_name(NAME)
+}
+
 // === Private Functions ===
 
 fun borrow(entity: &Entity): &Metadata {
-    let m: &Module<Metadata> = entity.module_ref(module_name(), module_permit());
+    let m: &Module<Metadata> = entity.module_ref(module_id(), module_permit());
     assert!(mod::version(m) == VERSION, EWrongVersion);
     m.inner()
 }
@@ -135,8 +147,8 @@ fun emit_changed(entity: &Entity, metadata: &Metadata) {
     });
 }
 
-fun module_name(): String {
-    string::utf8(b"metadata")
+fun module_label(): String {
+    string::utf8(NAME)
 }
 
 fun module_permit(): Permit<Metadata> {

--- a/contracts/metadata/tests/metadata_tests.move
+++ b/contracts/metadata/tests/metadata_tests.move
@@ -7,6 +7,7 @@ use core::{
     admin_service::{Self, AdminACL},
     entity::{Self, Entity},
     location_service,
+    mod,
     object_registry::ObjectRegistry,
     test_helpers::{claim, setup, take_acl, take_registry}
 };
@@ -139,7 +140,8 @@ fun install_sets_fields_and_emits() {
     let acl = take_acl(&scenario);
 
     let e = build_entity(&mut scenario, &mut registry, &acl, 1, NAME, DESC, URL);
-    assert!(e.has_module(string::utf8(b"metadata")));
+    assert!(e.has_module(metadata::module_id()));
+    assert!(metadata::module_id() == mod::id_from_name(b"metadata"));
     assert!(metadata::name(&e) == string::utf8(NAME));
     assert!(metadata::description(&e) == string::utf8(DESC));
     assert!(metadata::url(&e) == string::utf8(URL));
@@ -220,7 +222,7 @@ fun uninstall_removes_module() {
     let mut req = metadata::uninstall(&mut e, scenario.ctx());
     admin_service::verify_admin(&mut req, &acl, scenario.ctx());
     e.complete_request(req);
-    assert!(!e.has_module(string::utf8(b"metadata")));
+    assert!(!e.has_module(metadata::module_id()));
 
     e.share();
     ts::return_shared(acl);

--- a/docs/move-conventions.md
+++ b/docs/move-conventions.md
@@ -146,12 +146,11 @@ public fun verify_owner_cap(request: &mut Request) {
 }
 ```
 
-Module *identity* is enforced via the next requirement's `name`, read inside `entity::module_mut` —
-never trust a name passed as a handler argument:
+Module *identity* is enforced via the next requirement's `module_id`, read inside `entity::module_mut` —
 
 ```move
-let name = req.next().module_name().destroy_or!(abort ERequirementNotModuleScoped);
-df::borrow_mut(&mut entity.id, ModuleKey(name))
+let module_id = req.next().module_id().destroy_or!(abort ERequirementNotModuleScoped);
+df::borrow_mut(&mut entity.id, ModuleKey(module_id))
 ```
 
 ## Versioning
@@ -162,7 +161,7 @@ Modules pass their own `VERSION` at install time so they can upgrade independent
 ```move
 const VERSION: u64 = 1;
 assert!(e.version == VERSION, EWrongVersion);
-e.install("grid", Grid { .. }, VERSION, internal::permit(), ctx);
+e.install(module_id, option::some(b"grid".to_string()), Grid { .. }, VERSION, internal::permit(), ctx);
 ```
 
 ## Entity & dynamic fields
@@ -171,9 +170,10 @@ Keep `Entity` small; store modules/actions as dynamic fields keyed by **typed ke
 adding a module never changes the `Entity` type.
 
 ```move
-public struct ModuleKey(String) has copy, drop, store;
+public struct ModuleKey(u64) has copy, drop, store;
 public struct ActionsKey() has copy, drop, store;
-// df: ModuleKey(name) => Module<T>,  ActionsKey() => VecMap<String, Action>
+// df: ModuleKey(module_id) => Module<T>,  ActionsKey() => VecMap<String, Action>
+// well-known slots: id = first 8 bytes (LE) of blake2b256(name) via mod::id_from_name
 ```
 
 ## Requirements as BCS config
@@ -184,7 +184,7 @@ Use `type_name::with_original_ids<T>()` for stable type identity.
 
 ```move
 public struct Deposit(ItemRequirement) has drop;
-requirement::from_config(option::some(module_name), Deposit(rule)); // encode
+requirement::from_config(option::some(module_id), Deposit(rule)); // encode
 let req = parse_bcs_requirement(requirement.data());                // decode (mirror field order)
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@mysten/sui':
       specifier: ^2.0.0
       version: 2.4.0
+    '@noble/hashes':
+      specifier: ^1.8.0
+      version: 1.8.0
     '@types/node':
       specifier: ^24.10.4
       version: 24.10.4
@@ -68,6 +71,10 @@ importers:
         version: 5.9.3
 
   sdk/world-sdk:
+    dependencies:
+      '@noble/hashes':
+        specifier: 'catalog:'
+        version: 1.8.0
     devDependencies:
       '@mysten/sui':
         specifier: 'catalog:'

--- a/sdk/world-sdk/package.json
+++ b/sdk/world-sdk/package.json
@@ -38,6 +38,9 @@
     "peerDependencies": {
         "@mysten/sui": "^2.0.0"
     },
+    "dependencies": {
+        "@noble/hashes": "catalog:"
+    },
     "devDependencies": {
         "@mysten/sui": "catalog:",
         "@types/node": "catalog:",

--- a/sdk/world-sdk/scripts/seed-storage-units.ts
+++ b/sdk/world-sdk/scripts/seed-storage-units.ts
@@ -39,6 +39,7 @@ for (const [, unit] of entries) {
   createStorageUnit(createTx, config, {
     inGameId: BigInt(unit.itemId),
     tenant: resources.tenant,
+    moduleId: BigInt(unit.itemId),
     name: UNIT_NAME,
     mainCapacity: MAIN_CAPACITY,
     ephemeralCapacity: EPHEMERAL_CAPACITY,

--- a/sdk/world-sdk/src/__integration__/helpers.ts
+++ b/sdk/world-sdk/src/__integration__/helpers.ts
@@ -79,7 +79,12 @@ export async function mintAccessCap(
 export async function readBalance(
   client: WorldClient,
   config: WorldConfig,
-  args: { entity: string; moduleId: bigint; authorizedId: string; typeId: bigint },
+  args: {
+    entity: string
+    moduleId: bigint
+    authorizedId: string
+    typeId: bigint
+  },
 ): Promise<bigint> {
   const tx = new Transaction()
   tx.setSender(signer)

--- a/sdk/world-sdk/src/__integration__/helpers.ts
+++ b/sdk/world-sdk/src/__integration__/helpers.ts
@@ -79,12 +79,12 @@ export async function mintAccessCap(
 export async function readBalance(
   client: WorldClient,
   config: WorldConfig,
-  args: { entity: string; name: string; authorizedId: string; typeId: bigint },
+  args: { entity: string; moduleId: bigint; authorizedId: string; typeId: bigint },
 ): Promise<bigint> {
   const tx = new Transaction()
   tx.setSender(signer)
   balanceOf(tx, config, tx.object(args.entity), {
-    name: args.name,
+    moduleId: args.moduleId,
     authorizedId: args.authorizedId,
     typeId: args.typeId,
   })

--- a/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-ephemeral.test.ts
@@ -28,6 +28,7 @@ import {
 // A non-owner player brings items into their ephemeral inventory and
 // withdraws, using their own (character) caller cap. Ephemeral is keyed by the
 // cap's entity, so the player's balance changes while main stays untouched.
+const MODULE_ID = 0x51n
 const UNIT = 'SU-02'
 const FUEL = 88834n
 const VOL = 2n
@@ -46,6 +47,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      moduleId: MODULE_ID,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 1000n,
@@ -81,7 +83,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
       'eph_bridge_in',
       [
         callerRequirement(enableTx, config),
-        bridgeInRequirement(enableTx, config, UNIT, { ephemeral: true }),
+        bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: true }),
       ],
       ownerCap,
     )
@@ -92,7 +94,7 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
       'eph_withdraw',
       [
         callerRequirement(enableTx, config),
-        withdrawRequirement(enableTx, config, UNIT, { ephemeral: true }),
+        withdrawRequirement(enableTx, config, MODULE_ID, { ephemeral: true }),
       ],
       ownerCap,
     )
@@ -127,13 +129,13 @@ describe('inventory player ephemeral round-trip (localnet)', () => {
 
     const ephemeral = await readBalance(client, config, {
       entity: suId,
-      name: UNIT,
+      moduleId: MODULE_ID,
       authorizedId: characterId,
       typeId: FUEL,
     })
     const main = await readBalance(client, config, {
       entity: suId,
-      name: UNIT,
+      moduleId: MODULE_ID,
       authorizedId: suId,
       typeId: FUEL,
     })

--- a/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
@@ -33,6 +33,7 @@ import {
 // The SU owner cap is parked on a Character. To use the owner path, borrow
 // the cap from the Character inside a PTB, run owner-gated deposit/withdraw on the
 // SU, then return the cap — all in one player-signed transaction.
+const MODULE_ID = 0x51n
 const UNIT = 'SU-05'
 const FUEL = 88834n
 const VOL = 2n
@@ -50,6 +51,7 @@ describe('inventory owner-access via Character', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      moduleId: MODULE_ID,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 100n,
@@ -90,15 +92,15 @@ describe('inventory owner-access via Character', () => {
       for (const [name, req] of [
         [
           'bridge_in',
-          bridgeInRequirement(enableTx, config, UNIT, { ephemeral: false }),
+          bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
         ],
         [
           'withdraw',
-          withdrawRequirement(enableTx, config, UNIT, { ephemeral: false }),
+          withdrawRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
         ],
         [
           'deposit',
-          depositRequirement(enableTx, config, UNIT, { ephemeral: false }),
+          depositRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
         ],
       ] as const) {
         enableAction(
@@ -159,7 +161,7 @@ describe('inventory owner-access via Character', () => {
     // Main balance changed (0 -> 100) via the borrowed owner cap.
     const main = await readBalance(client, config, {
       entity: suId,
-      name: UNIT,
+      moduleId: MODULE_ID,
       authorizedId: suId,
       typeId: FUEL,
     })

--- a/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-owner-via-character.test.ts
@@ -92,11 +92,15 @@ describe('inventory owner-access via Character', () => {
       for (const [name, req] of [
         [
           'bridge_in',
-          bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
+          bridgeInRequirement(enableTx, config, MODULE_ID, {
+            ephemeral: false,
+          }),
         ],
         [
           'withdraw',
-          withdrawRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
+          withdrawRequirement(enableTx, config, MODULE_ID, {
+            ephemeral: false,
+          }),
         ],
         [
           'deposit',

--- a/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory-swap.test.ts
@@ -30,6 +30,7 @@ import {
 // Owner configures a multi-requirement swap (give a fuel from your ephemeral,
 // get a lens from main). A player executes the whole swap in one PTB with one
 // signer — no owner cap at call time, since the requirements are owner-trusted.
+const MODULE_ID = 0x51n
 const UNIT = 'SU-03'
 const FUEL = 88834n
 const LENS = 55n
@@ -48,6 +49,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     createStorageUnit(setupTx, config, {
       inGameId: suKey.id,
       tenant: suKey.tenant,
+      moduleId: MODULE_ID,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 1000n,
@@ -82,7 +84,7 @@ describe('inventory owner-configured swap (localnet)', () => {
       'bridge_in',
       [
         callerRequirement(enableTx, config),
-        bridgeInRequirement(enableTx, config, UNIT, { ephemeral: false }),
+        bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
       ],
       ownerCap,
     )
@@ -93,7 +95,7 @@ describe('inventory owner-configured swap (localnet)', () => {
       'eph_bridge_in',
       [
         callerRequirement(enableTx, config),
-        bridgeInRequirement(enableTx, config, UNIT, { ephemeral: true }),
+        bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: true }),
       ],
       ownerCap,
     )
@@ -105,19 +107,19 @@ describe('inventory owner-configured swap (localnet)', () => {
       'swap',
       [
         callerRequirement(enableTx, config),
-        withdrawRequirement(enableTx, config, UNIT, {
+        withdrawRequirement(enableTx, config, MODULE_ID, {
           ephemeral: true,
           typeId: FUEL,
         }),
-        depositRequirement(enableTx, config, UNIT, {
+        depositRequirement(enableTx, config, MODULE_ID, {
           ephemeral: false,
           typeId: FUEL,
         }),
-        withdrawRequirement(enableTx, config, UNIT, {
+        withdrawRequirement(enableTx, config, MODULE_ID, {
           ephemeral: false,
           typeId: LENS,
         }),
-        depositRequirement(enableTx, config, UNIT, {
+        depositRequirement(enableTx, config, MODULE_ID, {
           ephemeral: true,
           typeId: LENS,
         }),
@@ -175,7 +177,7 @@ describe('inventory owner-configured swap (localnet)', () => {
     const read = (authorizedId: string, typeId: bigint) =>
       readBalance(client, config, {
         entity: suId,
-        name: UNIT,
+        moduleId: MODULE_ID,
         authorizedId,
         typeId,
       })

--- a/sdk/world-sdk/src/__integration__/inventory.test.ts
+++ b/sdk/world-sdk/src/__integration__/inventory.test.ts
@@ -30,6 +30,7 @@ import {
 // mint the owner cap to a plain address, enable owner deposit/withdraw/bridge
 // actions, then round-trip a balance: bridge_in seeds it, withdraw yields an Item,
 // deposit puts it back.
+const MODULE_ID = 0x51n
 const UNIT = 'SU-01'
 const FUEL = 88834n
 const VOL = 2n
@@ -46,6 +47,7 @@ describe('inventory owner round-trip (localnet)', () => {
     createStorageUnit(createTx, config, {
       inGameId: key.id,
       tenant: key.tenant,
+      moduleId: MODULE_ID,
       name: UNIT,
       mainCapacity: 1000n,
       ephemeralCapacity: 100n,
@@ -70,7 +72,7 @@ describe('inventory owner round-trip (localnet)', () => {
       'bridge_in',
       [
         callerRequirement(enableTx, config),
-        bridgeInRequirement(enableTx, config, UNIT, { ephemeral: false }),
+        bridgeInRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
       ],
       cap,
     )
@@ -81,7 +83,7 @@ describe('inventory owner round-trip (localnet)', () => {
       'withdraw',
       [
         callerRequirement(enableTx, config),
-        withdrawRequirement(enableTx, config, UNIT, { ephemeral: false }),
+        withdrawRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
       ],
       cap,
     )
@@ -92,7 +94,7 @@ describe('inventory owner round-trip (localnet)', () => {
       'deposit',
       [
         callerRequirement(enableTx, config),
-        depositRequirement(enableTx, config, UNIT, { ephemeral: false }),
+        depositRequirement(enableTx, config, MODULE_ID, { ephemeral: false }),
       ],
       cap,
     )
@@ -133,7 +135,7 @@ describe('inventory owner round-trip (localnet)', () => {
     // Net main balance: 100 in, 20 out, 20 back = 100.
     const main = await readBalance(client, config, {
       entity: entityId,
-      name: UNIT,
+      moduleId: MODULE_ID,
       authorizedId: entityId,
       typeId: FUEL,
     })

--- a/sdk/world-sdk/src/index.ts
+++ b/sdk/world-sdk/src/index.ts
@@ -58,7 +58,6 @@ export {
   verifyOwner,
   verifyProximity,
 } from './packages/core.js'
-export { moduleIdFromName } from './packages/module-id.js'
 export {
   currencyPackage,
   eveCoinType,
@@ -92,3 +91,4 @@ export {
   type MetadataFields,
   uninstallMetadata,
 } from './packages/metadata.js'
+export { moduleIdFromName } from './packages/module-id.js'

--- a/sdk/world-sdk/src/index.ts
+++ b/sdk/world-sdk/src/index.ts
@@ -58,6 +58,7 @@ export {
   verifyOwner,
   verifyProximity,
 } from './packages/core.js'
+export { moduleIdFromName } from './packages/module-id.js'
 export {
   currencyPackage,
   eveCoinType,

--- a/sdk/world-sdk/src/packages/inventory.ts
+++ b/sdk/world-sdk/src/packages/inventory.ts
@@ -24,13 +24,13 @@ function requirement(
   tx: Transaction,
   config: WorldConfig,
   fn: string,
-  name: string,
+  moduleId: bigint,
   rule: ItemRule,
 ): TransactionResult {
   return tx.moveCall({
     target: `${pkg(config)}::inventory::${fn}`,
     arguments: [
-      tx.pure.string(name),
+      tx.pure.u64(moduleId),
       tx.pure.bool(rule.ephemeral),
       tx.pure.option('u64', rule.typeId ?? null),
       tx.pure.option('u64', rule.minQuantity ?? null),
@@ -42,41 +42,42 @@ function requirement(
 export function bridgeInRequirement(
   tx: Transaction,
   config: WorldConfig,
-  name: string,
+  moduleId: bigint,
   rule: ItemRule,
 ): TransactionResult {
-  return requirement(tx, config, 'bridge_in_requirement', name, rule)
+  return requirement(tx, config, 'bridge_in_requirement', moduleId, rule)
 }
 
 export function bridgeOutRequirement(
   tx: Transaction,
   config: WorldConfig,
-  name: string,
+  moduleId: bigint,
   rule: ItemRule,
 ): TransactionResult {
-  return requirement(tx, config, 'bridge_out_requirement', name, rule)
+  return requirement(tx, config, 'bridge_out_requirement', moduleId, rule)
 }
 
 export function depositRequirement(
   tx: Transaction,
   config: WorldConfig,
-  name: string,
+  moduleId: bigint,
   rule: ItemRule,
 ): TransactionResult {
-  return requirement(tx, config, 'deposit_requirement', name, rule)
+  return requirement(tx, config, 'deposit_requirement', moduleId, rule)
 }
 
 export function withdrawRequirement(
   tx: Transaction,
   config: WorldConfig,
-  name: string,
+  moduleId: bigint,
   rule: ItemRule,
 ): TransactionResult {
-  return requirement(tx, config, 'withdraw_requirement', name, rule)
+  return requirement(tx, config, 'withdraw_requirement', moduleId, rule)
 }
 
 export interface InstallInventoryArgs {
-  name: string
+  moduleId: bigint
+  name?: string | null
   mainCapacity: bigint
   ephemeralCapacity: bigint
 }
@@ -92,7 +93,8 @@ export function installInventory(
     target: `${pkg(config)}::inventory::install`,
     arguments: [
       entity,
-      tx.pure.string(args.name),
+      tx.pure.u64(args.moduleId),
+      tx.pure.option('string', args.name ?? null),
       tx.pure.u64(args.mainCapacity),
       tx.pure.u64(args.ephemeralCapacity),
     ],
@@ -101,16 +103,16 @@ export function installInventory(
   completeRequest(tx, config, entity, request)
 }
 
-/** Remove the inventory module `name`, closing its admin-gated request. */
+/** Remove the inventory module `moduleId`, closing its admin-gated request. */
 export function uninstallInventory(
   tx: Transaction,
   config: WorldConfig,
   entity: TransactionArgument,
-  name: string,
+  moduleId: bigint,
 ): void {
   const request = tx.moveCall({
     target: `${pkg(config)}::inventory::uninstall`,
-    arguments: [entity, tx.pure.string(name)],
+    arguments: [entity, tx.pure.u64(moduleId)],
   })
   verifyAdmin(tx, config, request)
   completeRequest(tx, config, entity, request)
@@ -119,7 +121,8 @@ export function uninstallInventory(
 export interface CreateStorageUnitArgs {
   inGameId: bigint
   tenant: string
-  name: string
+  moduleId: bigint
+  name?: string | null
   mainCapacity: bigint
   ephemeralCapacity: bigint
 }
@@ -140,6 +143,7 @@ export function createStorageUnit(
   verifyAdmin(tx, config, claimReq)
   completeRequest(tx, config, entity, claimReq)
   installInventory(tx, config, entity, {
+    moduleId: args.moduleId,
     name: args.name,
     mainCapacity: args.mainCapacity,
     ephemeralCapacity: args.ephemeralCapacity,
@@ -148,7 +152,7 @@ export function createStorageUnit(
 }
 
 export interface BalanceOfArgs {
-  name: string
+  moduleId: bigint
   authorizedId: string
   typeId: bigint
 }
@@ -168,7 +172,7 @@ export function balanceOf(
     target: `${pkg(config)}::inventory::balance_of`,
     arguments: [
       entity,
-      tx.pure.string(args.name),
+      tx.pure.u64(args.moduleId),
       tx.pure.address(args.authorizedId),
       tx.pure.u64(args.typeId),
     ],

--- a/sdk/world-sdk/src/packages/metadata.ts
+++ b/sdk/world-sdk/src/packages/metadata.ts
@@ -53,7 +53,7 @@ export function uninstallMetadata(
   completeRequest(tx, config, entity, request)
 }
 
-/** Build an edit requirement targeting the fixed `"metadata"` module slot. */
+/** Build an edit requirement targeting the metadata module slot. */
 export function editRequirement(
   tx: Transaction,
   config: WorldConfig,

--- a/sdk/world-sdk/src/packages/module-id.test.ts
+++ b/sdk/world-sdk/src/packages/module-id.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { moduleIdFromName } from './module-id.js'
+
+describe('moduleIdFromName', () => {
+  it('is a deterministic u64', () => {
+    const identity = moduleIdFromName('identity')
+    expect(identity).toBe(moduleIdFromName('identity'))
+    expect(identity).toBeGreaterThan(0n)
+    expect(identity).toBeLessThan(1n << 64n)
+    expect(moduleIdFromName('metadata')).not.toBe(identity)
+  })
+})

--- a/sdk/world-sdk/src/packages/module-id.ts
+++ b/sdk/world-sdk/src/packages/module-id.ts
@@ -1,0 +1,8 @@
+import { blake2b } from '@noble/hashes/blake2b'
+
+/** Matches `core::mod::id_from_name`: first 8 bytes (LE) of `blake2b256(utf8(name))`. */
+export function moduleIdFromName(name: string): bigint {
+  const digest = blake2b(new TextEncoder().encode(name), { dkLen: 32 })
+  const view = new DataView(digest.buffer, digest.byteOffset, digest.byteLength)
+  return view.getBigUint64(0, true)
+}


### PR DESCRIPTION
## Summary
- Multiple modules of the same type on one entity are uniquely identified by module_id (u64), matching the in-game model. Optional name is display-only(e.g. two inventories).
- Identity/metadata keep a deterministic slot